### PR TITLE
docs: import English design documents (#36)

### DIFF
--- a/docs/00_overview.md
+++ b/docs/00_overview.md
@@ -1,0 +1,110 @@
+# sitos — Overview
+
+> **sitos** (σῖτος, Greek for “grain” or “food”) —
+> A distributed parameter store for compute pipelines, powered by Eclipse zenoh.
+
+## 1. Vision
+
+A public OSS library for both C++ and Python that supplies parameters and LUTs
+(Look-Up Tables) to each compute process in distributed compute systems
+(image reconstruction, signal processing, simulation, and similar workloads)
+**without timing bugs and with low overhead**.
+
+sitos generalizes requirements obtained from existing parameter store
+implementations for distributed computation and publishes them in an independent
+repository as a general-purpose library not limited to CT reconstruction.
+
+## 2. Elevator Pitch
+
+* **Problem**: In distributed computation, managing “which process sees which
+  version of which parameter, and when” is difficult, and custom synchronization
+  code becomes a breeding ground for timing bugs.
+* **Solution**: sitos builds a typed key-value store on top of the zenoh key
+  space. At compute session startup, a **snapshot** isolates the session from
+  external input, and changes during execution are delivered to every process
+  through **overlay + pub/sub differential distribution**. The read hot path is
+  a **zero-copy reference to an in-process cache**.
+* **Differentiators**:
+  - Pluggable storage engines (InMemory / RocksDB / user-defined additions)
+  - Exposes native engine snapshots in the zenoh key space in O(1)
+  - zenoh wire compatibility: languages with zenoh bindings can read and write
+    without sitos bindings
+
+## 3. Scope
+
+### In scope
+
+* Typed key-value store (bool / int64 / double / string / bytes)
+* Storage of LUTs (large byte strings and numeric arrays) and zero-copy reads
+* Per-session (per-job) snapshots and overlays
+* Inter-process sharing through zenoh get/put/subscribe
+* Pluggable storage engine abstraction
+* C++20 core + Python bindings (NumPy integration)
+
+### Out of scope
+
+* Transfer of image data or compute artifacts themselves (sitos targets
+  parameters/LUTs)
+* Transactions (atomic updates of multiple keys are limited to the scope of a
+  Put batch)
+* Access control and authentication (use zenoh ACL mechanisms if needed)
+* Conflict resolution for multi-master writes (consistency beyond
+  last-write-wins)
+
+## 4. Glossary
+
+| Term | Meaning |
+|---|---|
+| **StorageEngine** | Abstraction for persistence backends: put/get/list/delete + optional snapshot |
+| **StorageNode** | Component that connects zenoh queryables/subscribers with a StorageEngine. The “storehouse” of the sitos key space. Nickname: *sitobolon* (σιτοβολών = granary) |
+| **base** | Master data: externally supplied parameters, LUTs, and default values |
+| **session** | Unit of compute execution. The lifetime unit for snapshots and overlays |
+| **snapshot** | A consistent read view of base at session startup. It is isolated from subsequent base updates |
+| **overlay** | Differential area that receives Puts during session execution. Reads resolve in overlay → snapshot order |
+| **SessionView** | The logical KV view seen from a session, combining overlay + snapshot |
+| **ParamCache** | Read cache inside a subscriber-side process. Provides zero-copy reads |
+| **payload v1** | Encoding format consisting of a 1-byte type tag + little-endian raw value (§[03](03_wire_protocol.md)) |
+
+## 5. Document Map
+
+| Document | Visibility | Contents |
+|---|---|---|
+| [00_overview.md](00_overview.md) | Public | This document. Vision, scope, and terminology |
+| [01_requirements.md](01_requirements.md) | Public | Requirements specification (with IDs) |
+| [02_architecture.md](02_architecture.md) | Public | Architecture specification (components, sequences, thread model) |
+| [03_wire_protocol.md](03_wire_protocol.md) | Public | Wire protocol specification (key space, encoding, query semantics) |
+| [04_api_cpp.md](04_api_cpp.md) | Public | C++ API specification |
+| [05_api_python.md](05_api_python.md) | Public | Python API specification |
+| [06_build_test_packaging.md](06_build_test_packaging.md) | Public | Build, testing, and packaging |
+| [07_issue_breakdown.md](07_issue_breakdown.md) | Public | Milestones and proposed issue breakdown |
+| [09_dependency_policy.md](09_dependency_policy.md) | Public | Dependency and zenoh compatibility policy |
+| [10_adr_process.md](10_adr_process.md) | Public | ADR writing and operation rules (to be moved to docs/adr/README.md) |
+| [development_workflow.md](development_workflow.md) | Public | Branching strategy, TiDD, and TDD operation rules (to be moved to CONTRIBUTING) |
+
+Public documents (00–07) are maintained under `docs/` in the sitos repository.
+Public documents must not contain references to non-public documents.
+
+## 6. Record of Major Decisions (ADR Summary)
+
+The operation rules are in [10_adr_process.md](10_adr_process.md). At repository
+creation, D1 through D13 are filed in English as individual ADRs under
+`docs/adr/0001` through `0013`; after that, this table is maintained as an
+index to the ADRs.
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | Adopt zenoh as the communication foundation | Integration of pub/sub + query + storage, elimination of custom synchronization code, distributed extensibility |
+| D2 | Implement our own StorageNode in C++ instead of using zenoh storage-manager | The zenoh storage trait does not expose engine snapshots. Avoid requiring Rust plugin development to add engines |
+| D3 | Engines are InMemory (default) + RocksDB (opt-in). Do not adopt LevelDB | LevelDB is frozen upstream (stagnant since v1.23/2024). Unsuitable as a bundled dependency for public OSS |
+| D4 | Snapshots use engine-native functionality + queryable exposure | Same semantics as the current LevelDB snapshot in O(1). They can be inspected from zenoh without copying |
+| D5 | Name the project sitos | A coined term derived from σῖτος (grain/food). It represents “provisioning food for distributed computation” and is unused in major registries (PyPI/crates.io) |
+| D6 | C++20 core + Python bindings (Holoscan style) | No boost dependency. Uses `std::span` as a standard feature. One-shot pip install. NumPy zero-copy |
+| D7 | payload v1 follows the legacy-compatible format | Easy migration from existing systems. Versioned by Encoding schema name, allowing migration to CBOR or similar formats in the future |
+| D8 | License is Apache-2.0 | Compatible with zenoh (EPL-2.0/Apache-2.0) and RocksDB (Apache-2.0/GPLv2) |
+| D9 | The repository language is English (code, comments, docs, issues) | The standard for international OSS. This design document set is maintained in English in docs/ |
+| D10 | Python bindings use nanobind | Lightweight and fast. buffer protocol / GIL control matches requirements (P02, P04) |
+| D11 | The repository is public from the beginning | The development process is public as well. Operational discipline to keep internal information out of commit history is enforced from the start |
+| D12 | Code style is Google-based + ColumnLimit 100 | Design document naming (PascalCase methods, trailing `_` members) conforms to Google style. It also has the best affinity with implementation AI |
+| D13 | zenoh connection defaults to scouting + explicit endpoint configuration through Config | Balances a zero-configuration development experience with support for environments where multicast is prohibited (such as medical devices) |
+
+(END OF DOCUMENT)

--- a/docs/01_requirements.md
+++ b/docs/01_requirements.md
@@ -1,0 +1,90 @@
+# sitos — Requirements
+
+Requirement ID format: `sitos-req-<category><number>`
+Categories: F=functional, N=non-functional, C=compatibility, P=Python, X=extensibility
+
+Priority: **MUST** (required for the initial release) / **SHOULD** (target for
+the initial release) / **MAY** (can be addressed in the future)
+
+The “Inherited from” column shows the corresponding requirements inherited from
+the preceding legacy parameter store implementation.
+
+## 1. Functional Requirements (F)
+
+| ID | Priority | Requirement | Inherited from |
+|---|---|---|---|
+| F01 | MUST | Provide a key-value store whose keys are hierarchical strings and whose values are typed (BOOL/S64/DP/STR/BYTES) | R02 |
+| F02 | MUST | Scalar parameters and LUTs (byte strings and numeric arrays) can be read and written through the same API | R02 |
+| F03 | MUST | Keys can be enumerated by key prefix (List) | — |
+| F04 | MUST | Multiple processes can read and write the same key space. Writes are automatically distributed to all subscriber processes | R06 |
+| F05 | MUST | At session (compute execution unit) startup, a consistent snapshot of base can be taken and is isolated from subsequent base updates | R04 |
+| F06 | MUST | Parameters can be added and changed during session execution (overlay), and changes are distributed to all participating processes | R05 |
+| F07 | MUST | Provide SessionView (a composite view that resolves in overlay → snapshot order) | R04, R05 |
+| F08 | MUST | The contents of snapshots and overlays can be read through the zenoh key space (for debugging and external tools) | R07 |
+| F09 | MUST | Multiple keys can be Put as a batch (applied as one message on the receiver side) | — |
+| F10 | MUST | snapshot / overlay resources are released when the session ends | — |
+| F11 | SHOULD | Key existence can be checked (Contains) | — |
+| F12 | SHOULD | Keys can be deleted (Delete) (base only; snapshots are immutable) | — |
+| F13 | SHOULD | Value-change subscriptions (subscribe callbacks specified by key pattern) are exposed to applications | — |
+| F14 | MAY | TTL, history, and generation management | — |
+
+## 2. Non-Functional Requirements (N)
+
+| ID | Priority | Requirement |
+|---|---|---|
+| N01 | MUST | The subscriber-side read hot path completes using only an in-process cache reference and involves no copies, system calls, or inter-process communication. Guideline: on the order of several hundred ns per Get |
+| N02 | MUST | Snapshot acquisition is O(1) when the engine supports it (does not copy in proportion to data volume) |
+| N03 | MUST | Engines without snapshot support operate with the same semantics (copy-based fallback) |
+| N04 | MUST | The system operates in a single-machine configuration without an external daemon (zenohd) (peer connection) |
+| N05 | MUST | The system operates on Windows (MSVC) / Linux (gcc, clang) |
+| N06 | MUST | Core library dependencies are limited to the C++20 standard library + zenoh-cpp/zenoh-c (boost is prohibited. RocksDB is opt-in) |
+| N07 | MUST | Thread-safe: concurrent Get from multiple threads and concurrent execution of Get and Put are safe |
+| N08 | SHOULD | Session startup (snapshot acquisition + initial fetch assuming 10k keys / 100 MB LUT) completes within 1 second |
+| N09 | SHOULD | Latency from Put to reflection in another process's cache is within 10 ms on the same host (median) |
+| N10 | SHOULD | A crashed subscriber process can recover after restart through reconnection and refetch |
+| N11 | MAY | The system operates in a multi-machine configuration (through a zenoh router). This is achieved only through transport configuration with no API changes |
+
+## 3. Compatibility Requirements (C)
+
+| ID | Priority | Requirement |
+|---|---|---|
+| C01 | MUST | payload v1 (1-byte type tag + LE raw value) is the wire and storage format and is strictly defined in [03_wire_protocol.md](03_wire_protocol.md) |
+| C02 | MUST | A format identifier is set in zenoh `Encoding`, making coexistence with future payload v2 (CBOR, etc.) possible |
+| C03 | MUST | Reading and writing are possible using only standard zenoh APIs (get/put/subscribe) — interoperability with clients that do not depend on the sitos library (such as zenoh-python) |
+| C04 | MUST | Semantic versioning is adopted, and wire compatibility is broken only in major versions |
+| C05 | MUST | Provide an API that allows external compatibility adapters (such as wrappers for legacy KV APIs) to be implemented without changing the sitos core. In particular, Get with arithmetic casts between numeric types, prefix enumeration, and batch Put semantics must be available from the public API |
+
+> **Note**: Compatibility layers for product-specific legacy APIs are outside
+> the scope of sitos (public OSS). C05 specifies only the responsibility on the
+> sitos side: making it possible to implement external adapters.
+
+## 4. Python Requirements (P)
+
+| ID | Priority | Requirement |
+|---|---|---|
+| P01 | MUST | Provide a Python API with the same concepts and semantics as C++ (ParamStore/ParamCache/SessionView) |
+| P02 | MUST | LUTs can be read zero-copy as NumPy arrays (buffer protocol) |
+| P03 | MUST | Binary wheels are installed by `pip install sitos`, with no Rust/C++ toolchain required (Windows/Linux x86_64) |
+| P04 | MUST | subscribe callbacks can be registered as Python functions and do not cause GIL deadlocks |
+| P05 | SHOULD | Support Python 3.10+ |
+| P06 | MAY | asyncio integration (async subscribe iterator) |
+
+## 5. Extensibility Requirements (X)
+
+| ID | Priority | Requirement |
+|---|---|---|
+| X01 | MUST | Through the StorageEngine abstraction, users can add new persistence backends without changing the library core |
+| X02 | MUST | Include InMemoryEngine (zero dependencies) and RocksDBEngine |
+| X03 | MUST | The key prefix (default `sitos`) can be changed by configuration (coexistence of multiple instances on the same zenoh network) |
+| X04 | SHOULD | A zenoh session can be injected from outside (sharing a session owned by the application) |
+| X05 | MAY | Pluggable payload codecs (registration of formats other than v1) |
+
+## 6. Common Principles for Acceptance Criteria
+
+* Each MUST requirement must be verified by at least one automated test
+  ([06_build_test_packaging.md](06_build_test_packaging.md) §Test Strategy)
+* N01/N02/N08/N09 must be measured by a benchmark harness and regressions must
+  be detected in CI
+* C03 must be verified by an “interoperability test using only zenoh-python”
+
+(END OF DOCUMENT)

--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -1,0 +1,317 @@
+# sitos — Architecture Specification
+
+Requirement IDs ([01_requirements.md](01_requirements.md)) are referenced as [F..]/[N..].
+
+## 1. Component Structure
+
+```
+ ┌─ Host process (e.g., controller / orchestrator) ──────────┐
+ │                                                            │
+ │  zenoh session (peer)                                      │
+ │   ├ queryable("<prefix>/**")   ◄─── zenoh get ─────────────┼───┐
+ │   ├ subscriber("<prefix>/**")  ◄─── zenoh put/delete ──────┼───┤
+ │   │            │                                           │   │
+ │   │   ┌────────▼─────────┐   ┌───────────────────────┐     │   │
+ │   │   │   StorageNode    │──►│ StorageEngine (abs.)  │     │   │
+ │   │   │  - base R/W      │   │  InMemoryEngine       │     │   │
+ │   │   │  - overlay mgmt  │   │  RocksDBEngine        │     │   │
+ │   │   │  - snapshot mgmt │   │  (user-defined...)    │     │   │
+ │   │   └──────────────────┘   └───────────────────────┘     │   │
+ │   │                                                        │   │
+ │  ParamStore (write / List API)                             │   │
+ │  SessionController (session creation/destruction)          │   │
+ └────────────────────────────────────────────────────────────┘   │
+                                                                   │
+ ┌─ Subscriber process (e.g., compute worker) ×N ───────────┐      │
+ │  zenoh session (peer) ───────────────────────────────────┼──────┘
+ │   ├ get (initial fetch)                                  │
+ │   └ subscriber("<prefix>/session/<id>/**") (delta)        │
+ │            │                                             │
+ │   ┌────────▼────────┐                                    │
+ │   │   ParamCache    │ ← zero-copy compute reads           │
+ │   └─────────────────┘                                    │
+ └──────────────────────────────────────────────────────────┘
+```
+
+| Component | Role | Dependencies |
+|---|---|---|
+| `StorageEngine` | Persistence abstraction. put/get/list/delete + optional snapshot | None (zenoh-independent) [X01] |
+| `Transport` | Thin adapter that hides the zenoh API. Limited to put/get/queryable/subscriber/delete/attachment/encoding functionality | zenoh |
+| `StorageNode` | Connects zenoh queryable/subscriber ↔ engine. Manages overlay/snapshot lifecycles | zenoh, StorageEngine |
+| `ParamStore` | Client API: typed Put/Get/List/Delete/Subscribe. Wraps a zenoh session | zenoh |
+| `ParamCache` | Subscriber-side read cache. Initial fetch + delta subscription + zero-copy Get | zenoh |
+| `SessionController` | Session creation, snapshot registration, and destruction (inside the process that owns StorageNode) | StorageNode |
+| `SessionView` | Logical view that resolves overlay → snapshot (thin facade over ParamStore/ParamCache) | ParamStore or ParamCache |
+
+**Design principle**: `engine/` does not know about zenoh. `ParamStore`/`ParamCache` do not
+know about engine. Direct dependencies on the zenoh-cpp API are confined to the
+`transport/zenoh` layer, and higher-level components see only the `Transport` abstraction.
+This limits the impact scope when zenoh is upgraded ([09_dependency_policy.md](09_dependency_policy.md)).
+
+## 2. Key Space
+
+Default prefix: `sitos` (configurable [X03]). For the detailed grammar and normalization rules,
+see [03_wire_protocol.md](03_wire_protocol.md).
+
+```
+<prefix>/base/<key...>                 # master data
+<prefix>/session/<sid>/<key...>        # session overlay (Put during execution)
+<prefix>/snap/<sid>/<key...>           # read view of the session snapshot (read-only)
+<prefix>/meta/session/<sid>            # session metadata (state, creation time)
+```
+
+* put to `base/**` → the StorageNode subscriber writes to the engine [F04]
+* get to `base/**` → the StorageNode queryable responds from the engine [F03, F08]
+* put to `session/<sid>/**` → StorageNode records it in the overlay (an in-memory map
+  separate from the engine). zenoh directly distributes it to subscribers (ParamCache) [F06]
+* get to `snap/<sid>/**` → StorageNode responds from the snapshot view.
+  put/delete through the library API returns a `ReadOnly` error; raw zenoh put/delete is
+  fire-and-forget, so it is ignored + a warning is logged [F05, F08]
+
+## 3. StorageEngine Abstraction
+
+```cpp
+namespace sitos {
+
+using Bytes     = std::span<const std::byte>;
+using EntrySink = std::function<bool(std::string_view key, Bytes value)>;
+
+/// Read-only view. Common type for the engine itself and snapshots.
+class StorageReader {
+public:
+    virtual ~StorageReader() = default;
+    /// If key exists, call sink once and return true. If not, return false.
+    virtual bool Get(std::string_view key, const EntrySink& sink) const = 0;
+    /// Call sink for every entry that matches prefix (by prefix match on the key string).
+    /// If sink returns false, abort and return false. If iteration completes, return true.
+    virtual bool List(std::string_view prefix, const EntrySink& sink) const = 0;
+};
+
+class StorageEngine : public StorageReader {
+public:
+    virtual bool Put(std::string_view key, Bytes value) = 0;
+    virtual bool Delete(std::string_view key)           = 0;
+
+    /// Return a consistent read view at that point in time.
+    /// Default implementation: an InMemory view copied in full via List (O(n)) [N03].
+    /// LevelDB/RocksDB-style engines implement this as O(1) with native snapshots [N02].
+    virtual std::shared_ptr<const StorageReader> TakeSnapshot() const;
+};
+
+} // namespace sitos
+```
+
+Conventions:
+
+* Engines treat values as opaque byte sequences (they do not know the payload format)
+* Pointers passed to `Get`/`List` sinks are valid only during the sink call
+* Thread safety: the engine guarantees safe concurrent reads + safe concurrent read/write [N07].
+  `InMemoryEngine` uses `std::shared_mutex`; RocksDB uses its native guarantees
+* The view returned by `TakeSnapshot()` is not affected by Put/Delete operations after the call
+
+## 4. StorageNode
+
+### 4.1 Responsibilities
+
+1. Declare zenoh `queryable`: respond to get requests for `<prefix>/**`
+   - `base/**` → engine
+   - `snap/<sid>/**` → view in the snapshot table
+   - `session/<sid>/**` → overlay table
+2. Declare zenoh `subscriber`: receive put/delete for `<prefix>/**`
+   - `base/**` → apply to engine
+   - `session/<sid>/**` → apply to overlay
+   - put to `snap/**` → ignore + warning log (read-only)
+3. Session lifecycle (via SessionController):
+   - `CreateSession(sid)`: obtain `engine->TakeSnapshot()` and register it in
+     `snapshots_[sid]`. Create an empty `overlays_[sid]`
+   - `CloseSession(sid)`: delete both tables (release shared_ptr) [F10]
+
+### 4.2 Data Structures
+
+```cpp
+class StorageNode {
+    std::shared_ptr<StorageEngine> engine_;
+    // sid → snapshot view
+    std::unordered_map<std::string, std::shared_ptr<const StorageReader>> snapshots_;
+    // sid → overlay (key → payload byte sequence)
+    std::unordered_map<std::string, OverlayMap> overlays_;
+    std::shared_mutex mutex_;  // protects table structure (each overlay locks itself internally)
+};
+```
+
+### 4.3 Consistency Model
+
+* Write ordering: zenoh preserves the order of puts from the same publisher.
+  It does not guarantee ordering across different publishers (last-write-wins)
+* Relationship with puts around `CreateSession`: the snapshot contains
+  “the contents already reflected in the engine at the moment StorageNode processes CreateSession”.
+  The caller must confirm completion of all required base writes before starting a session
+  (because put passes through StorageNode receive processing,
+  `ParamStore::Put` by default performs a round-trip confirmation (ack) to the queryable. §6.2)
+
+### 4.4 Transport Integration Pseudocode
+
+Pseudocode for implementers. StorageNode does not use the raw zenoh-cpp API directly;
+it goes through the `Transport` abstraction ([09_dependency_policy.md](09_dependency_policy.md) §3).
+
+```cpp
+StorageNode::Start(engine, transport, config):
+  node.engine_ = engine
+  node.queryable_ = transport->DeclareQueryable(config.prefix + "/**",
+    [node](TransportQuery& q) {
+      ParsedKey k = ParseKey(q.keyexpr)
+      switch (k.kind):
+        case Base:
+          ReplyFromReader(q, *node.engine_, k.relative_key)
+        case Snapshot:
+          reader = node.FindSnapshot(k.sid)
+          if reader: ReplyFromReader(q, *reader, k.relative_key)
+        case Session:
+          overlay = node.FindOverlay(k.sid)
+          if overlay: ReplyFromOverlay(q, *overlay, k.relative_key)
+        case MetaAck:
+          if node.ack_cache.contains(k.uuid): q.Reply(k.keyexpr, OkPayload(), kSitosV1)
+        case MetaSession:
+          if node.sessions.contains(k.sid): q.Reply(k.keyexpr, SessionJson(k.sid), kSitosV1)
+    })
+
+  node.subscriber_ = transport->DeclareSubscriber(config.prefix + "/**",
+    [node](const TransportSample& s) {
+      ParsedKey k = ParseKey(s.key)
+      if s.kind == TransportSample::Kind::Delete:
+        if k.kind == Base: node.engine_->Delete(k.relative_key)
+        else if k.kind == Session: node.overlay(k.sid).Delete(k.relative_key)
+        else LogWarn("read-only or unsupported delete")
+        return
+
+      if k.is_batch:
+        entries = DecodeBatch(s.payload)
+        ApplyBatch(k.scope, entries)
+      else:
+        if k.kind == Base: node.engine_->Put(k.relative_key, s.payload)
+        else if k.kind == Session: node.overlay(k.sid).Put(k.relative_key, s.payload)
+        else LogWarn("read-only or unsupported put")
+
+      if s.ack_token: node.ack_cache.insert(*s.ack_token)
+    })
+```
+
+`ReplyFromReader` uses `Get` for single-key queries and `List` for `**` queries.
+Inside a queryable callback, do not wait; allow only short reads from engine/overlay.
+
+## 5. ParamCache (Subscriber Side)
+
+### 5.1 Construction Sequence (Joining a Session)
+
+```
+ParamCache::Attach(sid):
+  1. declare subscriber: <prefix>/session/<sid>/**     … (a)
+  2. get: <prefix>/snap/<sid>/**    → store in cache   … (b)
+  3. get: <prefix>/session/<sid>/** → overwrite cache  … (c)
+  4. apply the buffer already received by (a), then apply sequentially thereafter
+```
+
+Because the order is (a)→(b)→(c), puts that occur between (b) and (c) are also picked up by (a),
+so there are no missed updates (the same technique as zenoh Querying Subscriber).
+Duplicate application is idempotent because it overwrites the same key.
+
+### 5.2 Data Structures and Zero-Copy Reads [N01]
+
+```cpp
+class ParamCache {
+    // Key → decoded value. Values are held by shared_ptr,
+    // so readers can safely keep references outside the lock section.
+    std::unordered_map<std::string, std::shared_ptr<const ParamValue>> map_;
+    mutable std::shared_mutex mutex_;
+};
+```
+
+* `ParamValue` holds `std::variant<bool, std::int64_t, double, std::string,
+  std::vector<std::byte>>`
+* `Get<std::span<const float>>(key)` returns a span pointing to the internal buffer of a BYTES value
+  via shared_ptr aliasing — no copy, lifetime-safe
+* Delta application (writer) only replaces the value with a new `shared_ptr<const ParamValue>`.
+  Old values held by existing readers are protected by shared_ptr
+
+### 5.3 Direct Base Reference Mode
+
+For simple use cases without sessions, also provide a mode where `Attach("base")`
+initially fetches + subscribes to `base/**` (no snapshot isolation).
+
+## 6. ParamStore (Writes and Ad Hoc Reads)
+
+### 6.1 API Semantics
+
+* `Put(key, value)` / `Put(entries)` — a batch is one zenoh put
+  (multi-entry format in the payload, [03](03_wire_protocol.md) §5) [F09]
+* `Get<T>(key)` — zenoh get (round trip). Not for the hot path
+* `List(prefix, sink)` — zenoh get `<prefix>**`
+* `Subscribe(pattern, callback)` — application-facing subscription [F13]
+
+### 6.2 Put Completion Guarantee
+
+Because zenoh put is fire-and-forget, provide an option that guarantees
+“Put complete = reflected in StorageNode”:
+
+* `PutOptions::ack = true` (default): after put, get the StorageNode ack queryable
+  (`<prefix>/meta/ack/...`) to confirm reflection
+* `ack = false`: prioritize low latency (for example, in-flight puts to a session overlay,
+  where ordering alone is sufficient)
+
+## 7. Session Lifecycle (Overall Sequence)
+
+```
+External client        Controller(StorageNode)          Calc(ParamCache)
+     │ put base/** ────────►│ engine.Put                     │
+     │ POST /job ──────────►│                                │
+     │                      │ CreateSession(sid):            │
+     │                      │   snap = engine.TakeSnapshot() │
+     │                      │   overlays[sid] = {}           │
+     │                      │ spawn Calc(sid) ──────────────►│
+     │                      │                                │ Attach(sid):
+     │                      │◄─ get snap/<sid>/** ───────────│  initial fetch
+     │                      │── replies ────────────────────►│  build cache
+     │                      │                                │ (compute start)
+     │ put base/** ────────►│ engine.Put                     │ ← no effect [F05]
+     │                      │                                │
+     │ (or Calc) ──────────►│ put session/<sid>/k ──(zenoh distributes to all subscribers)──►│ cache update [F06]
+     │                      │   overlays[sid][k] = v         │
+     │                      │                                │ (compute end)
+     │ DELETE /job ────────►│ CloseSession(sid)              │ Detach()
+     │                      │   delete snapshots/overlays [F10]│
+```
+
+## 8. Thread Model
+
+| Component | Threads |
+|---|---|
+| zenoh callbacks (queryable/subscriber) | zenoh internal thread pool. sitos callbacks return quickly (engine I/O is allowed; blocking waits are prohibited) |
+| ParamCache delta application | zenoh subscriber thread. The writer lock is held only briefly for replacement |
+| ParamCache Get | Any application thread (shared lock) [N07] |
+| Python callbacks | Dedicated dispatch thread + queue (the GIL is not acquired on zenoh threads) [P04] |
+
+## 9. Error Handling Policy
+
+* APIs return `bool` / `std::optional` / `sitos::Result<T>` (error code +
+  message). Exceptions are used only for unrecoverable cases such as constructor failure
+* On zenoh disconnection: ParamCache raises a stale flag, then recovers after reconnection
+  by performing the equivalent of Attach again [N10]
+* Type-mismatched Get: arithmetic casts are allowed among numeric types (BOOL/S64/DP) [C05];
+  all other cases return failure
+
+## 10. Configuration (Config)
+
+```cpp
+struct Config {
+    std::string prefix = "sitos";
+    std::optional<std::string> zenoh_config_json;  // zenoh Config (JSON5)
+    bool put_ack = true;
+    std::chrono::milliseconds query_timeout{5000};
+};
+```
+
+The default zenoh connection uses multicast scouting (same-host peers connect with zero configuration).
+In environments where multicast cannot be used, specify explicit endpoints
+(`connect.endpoints` / `listen.endpoints`) with `zenoh_config_json` [D13].
+
+(END OF DOCUMENT)

--- a/docs/03_wire_protocol.md
+++ b/docs/03_wire_protocol.md
@@ -1,0 +1,223 @@
+# sitos — Wire Protocol Specification
+
+This document defines cross-language interoperability for sitos [C03].
+A standard zenoh client can interoperate with sitos simply by following this specification.
+
+## 1. Key space
+
+### 1.1 Structure
+
+```
+<prefix>/base/<key>
+<prefix>/session/<sid>/<key>
+<prefix>/snap/<sid>/<key>
+<prefix>/meta/session/<sid>
+<prefix>/meta/ack/<uuid>
+<prefix>/base/$batch
+<prefix>/session/<sid>/$batch
+```
+
+* `<prefix>`: Default is `sitos`. Configurable. One or more zenoh chunks
+* `<sid>`: session ID. `[0-9a-zA-Z_-]+` (UUID recommended). One chunk
+* `<key>`: User key. One or more chunks (hierarchical keys allowed)
+
+### 1.2 User-key grammar
+
+```
+key    = chunk *( "/" chunk )
+chunk  = 1*( ALPHA / DIGIT / "_" / "-" / "." )
+```
+
+* Prohibited: empty chunks, `*` `$` `?` `#` `@` whitespace (reserved characters in
+  zenoh key expressions), leading or trailing `/`
+* Case-sensitive
+* Recommended: represent hierarchy with `/` (example: `recon/fov`).
+  Legacy `.`-separated keys (example: `recon.fov`) are legal as one chunk, but
+  cannot be partially enumerated with zenoh wildcards (§4.2)
+
+### 1.3 Migration rule for legacy keys (informative)
+
+When moving keys from the legacy parameter store to sitos, a mechanical `.` → `/`
+conversion is recommended. The conversion is the responsibility of an external adapter layer;
+sitos itself is not involved.
+
+## 2. payload v1 encoding
+
+### 2.1 Single value
+
+```
+offset  size  Contents
+0       1     Type tag (uint8)
+1       n     Value body (little-endian)
+```
+
+| Type tag | Name | Value body | Corresponding type (C++ / Python) |
+|---|---|---|---|
+| 0 | BOOL | 1 byte (0=false, nonzero=true) | `bool` / `bool` |
+| 1 | S64 | 8-byte signed integer LE | `std::int64_t` / `int` |
+| 2 | DP | 8-byte IEEE754 double-precision LE | `double` / `float` |
+| 3 | STR | UTF-8 byte sequence (length derived from payload length; no NUL terminator) | `std::string` / `str` |
+| 4 | BYTES | Raw byte sequence | `std::vector<std::byte>` / `bytes`, `numpy.ndarray` |
+
+* Type tag values match the type enumeration order of the preceding legacy parameter store
+  (BOOL, S64, DP, STR, BYTES) [C01]
+* Numeric-array interpretation of BYTES (for example, a float32 LUT) is the reader's
+  responsibility (same as the legacy parameter store). Element-type metadata is not included
+  in v1
+* 5–127 are reserved for future types. 128–255 are unused
+
+### 2.3 Golden fixtures
+
+All implementations (C++ codec / Python binding / zenoh-python interop) must match the
+following fixtures **byte-for-byte**. The hexadecimal notation represents the entire payload
+(including the type tag).
+
+| fixture name | Value | Type | payload hex |
+|---|---:|---|---|
+| `bool_false` | `false` | BOOL | `00 00` |
+| `bool_true` | `true` | BOOL | `00 01` |
+| `s64_zero` | `0` | S64 | `01 00 00 00 00 00 00 00 00` |
+| `s64_minus1` | `-1` | S64 | `01 ff ff ff ff ff ff ff ff` |
+| `s64_i32max` | `2147483647` | S64 | `01 ff ff ff 7f 00 00 00 00` |
+| `dp_zero` | `0.0` | DP | `02 00 00 00 00 00 00 00 00` |
+| `dp_240` | `240.0` | DP | `02 00 00 00 00 00 00 6e 40` |
+| `dp_nan` | quiet NaN | DP | `02 00 00 00 00 00 00 f8 7f` |
+| `str_empty` | `""` | STR | `03` |
+| `str_ascii` | `"abc"` | STR | `03 61 62 63` |
+| `str_utf8` | `"穀"` | STR | `03 e7 a9 80` |
+| `bytes_empty` | `[]` | BYTES | `04` |
+| `bytes_0102ff` | `[0x01,0x02,0xff]` | BYTES | `04 01 02 ff` |
+
+For `dp_nan`, use the bit pattern in the table above as the canonical fixture for an IEEE754
+quiet NaN. Compare decoded values with `isnan()`, and normalize to the canonical NaN above
+when re-encoding.
+
+### 2.2 zenoh Encoding
+
+Set the following zenoh `Encoding` on put/reply [C02]:
+
+```
+zenoh.bytes;sitos.v1          (single value)
+zenoh.bytes;sitos.v1.batch   (batch, §5)
+```
+
+(`Encoding` = type `zenoh.bytes` + schema suffix)
+
+Receiver interpretation rules:
+
+* schema is `sitos.v1` → decode according to this specification
+* schema is absent/unknown → accept it as BYTES (raw value without a type tag) and log a warning.
+  This lets a plain zenoh client still exchange the value as a binary value even if it forgets to
+  set Encoding (interoperability fallback)
+
+## 3. Mapping operations to keys
+
+| Operation | zenoh operation | Key |
+|---|---|---|
+| Write value | `put` | `<prefix>/base/<key>` or `<prefix>/session/<sid>/<key>` |
+| Delete value | `delete` | Same as above (valid only for base; not allowed for snap) |
+| Read value | `get` | Same key as for writes, or `<prefix>/snap/<sid>/<key>` |
+| Prefix enumeration | `get` | `<prefix>/base/<chunk...>/**`, etc. |
+| Batch write | `put` (batch payload) | `<prefix>/base/$batch` / `<prefix>/session/<sid>/$batch` (§5) |
+
+## 4. Query semantics
+
+### 4.1 Single-key get
+
+Get with an exact-match key. If no key matches, there are 0 replies (not an error).
+
+### 4.2 Enumeration (List)
+
+zenoh wildcards operate on chunks (`*` = one chunk, `**` = zero or more chunks).
+**Partial prefix matching inside a chunk cannot be represented on the wire**.
+
+* Enumeration at a chunk boundary: `get("sitos/base/recon/**")` — StorageNode replies using
+  the engine's `List("recon/")`
+* Non-boundary prefixes (such as the legacy-compatible API's `List("recon.f")`):
+  the client library gets the parent scope (`sitos/base/**`) and filters on the client side.
+  This is not specified as part of the wire protocol
+
+### 4.3 read-only rules for snap / session
+
+* put/delete to `snap/**`: StorageNode ignores it and logs a warning (no error response — zenoh
+  put is fire-and-forget)
+* get for a nonexistent `<sid>`: 0 replies
+
+## 5. Batch format (`sitos.v1.batch`)
+
+Delivers multiple entries atomically in one zenoh put [F09].
+Put to key `<prefix>/base/$batch` or `<prefix>/session/<sid>/$batch`, and store all entries in
+the payload.
+
+```
+offset  size  Contents
+0       4     Entry count N (uint32 LE)
+Repeated N times thereafter:
+        4     Key length kLen (uint32 LE)
+        kLen  Key (UTF-8; relative key with <prefix>/... removed)
+        1     Type tag
+        4     Value length vLen (uint32 LE)
+        vLen  Value body
+```
+
+* After receiving a batch, StorageNode applies all entries to the engine / overlay before
+  processing the next message (guaranteeing order and atomicity within the batch)
+* Subscribers (ParamCache) also subscribe to the batch key and apply the same format
+  (because it is included in the normal subscription ranges `session/<sid>/**` and `base/**`,
+  it can be received through the same path as ordinary delta subscriptions)
+* Subscribers that need per-key notifications expand the batch before handling it
+
+> Design note: The field order is aligned with the delivery wire format of the preceding legacy
+> parameter store (num + [keyLen, key, type, len, data]...), which simplifies migration-adapter
+> implementation.
+
+### 5.1 Batch fixture
+
+`batch_base_two_entries`:
+
+* put key: `sitos/base/$batch`
+* entries:
+  1. key=`recon/fov`, value=`DP 240.0`
+  2. key=`recon/kernel`, value=`STR "sharp"`
+* payload hex:
+
+```
+02 00 00 00
+09 00 00 00 72 65 63 6f 6e 2f 66 6f 76 02 08 00 00 00 00 00 00 00 00 00 6e 40
+0c 00 00 00 72 65 63 6f 6e 2f 6b 65 72 6e 65 6c 03 05 00 00 00 73 68 61 72 70
+```
+
+## 6. ack protocol (Put completion confirmation)
+
+A Put with `PutOptions::ack = true` follows this procedure:
+
+1. The client generates an ack token (UUID) corresponding to the beginning of the put payload and
+   attaches `ack=<uuid>` to the zenoh put `attachment`
+2. After completing the apply, StorageNode keeps a completion record in a ring buffer (most recent
+   4096 entries) so it can respond to get on `<prefix>/meta/ack/<uuid>`
+3. After the put, the client performs `get("<prefix>/meta/ack/<uuid>")`; if there is a reply,
+   completion is confirmed. On timeout (default 1 s), it retries up to 3 times
+
+Clients that do not support attachment are treated as ack-less put clients (compatible behavior).
+
+## 7. meta keys
+
+### 7.1 `meta/session/<sid>`
+
+For checking session existence and debugging. StorageNode creates it on CreateSession.
+The value is JSON encoded as payload v1 STR:
+
+```json
+{"state": "active", "created_at": "2026-07-07T01:23:45Z"}
+```
+
+Deleted by CloseSession.
+
+## 8. Versioning [C04]
+
+* This specification is **wire v1**. Schema suffixes `sitos.v1*` are the identifiers
+* Backward-compatible additions (new meta keys, new type tags) are minor versions
+* Changes to or deletion of meanings of existing fields are major versions (change the schema to
+  `sitos.v2*`, and provide an implementation supporting both during the migration period)
+
+(END OF DOCUMENT)

--- a/docs/04_api_cpp.md
+++ b/docs/04_api_cpp.md
@@ -1,0 +1,270 @@
+# sitos — C++ API Specification
+
+namespace: `sitos::`. C++20. The header is `#include <sitos/sitos.hpp>` (umbrella).
+Exceptions are used only for unrecoverable errors in constructors/factories. All other errors are represented by return values.
+
+## 1. Basic Types
+
+```cpp
+namespace sitos {
+
+/// Value type. Corresponds to the five payload v1 types ([03_wire_protocol.md] §2.1)
+class ParamValue {
+public:
+    using Variant = std::variant<bool, std::int64_t, double,
+                                 std::string, std::vector<std::byte>>;
+
+    // Construction (numeric types are normalized to S64/DP: int32→S64, float→DP, etc.)
+    template<typename T> explicit ParamValue(T&& v);
+
+    ValueType type() const;   // enum class ValueType { Bool, S64, Dp, Str, Bytes }
+
+    /// Typed extraction. Arithmetic casts are allowed among numeric types (Bool/S64/Dp).
+    /// Impossible combinations return std::nullopt.
+    template<typename T> std::optional<T> As() const;
+
+    /// View a Bytes value as an array of T (zero-copy). T is trivially copyable.
+    /// Returns std::nullopt if the value is not Bytes or its size is not a multiple of sizeof(T).
+    template<typename T> std::optional<std::span<const T>> AsSpan() const;
+
+    /// Encode/decode to/from payload v1
+    std::vector<std::byte> Encode() const;
+    static std::optional<ParamValue> Decode(std::span<const std::byte> payload);
+};
+
+/// Result with error information
+template<typename T>
+struct Result {
+    std::optional<T> value;
+    Status status;            // enum class Status { Ok, NotFound, TypeMismatch,
+                              //   Timeout, Disconnected, ReadOnly, InvalidKey, Error }
+    std::string message;      // Human-readable details
+    explicit operator bool() const { return status == Status::Ok; }
+};
+
+/// Specialization for void. Used by APIs that return only Status (`Result<void>`).
+template<>
+struct Result<void> {
+    Status status;
+    std::string message;
+    explicit operator bool() const { return status == Status::Ok; }
+};
+
+struct Config {
+    std::string prefix = "sitos";
+    std::optional<std::string> zenoh_config_json;  // zenoh Config (JSON5)
+    bool put_ack = true;
+    std::chrono::milliseconds query_timeout{5000};
+};
+
+/// Payload format identifier ([03] §2.2). Corresponds to transport Encoding.
+enum class Encoding { SitosV1, SitosV1Batch, Raw };
+
+/// Put completion guarantee option ([02] §6.2)
+struct PutOptions {
+    bool ack = true;
+};
+
+/// Common sink for List APIs. Returning false aborts enumeration.
+using ListSink = std::function<bool(std::string_view key, const ParamValue&)>;
+
+/// RAII handle for subscriptions/queryables. Destruction undeclares it.
+class Subscription;
+class Queryable;
+
+} // namespace sitos
+```
+
+Key arguments are `std::string_view` in all APIs. Invalid keys ([03] §1.2) produce
+`Status::InvalidKey`.
+
+The `Transport` abstraction (a zenoh adapter that provides put/get/queryable/subscriber) is
+defined in [09_dependency_policy.md](09_dependency_policy.md) §3.
+`ParamStore`/`ParamCache`/`StorageNode` do not expose raw zenoh-cpp types in the public API.
+zenoh session injection [X04] is performed by converting the session to
+`std::shared_ptr<Transport>` with the `ZenohTransport::From(session)` factory before passing it in.
+
+### 1.1 Status / Python Exception Mapping
+
+| Status | C++ condition | Python exception |
+|---|---|---|
+| `Ok` | Success | None |
+| `NotFound` | get target absent, nonexistent session | `sitos.NotFoundError` |
+| `TypeMismatch` | Type conversion impossible, Bytes dtype/size mismatch | `sitos.TypeMismatchError` |
+| `Timeout` | query/ack does not complete within `Config::query_timeout` | `sitos.TimeoutError` |
+| `Disconnected` | zenoh session disconnected, StorageNode stopped | `sitos.DisconnectedError` |
+| `ReadOnly` | put/delete through the library API to `snap/<sid>/**` | `sitos.ReadOnlyError` |
+| `InvalidKey` | Key/scope/session id violates the grammar | `ValueError` |
+| `Error` | Other implementation-dependent error (RocksDB status, etc.) | `sitos.SitosError` |
+
+Python `get(..., default=...)` does not raise for `NotFound` only; it returns default.
+All other Status values are converted to exceptions.
+
+## 2. ParamStore — Writes and Ad Hoc Reads
+
+```cpp
+class ParamStore {
+public:
+    /// Open a new zenoh session (creates ZenohTransport internally)
+    static Result<ParamStore> Open(const Config& config);
+    /// Share an existing Transport [X04]
+    static Result<ParamStore> Open(std::shared_ptr<Transport> transport,
+                                   const Config& config);
+
+    // ---- Writes (scope: "base" or "session/<sid>") ----
+    Result<void> Put(std::string_view scope, std::string_view key,
+                     const ParamValue& value);
+    template<typename T>
+    Result<void> Put(std::string_view scope, std::string_view key, T&& value);
+    /// Batch [F09]: atomically delivered in one zenoh put
+    Result<void> PutBatch(std::string_view scope,
+                          std::span<const std::pair<std::string, ParamValue>> entries);
+    Result<void> Delete(std::string_view scope, std::string_view key); // base only [F12]
+
+    // ---- Reads (round trip. Use ParamCache for the hot path) ----
+    Result<ParamValue> Get(std::string_view scope, std::string_view key);
+    template<typename T>
+    Result<T> Get(std::string_view scope, std::string_view key);
+    bool Contains(std::string_view scope, std::string_view key);      // [F11]
+
+    /// Enumerate under prefix (chunk boundary). Abort if sink returns false. [F03]
+    Result<void> List(std::string_view scope, std::string_view prefix,
+                      const ListSink& sink);
+
+    // ---- Subscription [F13] ----
+    class Subscription;  // RAII. Destruction unsubscribes
+    using SubscribeCallback =
+        std::function<void(std::string_view key, const ParamValue&)>;
+    Result<Subscription> Subscribe(std::string_view scope,
+                                   std::string_view key_pattern,
+                                   SubscribeCallback callback);
+};
+```
+
+`scope` format: `"base"`, `"session/<sid>"`, `"snap/<sid>"` (read-only).
+Put/Delete to `snap` returns `Status::ReadOnly`.
+
+## 3. StorageEngine / StorageNode — Storage Node Side
+
+`StorageEngine`/`StorageReader` are as described in [02_architecture.md](02_architecture.md) §3.
+Bundled engines:
+
+```cpp
+/// Zero dependencies. TakeSnapshot performs a full copy [X02]
+class InMemoryEngine final : public StorageEngine { ... };
+
+/// Provided only when built with SITOS_WITH_ROCKSDB.
+/// TakeSnapshot is O(1) via rocksdb::DB::GetSnapshot [N02]
+class RocksDBEngine final : public StorageEngine {
+public:
+    static Result<std::unique_ptr<RocksDBEngine>> Open(const std::string& path);
+};
+```
+
+```cpp
+class StorageNode {
+public:
+    static Result<StorageNode> Start(std::shared_ptr<StorageEngine> engine,
+                                     const Config& config);
+    static Result<StorageNode> Start(std::shared_ptr<StorageEngine> engine,
+                                     std::shared_ptr<Transport> transport,
+                                     const Config& config);
+
+    /// In-process direct access to engine (no zenoh round trip).
+    /// For fast reads in the host process (controller/orchestrator).
+    const StorageEngine& engine() const;
+
+    // ---- session management (equivalent to SessionController) ----
+    Result<void> CreateSession(std::string_view sid);   // [F05]
+    Result<void> CloseSession(std::string_view sid);    // [F10]
+    std::vector<std::string> ActiveSessions() const;
+
+    void Stop();   // undeclares queryable/subscriber. Also called by the destructor
+};
+```
+
+## 4. ParamCache — Subscriber-Side Hot Path
+
+```cpp
+class ParamCache {
+public:
+    static Result<ParamCache> Open(const Config& config);
+    static Result<ParamCache> Open(std::shared_ptr<Transport> transport,
+                                   const Config& config);
+
+    /// Join a session: initially fetch snap + overlay, then start delta subscription.
+    /// Synchronously blocks until completion (timeout is config.query_timeout).
+    Result<void> Attach(std::string_view sid);
+    /// Direct base reference mode ([02] §5.3)
+    Result<void> AttachBase();
+    void Detach();
+
+    // ---- Zero-copy reads [N01] ----
+    /// Shared reference to the value. The lock is held only during lookup. Return-value lifetime is managed by shared_ptr.
+    std::shared_ptr<const ParamValue> GetShared(std::string_view key) const;
+
+    template<typename T>
+    std::optional<T> Get(std::string_view key) const;          // Scalar (copy)
+    template<typename T>
+    T GetOr(std::string_view key, T default_value) const;
+
+    /// LUT reference: span pointing to the internal buffer + lifetime keepalive handle
+    template<typename T>
+    struct SpanHandle {
+        std::span<const T> span;
+        std::shared_ptr<const ParamValue> keepalive;
+    };
+    template<typename T>
+    std::optional<SpanHandle<T>> GetSpan(std::string_view key) const;
+
+    bool Contains(std::string_view key) const;
+    /// Enumerate within the cache (no communication)
+    void List(std::string_view prefix, const ListSink& sink) const;
+
+    // ---- Writes within a session (put to overlay) ----
+    Result<void> Put(std::string_view key, const ParamValue& value);
+    Result<void> PutBatch(std::span<const std::pair<std::string, ParamValue>> entries);
+
+    // ---- State ----
+    bool stale() const;   // true while disconnected. Recovers by refetching after reconnection [N10]
+};
+```
+
+### Usage Example (Compute Process)
+
+```cpp
+auto cache = sitos::ParamCache::Open(config).value.value();
+cache.Attach(sid);
+
+double fov   = cache.GetOr<double>("recon/fov", 240.0);
+auto lut     = cache.GetSpan<float>("recon/bhc/lut");   // zero-copy
+if (lut) Process(lut->span);
+
+cache.Put("recon/progress", 0.5);   // distributed to all participating processes
+```
+
+## 5. SessionView — Composite View (Optional Use)
+
+A facade for the host process side that handles overlay → snapshot resolution through one read
+interface.
+
+```cpp
+class SessionView {
+public:
+    SessionView(const StorageNode& node, std::string_view sid);
+    // Get/GetOr/GetSpan/Contains/List with the same shape as ParamCache (in-process resolution)
+    // Put writes to the overlay + distributes via zenoh
+};
+```
+
+## 6. Thread-Safety Contract
+
+| Class | Contract |
+|---|---|
+| `ParamValue` | Immutable. Can be freely shared |
+| `ParamStore` | All methods may be called concurrently |
+| `ParamCache` | Get methods may run concurrently. Attach/Detach must be serialized externally |
+| `StorageNode` | All methods may be called concurrently |
+| callback | Called from zenoh threads. Blocking is prohibited. From inside a callback, only Get-style APIs on the same object may be called |
+
+(END OF DOCUMENT)

--- a/docs/05_api_python.md
+++ b/docs/05_api_python.md
@@ -1,0 +1,141 @@
+# sitos — Python API Specification
+
+Package name: `sitos`. Python 3.10+ [P05].
+nanobind wrapper for the C++ core + a thin pythonic layer [P01].
+
+## 1. Value Type Mapping
+
+| payload v1 | Python (Get) | Python (types accepted by Put) |
+|---|---|---|
+| BOOL | `bool` | `bool` |
+| S64 | `int` | `int` (`OverflowError` if outside the 64-bit range) |
+| DP | `float` | `float` |
+| STR | `str` | `str` |
+| BYTES | `bytes` / `numpy.ndarray` (when dtype is specified) | `bytes`, `bytearray`, `memoryview`, C-contiguous `numpy.ndarray` |
+
+* Put of `numpy.ndarray` performs one copy through the buffer protocol (during encoding)
+* dtype/shape metadata is not included in the v1 payload ([03] §2.1).
+  The reader specifies the dtype
+
+## 2. API
+
+### 2.1 ParamStore
+
+```python
+import sitos
+
+store = sitos.ParamStore(prefix="sitos", zenoh_config=None, put_ack=True)
+# Or share an existing zenoh session:
+# store = sitos.ParamStore.from_zenoh_session(session, prefix="sitos")
+
+store.put("base", "recon/fov", 240.0)
+store.put_batch("base", {"recon/fov": 240.0, "recon/kernel": "sharp"})
+store.delete("base", "recon/tmp")
+
+value = store.get("base", "recon/fov")           # -> 240.0 (type is automatic)
+value = store.get("base", "recon/fov", type=int) # Arithmetic cast. TypeError if impossible
+exists = store.contains("base", "recon/fov")
+
+for key, value in store.list("base", "recon"):   # generator
+    ...
+
+sub = store.subscribe("base", "recon/**", callback=lambda key, value: ...)
+sub.close()          # Or: with store.subscribe(...) as sub:
+store.close()        # Supports context manager (__enter__/__exit__)
+```
+
+* Errors: misses do not return `None`; they raise `sitos.NotFoundError`, or
+  `get(..., default=...)` returns the default value. Communication loss raises `sitos.DisconnectedError`
+* callback is called from a dedicated dispatch thread ([02] §8).
+  Long-running work inside the callback delays other notifications (warn about this in the documentation)
+
+### 2.2 ParamCache
+
+```python
+cache = sitos.ParamCache(prefix="sitos")
+cache.attach(sid)                     # Fetch snapshot + overlay
+# cache.attach_base()                 # Direct base reference mode
+
+fov  = cache.get("recon/fov", default=240.0)
+lut  = cache.get_array("recon/bhc/lut", dtype="float32")   # -> numpy.ndarray
+# get_array is zero-copy [P02]: a read-only ndarray pointing to the internal buffer.
+# While the ndarray is alive, the underlying buffer is not released (keepalive).
+assert lut.flags.writeable is False
+
+cache.put("recon/progress", 0.5)      # Write to overlay + distribute
+cache.contains("recon/fov")
+dict(cache.items("recon"))            # Enumerate within cache (no communication)
+cache.stale                           # True while disconnected
+cache.detach(); cache.close()
+```
+
+### 2.3 StorageNode / Engines
+
+```python
+engine = sitos.InMemoryEngine()
+# engine = sitos.RocksDBEngine("/var/lib/myapp/params")  # when the sitos-rocksdb wheel is installed
+
+node = sitos.StorageNode(engine, prefix="sitos")
+node.create_session(sid)
+node.close_session(sid)
+node.active_sessions()                # -> list[str]
+node.stop()
+```
+
+### 2.4 SessionView
+
+API for using the composite view of snapshot + overlay directly from Python inside the process
+that owns StorageNode. It has the same semantics as C++ `SessionView`.
+
+```python
+view = node.session_view(sid)
+fov = view.get("recon/fov", default=240.0)      # Resolve in overlay → snapshot order
+view.put("recon/progress", 0.5)                 # Write to overlay + distribute
+```
+
+Custom engines [X01] can also be defined in Python
+(subclass `sitos.StorageEngine` and implement `put/get/list/delete`.
+However, state explicitly that performance is the user's responsibility):
+
+```python
+class MyEngine(sitos.StorageEngine):
+    def put(self, key: str, value: bytes) -> None: ...
+    def get(self, key: str) -> bytes | None: ...
+    def list(self, prefix: str): ...        # -> Iterable[tuple[str, bytes]]
+    def delete(self, key: str) -> None: ...
+    # If take_snapshot() is not implemented, use the copy fallback [N03]
+```
+
+## 3. GIL and Thread Design [P04]
+
+* zenoh threads in the C++ core do not acquire the GIL
+* Notifications to Python callbacks are one-way: “C++-side queue → dedicated Python dispatch
+  thread (acquires the GIL)”. zenoh threads never block waiting for the GIL
+* `get`/`get_array` use only a C++-side shared lock. They keep holding the GIL
+  (because there is no I/O, it is not released)
+* In a StorageNode that uses a Python engine (§2.3), zenoh threads call into Python,
+  so GIL acquisition occurs. State explicitly that C++ engines are recommended for production use
+
+## 4. Type Stubs and Documentation
+
+* Include type stubs under `sitos/*.pyi` and verify them with mypy/pyright
+* docstrings must match the content of the C++ Doxygen comments
+* Include an interoperability example in README for “talking to sitos with zenoh-python only” [C03]:
+
+```python
+import zenoh, struct
+session = zenoh.open(zenoh.Config())
+# DP in sitos payload v1 (type tag 2 + double LE)
+session.put("sitos/base/recon/fov", bytes([2]) + struct.pack("<d", 240.0),
+            encoding=zenoh.Encoding.ZENOH_BYTES.with_schema("sitos.v1"))
+```
+
+## 5. Packaging Requirements (Reference)
+
+Wheel structure and build are described in [06_build_test_packaging.md](06_build_test_packaging.md).
+The standard wheel installed by `pip install sitos` bundles InMemoryEngine + zenoh-c,
+and has only NumPy as an additional runtime dependency (simplified as a required dependency,
+not optional `sitos[numpy]`) [P03].
+RocksDBEngine is provided as a `sitos-rocksdb` wheel or as a future optional extra.
+
+(END OF DOCUMENT)

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -1,0 +1,120 @@
+# sitos — Build / Test / Packaging
+
+## 1. Repository layout
+
+```
+sitos/
+  CMakeLists.txt              # Top level. Options: SITOS_WITH_ROCKSDB,
+                              #   SITOS_BUILD_PYTHON, SITOS_BUILD_TESTS, SITOS_BUILD_EXAMPLES
+  cmake/                      # zenoh-c integration (FetchContent/Corrosion/find_package)
+  include/sitos/              # Public headers (API from 04_api_cpp.md)
+  src/                        # Implementation
+  python/
+    pyproject.toml            # scikit-build-core
+    bindings/                 # nanobind module (_sitos)
+    sitos/                    # Pure Python layer + .pyi
+  tests/
+    unit/                     # gtest (prefer tests based on InMemoryEngine and not requiring zenoh)
+    integration/              # Multiprocess / via zenoh
+    interop/                  # Interoperability tests that speak only zenoh-python [C03]
+    bench/                    # Benchmarks (Google Benchmark)
+    python/                   # pytest
+  examples/
+    cpp/                      # quickstart, storage_node demo (binary name: sitobolon)
+    python/
+  docs/                       # English design documents + Doxygen/Sphinx
+  .github/workflows/
+```
+
+## 2. Build (C++)
+
+* C++20, maximum warning level + warning-as-error (MSVC `/W4 /WX`, gcc/clang `-Wall -Wextra -Werror`)
+* **Code style** (D12): `.clang-format` is `BasedOnStyle: Google` +
+  `ColumnLimit: 100`. Naming follows the Google C++ Style Guide
+  (types/methods = PascalCase, variables = snake_case, members = trailing `_`,
+  constants = kPascalCase). File names are snake_case (`param_value.hpp`)
+* **Language** (D9): code, comments, commit messages, Issues/PRs, and docs are English.
+  This design document set is the English edition in `docs/`
+* Dependency resolution:
+  - **zenoh-c/zenoh-cpp**: First choice is to use official prebuilt releases via
+    `find_package(zenohc)`. CI pins versions with FetchContent.
+    Also provide a Corrosion (Rust) path for environments that need source builds
+  - **RocksDB** (when `SITOS_WITH_ROCKSDB=ON`): `find_package(RocksDB)`.
+    Supplied by vcpkg / apt / brew
+  - **gtest / benchmark**: FetchContent
+* Presets: define `dev-windows`, `dev-linux`, `release`, and `python-wheel` in
+  `CMakePresets.json`
+
+## 3. Build (Python wheel)
+
+* scikit-build-core + nanobind. Generate wheels with `python -m build`
+* CI build with cibuildwheel: `cp310–cp313 × {win_amd64, manylinux_2_28_x86_64}` [P03]
+* Standard wheels bundle zenoh-c and do not include RocksDB
+  (Linux: auditwheel repair, Windows: delvewheel).
+  RocksDBEngine is separated as a `sitos-rocksdb` wheel or a future optional extra.
+* Runtime dependency: `numpy>=1.24`
+
+## 4. Test strategy
+
+| Layer | Framework | Target | Run in CI |
+|---|---|---|---|
+| unit | gtest | ParamValue encode/decode (payload v1 golden tests), StorageEngine contract tests (common test suite instantiated for each engine), key validation, Overlay resolution | Always |
+| integration | gtest | Connect StorageNode + ParamStore + ParamCache with multiple zenoh sessions in one process. Full session lifecycle ([02] §7), disconnect/reconnect [N10], batch, ack | Always |
+| multiprocess | gtest + spawn | Attach/delivery/crash recovery with real process isolation | Always (Linux) / nightly (Windows) |
+| interop | pytest + zenoh-python | Read/write using only the wire specification ([03]) without the sitos library [C03] | Always |
+| python | pytest | API parity, NumPy zero-copy (writeable=False, base-buffer identity), GIL (concurrent get inside callback) | Always |
+| bench | Google Benchmark | N01 (cache Get), N02 (TakeSnapshot), N08 (session start), N09 (delivery latency) | nightly + regression comparison in PR comments |
+
+**Contract-test principle**: Write the `StorageEngine` test suite against the abstraction, in a
+form reusable for InMemory/RocksDB/(future user engines) [X01].
+
+**Golden tests**: Save the payload v1 byte sequences as fixtures and verify byte-for-byte matches
+for encoded results (the cornerstone of compatibility across languages and versions).
+The Python side also references the same fixtures.
+
+### 4.1 Required test names
+
+To prevent AI/implementers from misreading the intent, the following test names are fixed for
+major behaviors.
+
+| Test name | Target requirement | Verification |
+|---|---|---|
+| `PayloadV1GoldenFixtures` | C01 | Exact match with the fixtures in [03] §2.3 |
+| `BatchV1GoldenFixture` | F09/C01 | Exact match with the batch fixture in [03] §5.1 |
+| `InvalidKeysAreRejected` | X03 | Reject reserved characters, empty chunks, and invalid sid |
+| `SnapshotIsIsolatedFromBasePut` | F05/N02 | A base put after CreateSession does not affect snap reads |
+| `SnapshotFallbackCopiesForInMemory` | N03 | InMemory snapshot works with the same semantics |
+| `AttachDoesNotMissConcurrentPut` | F06 | Does not miss a concurrent put during Attach |
+| `BatchIsReceivedBySessionSubscriber` | F09 | `$batch` is received by a `session/<sid>/**` subscription |
+| `SpanHandleSurvivesOverwrite` | N01/P02 | old SpanHandle/ndarray remains valid after an update |
+| `RawZenohClientCanPutAndGet` | C03 | Single-value interoperability using only zenoh-python |
+| `RawZenohClientCanSendBatch` | C03/F09 | Batch interoperability using only zenoh-python |
+| `PutAckTimesOutWhenNodeUnavailable` | N10 | ack timeout/status mapping |
+| `PythonCallbackDoesNotDeadlockWithGet` | P04 | get inside callback does not deadlock |
+
+## 5. CI (GitHub Actions)
+
+| workflow | Trigger | Contents |
+|---|---|---|
+| `ci.yml` | PR/push | Windows (MSVC) + Linux (gcc, clang) builds; unit + integration + python + interop; clang-format/clang-tidy; mypy |
+| `wheels.yml` | tag / nightly | cibuildwheel → PyPI (on tag) / TestPyPI (nightly) |
+| `bench.yml` | nightly / label | Run benchmarks and comment baseline comparisons |
+| `dependency-upgrade.yml` | nightly / manual | Build and interop tests with the minimum supported and latest stable zenoh versions. Details: [09_dependency_policy.md](09_dependency_policy.md) |
+| `docs.yml` | push main | Doxygen + Sphinx → GitHub Pages |
+
+## 6. Quality gates
+
+* Code coverage: line 80% or higher (gcov/llvm-cov, Codecov)
+* sanitizer: ASan/UBSan (Linux CI), TSan nightly for integration
+* Static analysis: clang-tidy (modernize-*, bugprone-*, concurrency-*)
+* Commit convention: Conventional Commits (automatic CHANGELOG generation with release-please)
+
+## 7. Release
+
+* Semantic versioning [C04]. C++ and Python use the same version
+* Artifacts: GitHub Release (source + prebuilt static/shared libraries), PyPI wheel.
+  Future: vcpkg / conan registry registration
+* Pre-publication checklist: intellectual-property and export-control review, check for inclusion
+  of company-specific information, LICENSE (Apache-2.0) / NOTICE / third-party license list
+
+(END OF DOCUMENT)

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -1,0 +1,421 @@
+# sitos — Issue Breakdown / Milestones and Issue Split Proposal
+
+Split the work into units that other AI models (or developers) can start implementing as-is.
+Each Issue has "Reference documents", "Acceptance criteria (AC)", and "Dependencies".
+
+**Issue numbers must match GitHub Issue numbers 1:1** (creation order = the sequence numbers in this document).
+Principle for the dependency graph: most of M1 can be implemented in parallel without zenoh dependencies.
+zenoh integration (M2) is the overall critical path.
+
+## Release boundaries
+
+Register release boundaries as **GitHub Milestones**, and assign each Issue to the corresponding
+Milestone (M0–M5 are design-phase classifications; progress management on GitHub uses
+Milestone = release boundary).
+
+| Milestone | Target state | Required Issues |
+|---|---|---|
+| **v0.1** | The zenoh-independent core works. Payload fixtures and InMemoryEngine contract tests are green | #1, #4, #5, #6, #7 |
+| **v0.2** | StorageNode/ParamStore/ParamCache work in C++ through same-process zenoh sessions | #2, #3, #9–#13, #15, #18, #19, #21 |
+| **v0.3** | Basic Python APIs work (InMemory, ParamStore, ParamCache, NumPy read) | #22, #23, #24, #25, #27 |
+| **v0.4** | RocksDB, single-value interop, bench, and examples are in place | #8, #29, #31, #32, #33 |
+| **v1.0** | Public OSS quality. docs/release/wheels/ack/batch interop/GIL/custom engine completed | #14, #16, #17, #20, #26, #28, #30, #34, #35 |
+
+`ack`-related work (#14, #17) is useful, but implementation is heavy relative to initial value,
+so it is not a v0.2 blocker. Include it by v1.0.
+
+---
+
+## M0: Repository bootstrap
+
+### #1 Repository skeleton and CI skeleton
+* Milestone: v0.1
+* References: [06] §1, §2, §5, [00] §6 (D9–D12)
+* Scope: CMake project skeleton (option definitions, presets), gtest introduction,
+  GitHub Actions `ci.yml` (Windows/Linux build + empty test run),
+  `.clang-format` (`BasedOnStyle: Google`, `ColumnLimit: 100`)/.editorconfig,
+  `.gitignore`/`.gitattributes` (quote and combine the C++/CMake/Python portions from
+  github/gitignore and gitattributes/gitattributes, and clearly note the source URLs in the files),
+  `AGENTS.md` (entry point for AI implementers: document pointers + summary of absolute rules.
+  Do not duplicate [11]; keep it to pointers),
+  LICENSE (Apache-2.0), README skeleton.
+  Create `docs/adr/` and write initial ADRs 0001–0013 in English ([10] §8).
+  Configure the PR template ([11] §4) and branch protection on main (CI required, direct push prohibited).
+  Because the repository is **public from the start** (D11), reserve the `sitos` name on PyPI
+  (placeholder release) in this Issue as well. All deliverables are in English (D9)
+* Acceptance criteria: CI is green on both OSes. `cmake --preset dev-linux && ctest` passes.
+  The `sitos` placeholder exists on PyPI. `docs/adr/` contains 0001–0013
+* Depends on: none
+
+### #2 Build integration for zenoh-c/zenoh-cpp
+* Milestone: v0.2
+* References: [06] §2
+* Scope: Prebuilt zenoh-c acquisition + `find_package` / FetchContent integration.
+  Pin the version. Smoke test that only opens and closes a zenoh session
+* Acceptance criteria: zenoh session open/close test passes in CI on both OSes
+* Depends on: #1
+
+### #3 Transport adapter and zenoh compatibility CI
+* Milestone: v0.2
+* References: [02] §1, [09]
+* Implementation targets: `include/sitos/transport.hpp`,
+  `src/transport/zenoh_transport.cpp`, `tests/integration/transport_test.cpp`,
+  `.github/workflows/dependency-upgrade.yml`
+* Scope: Implement a `Transport` abstraction that hides the zenoh-cpp API, so StorageNode/ParamStore/
+  ParamCache do not depend directly on raw zenoh-cpp types. Verify the minimum supported and
+  latest stable zenoh versions in CI. Confirm that the attachment API is available in the locked version
+* Acceptance criteria: transport_test is green for both the minimum supported version and latest stable.
+  Static check confirms there are no raw zenoh-cpp API includes outside transport under `src/`
+* Depends on: #2
+
+---
+
+## M1: Core (parallelizable without zenoh dependencies)
+
+### #4 ParamValue and payload v1 codec
+* Milestone: v0.1
+* References: [04] §1, [03] §2
+* Implementation targets: `include/sitos/param_value.hpp`, `src/param_value.cpp`,
+  `tests/unit/param_value_test.cpp`, `tests/fixtures/payload_v1/*.hex`
+* Scope: `ParamValue` (variant, As/AsSpan, Encode/Decode), type tags,
+  numeric arithmetic cast rules, encoder/decoder for the batch format ([03] §5).
+  Validate the fixtures themselves with an independent implementation (Python struct)
+* Acceptance criteria: unit tests including golden tests (byte-for-byte fixture matches).
+  Round-trip for all types, boundary values (NaN, ±inf, empty string, empty bytes), rejection of invalid payloads
+* Depends on: #1
+
+### #5 Key validation and key-expression construction
+* Milestone: v0.1
+* References: [03] §1
+* Implementation targets: `include/sitos/key.hpp`, `src/key.cpp`, `tests/unit/key_test.cpp`
+* Scope: Validate user-key grammar, construct `<prefix>/<scope>/<key>`,
+  scope parser ("base" / "session/<sid>" / "snap/<sid>")
+* Acceptance criteria: unit tests for valid/invalid cases (reserved characters, empty chunks)
+* Depends on: #1
+
+### #6 StorageEngine abstraction and contract test suite
+* Milestone: v0.1
+* References: [02] §3, [06] §4
+* Implementation targets: `include/sitos/storage_engine.hpp`,
+  `tests/unit/storage_engine_contract.hpp`, `tests/unit/storage_engine_contract_test.cpp`
+* Scope: `StorageReader`/`StorageEngine` interfaces,
+  default copy-fallback implementation of `TakeSnapshot()`,
+  contract test suite reusable by swapping engine implementations
+* Acceptance criteria: Contract tests are written against the abstraction and are green with a mock engine
+* Depends on: #1
+
+### #7 InMemoryEngine
+* Milestone: v0.1
+* References: [02] §3, [04] §3
+* Implementation targets: `include/sitos/in_memory_engine.hpp`, `src/in_memory_engine.cpp`,
+  `tests/unit/in_memory_engine_test.cpp`
+* Scope: `std::map` + `std::shared_mutex` implementation. Snapshots are copies
+* Acceptance criteria: Contract tests green. Stress test for concurrent read/write (TSan)
+* Depends on: #6
+
+### #8 RocksDBEngine
+* Milestone: v0.4
+* References: [02] §3, [04] §3, [06] §2
+* Implementation targets: `include/sitos/rocksdb_engine.hpp`, `src/rocksdb_engine.cpp`,
+  `tests/unit/rocksdb_engine_test.cpp`, `cmake/FindRocksDB.cmake` (if needed)
+* Scope: `SITOS_WITH_ROCKSDB` option, `rocksdb::DB` wrapper,
+  O(1) TakeSnapshot based on `GetSnapshot()`
+* Acceptance criteria: Contract tests green. Put after TakeSnapshot does not affect snapshot reads.
+  TakeSnapshot execution time does not depend on data size (bench)
+* Depends on: #6
+
+---
+
+## M2: StorageNode and zenoh integration (critical path)
+
+### #9 StorageNode: queryable get/list skeleton
+* Milestone: v0.2
+* References: [02] §4, [03] §3–4
+* Implementation targets: `include/sitos/storage_node.hpp`, `src/storage_node.cpp`,
+  `tests/integration/storage_node_query_test.cpp`
+* Scope: queryable declaration for `<prefix>/**`, get/List routing to base,
+  minimal Stop/RAII implementation
+* Acceptance criteria: integration tests — get round-trip from a separate zenoh session,
+  chunk-boundary List, 0 replies for get of an unknown key
+* Depends on: #3, #4, #5, #7
+
+### #10 StorageNode: subscriber put/delete
+* Milestone: v0.2
+* References: [02] §4, [03] §3–4
+* Implementation targets: `src/storage_node.cpp`,
+  `tests/integration/storage_node_subscriber_test.cpp`
+* Scope: subscriber declaration for `<prefix>/**`, put/delete routing to base,
+  warning logs for read-only paths
+* Acceptance criteria: integration tests — put→get round-trip from a separate zenoh session,
+  get returns 0 replies after delete, raw put to snap is ignored
+* Depends on: #9
+
+### #11 StorageNode lifecycle / RAII
+* Milestone: v0.2
+* References: [02] §4, [04] §3
+* Implementation targets: `include/sitos/storage_node.hpp`, `src/storage_node.cpp`,
+  `tests/integration/storage_node_lifecycle_test.cpp`
+* Scope: StorageNode::Start/Stop, undeclare queryable/subscriber, move/RAII contract
+* Acceptance criteria: queryable/subscriber do not respond after Stop, and double Stop is safe
+* Depends on: #10
+
+### #12 StorageNode: session management (snapshot/overlay)
+* Milestone: v0.2
+* References: [02] §4.1–4.3, §7
+* Implementation targets: `include/sitos/session.hpp`, `src/storage_node.cpp`,
+  `tests/integration/storage_node_session_test.cpp`
+* Scope: CreateSession/CloseSession, snapshot table, overlay table,
+  `snap/<sid>/**` get replies, `session/<sid>/**` put/get,
+  warnings for read-only violations, `meta/session/<sid>`
+* Acceptance criteria: integration tests — snapshot isolation (base put after CreateSession does not affect snap reads),
+  get returns 0 replies after Close, resource release (leak test)
+* Depends on: #11, (#8 can proceed in parallel)
+
+### #13 Batch delivery
+* Milestone: v0.2
+* References: [03] §5, [02] §6.1
+* Implementation targets: `include/sitos/batch.hpp`, `src/batch.cpp`, `src/storage_node.cpp`,
+  `tests/integration/batch_test.cpp`
+* Scope: Receiving process for `$batch` keys (`base/$batch`, `session/<sid>/$batch`)
+  (atomic apply), and ParamCache receiving batch through the normal subscription range
+* Acceptance criteria: integration tests — all batch entries applied and ordered, received through normal subscription,
+  expansion into per-key notifications
+* Depends on: #11, #12
+
+### #14 ack protocol
+* Milestone: v1.0
+* References: [03] §6, [02] §6.2
+* Implementation targets: `include/sitos/ack.hpp`, `src/ack.cpp`, `src/storage_node.cpp`,
+  `tests/integration/ack_test.cpp`
+* Scope: ack ring buffer and `meta/ack/<uuid>` queryable, client retry
+* Acceptance criteria: integration tests — ack round-trip, retry on ack timeout,
+  put without attachment is treated as ack-less
+* Depends on: #11
+
+### #15 ParamStore: Put/Get/List/Delete
+* Milestone: v0.2
+* References: [04] §2
+* Implementation targets: `include/sitos/param_store.hpp`, `src/param_store.cpp`,
+  `tests/integration/param_store_test.cpp`
+* Scope: Open (new/session injection), Put/PutBatch/Delete/Get/Contains/List,
+  scope validation, basic Result/Status mapping
+* Acceptance criteria: integration tests — all API round-trips against StorageNode.
+  Scope validation (Put to snap is ReadOnly)
+* Depends on: #11, #13
+
+### #16 ParamStore: Subscribe
+* Milestone: v1.0
+* References: [04] §2, [01] F13
+* Implementation targets: `include/sitos/param_store.hpp`, `src/param_store.cpp`,
+  `tests/integration/param_store_subscribe_test.cpp`
+* Scope: Subscribe/Subscription RAII, callback error handling, unsubscribe
+* Acceptance criteria: integration tests — put notification, expanded batch notifications, no notifications after unsubscribe
+* Depends on: #15
+
+### #17 ParamStore: ack/error mapping
+* Milestone: v1.0
+* References: [03] §6, [04] §2
+* Implementation targets: `include/sitos/status.hpp`, `src/param_store.cpp`,
+  `tests/integration/param_store_ack_test.cpp`
+* Scope: PutOptions::ack, ack timeout/retry, detailed Status mapping
+* Acceptance criteria: integration tests — ack success/failure/timeout, Disconnected/Timeout when StorageNode is stopped
+* Depends on: #14, #15
+
+---
+
+## M3: ParamCache and SessionView
+
+### #18 ParamCache: initial fetch + delta subscription
+* Milestone: v0.2
+* References: [02] §5, [04] §4
+* Implementation targets: `include/sitos/param_cache.hpp`, `src/param_cache.cpp`,
+  `tests/integration/param_cache_attach_test.cpp`
+* Scope: Attach(sid)/AttachBase/Detach, loss-prevention sequence (a)→(b)→(c),
+  shared_ptr-based cache, delta application
+* Acceptance criteria: integration tests — final state is correct even with a concurrent put during Attach
+  (race reproduction test), batch apply, subscription stops after Detach
+* Depends on: #5, #12, #13
+
+### #19 ParamCache: zero-copy reads and performance
+* Milestone: v0.2
+* References: [04] §4, [01] N01
+* Implementation targets: `include/sitos/param_cache.hpp`, `src/param_cache.cpp`,
+  `tests/unit/param_cache_read_test.cpp`, `tests/bench/cache_get_bench.cpp`
+* Scope: GetShared/Get/GetOr/GetSpan (SpanHandle), List, bench harness
+* Acceptance criteria: bench — Get is in the target order (including confirmation of no interprocess communication).
+  The old buffer remains valid even if the value is updated while holding SpanHandle (verified with ASan)
+* Depends on: #18
+
+### #20 Disconnect/reconnect recovery
+* Milestone: v1.0
+* References: [02] §9, [01] N10
+* Implementation targets: `src/param_cache.cpp`,
+  `tests/integration/reconnect_test.cpp`
+* Scope: stale flag, zenoh reconnect detection, automatic refetch
+* Acceptance criteria: integration — ParamCache recovers across StorageNode restart
+* Depends on: #18
+
+### #21 SessionView (host-process facade)
+* Milestone: v0.2
+* References: [04] §5
+* Implementation targets: `include/sitos/session_view.hpp`, `src/session_view.cpp`,
+  `tests/unit/session_view_test.cpp`
+* Scope: in-process resolving read from overlay → snapshot, Put delivery
+* Acceptance criteria: unit + integration — resolution order, consistency with direct engine reference
+* Depends on: #12
+
+---
+
+## M4: Python bindings
+
+### #22 nanobind module skeleton and wheel build
+* Milestone: v0.3
+* References: [05], [06] §3
+* Implementation targets: `python/pyproject.toml`, `python/bindings/module.cpp`,
+  `python/sitos/__init__.py`, `tests/python/test_import.py`
+* Scope: `_sitos` module, scikit-build-core, cibuildwheel configuration,
+  ParamValue ↔ Python type conversion
+* Acceptance criteria: `pip install dist/*.whl && python -c "import sitos"` on both OSes.
+  pytest for type conversion (shared golden fixtures)
+* Depends on: #4 (can proceed in parallel; preferably after #15/#18 APIs settle)
+
+### #23 Python ParamStore
+* Milestone: v0.3
+* References: [05] §2.1
+* Implementation targets: `python/bindings/param_store.cpp`, `python/sitos/store.py`,
+  `tests/python/test_param_store.py`
+* Scope: Python binding for ParamStore, context manager, exception mapping
+* Acceptance criteria: pytest — Put/Get/List/Delete/Subscribe round-trip
+* Depends on: #15, #16, #22
+
+### #24 Python ParamCache
+* Milestone: v0.3
+* References: [05] §2.2
+* Implementation targets: `python/bindings/param_cache.cpp`, `python/sitos/cache.py`,
+  `tests/python/test_param_cache.py`
+* Scope: Python binding for ParamCache, attach/detach, stale, items
+* Acceptance criteria: pytest — attach/delta-subscription scenarios equivalent to C++ ParamCache
+* Depends on: #18, #22
+
+### #25 Python StorageNode / SessionView
+* Milestone: v0.3
+* References: [05] §2.3–2.4
+* Implementation targets: `python/bindings/storage_node.cpp`, `python/bindings/session_view.cpp`,
+  `python/sitos/node.py`, `tests/python/test_storage_node.py`
+* Scope: Python bindings for StorageNode, InMemoryEngine, SessionView
+* Acceptance criteria: pytest — create_session/close_session, session_view overlay→snapshot resolution
+* Depends on: #12, #21, #22
+
+### #26 Python callback / GIL dispatch
+* Milestone: v1.0
+* References: [05] §3
+* Implementation targets: `python/bindings/callback_dispatcher.cpp`,
+  `tests/python/test_callbacks.py`
+* Scope: Python callback dispatch thread, acquire GIL, log exceptions
+* Acceptance criteria: pytest — concurrent get inside callback does not deadlock
+* Depends on: #23, #24
+
+### #27 NumPy zero-copy and type stubs
+* Milestone: v0.3
+* References: [05] §1–2, §4
+* Implementation targets: `python/bindings/numpy.cpp`, `python/sitos/py.typed`,
+  `python/sitos/*.pyi`, `tests/python/test_numpy_zero_copy.py`
+* Scope: `get_array(dtype)` (buffer protocol, writeable=False, keepalive),
+  ndarray put, `.pyi` stubs
+* Acceptance criteria: pytest — verify base-buffer identity (no copy), mypy green
+* Depends on: #24
+
+### #28 Python custom engine
+* Milestone: v1.0
+* References: [05] §2.3, [01] X01
+* Implementation targets: `python/bindings/storage_engine_trampoline.cpp`,
+  `tests/python/test_custom_engine.py`
+* Scope: Support Python inheritance of `sitos.StorageEngine` (trampoline)
+* Acceptance criteria: Python engine passes the contract tests (pytest version)
+* Depends on: #25
+
+---
+
+## M5: Interoperability, documentation, and release
+
+### #29 zenoh-python single-value interoperability test
+* Milestone: v0.4
+* References: [03], [01] C03, [06] §4
+* Implementation targets: `tests/interop/test_raw_zenoh_single.py`
+* Scope: Interop test that put/get/subscribe single values using only zenoh-python + struct,
+  without using the sitos library
+* Acceptance criteria: Test written only from the wire specification is green
+* Depends on: #11, #12
+
+### #30 zenoh-python batch/ack interoperability test
+* Milestone: v1.0
+* References: [03] §5–6, [01] C03, [06] §4
+* Implementation targets: `tests/interop/test_raw_zenoh_batch_ack.py`
+* Scope: Verify `$batch` and ack using only zenoh-python + struct
+* Acceptance criteria: batch/ack test written only from the wire specification is green
+* Depends on: #13, #14
+
+### #31 C++ examples and demo binary sitobolon
+* Milestone: v0.4
+* References: [00] §4, [06] §1
+* Implementation targets: `examples/cpp/quickstart.cpp`, `examples/cpp/sitobolon.cpp`,
+  `examples/cpp/CMakeLists.txt`
+* Scope: C++ quickstart, standalone StorageNode executable
+  `sitobolon` (engine selected by config file)
+* Acceptance criteria: C++ examples are built and run in CI
+* Depends on: #15, #18
+
+### #32 Python examples
+* Milestone: v0.4
+* References: [05], [06] §1
+* Implementation targets: `examples/python/quickstart.py`, `examples/python/numpy_lut.py`,
+  `examples/python/raw_zenoh.py`
+* Scope: Python quickstart, NumPy LUT sample, zenoh-python raw interop sample
+* Acceptance criteria: Python examples are run in CI
+* Depends on: #23, #24, #27, #29
+
+### #33 Benchmark CI and performance requirement verification
+* Milestone: v0.4
+* References: [01] N01–N02, N08–N09, [06] §4–5
+* Implementation targets: `tests/bench/*.cpp`, `.github/workflows/bench.yml`
+* Scope: bench workflow, baseline management, N08/N09 measurement scenarios
+* Acceptance criteria: nightly bench runs and produces comparison reports against requirement values
+* Depends on: #8, #18, #19
+
+### #34 Documentation site
+* Milestone: v1.0
+* References: [06] §5, §7
+* Implementation targets: `docs/`, `Doxyfile`, `docs/conf.py`, `.github/workflows/docs.yml`
+* Scope: Doxygen/Sphinx, completed README, CONTRIBUTING, docs.yml
+* Acceptance criteria: docs.yml green. Public documents do not reference private documents
+* Depends on: #1
+
+### #35 Release / publication readiness
+* Milestone: v1.0
+* References: [06] §7
+* Implementation targets: `NOTICE`, `.github/workflows/wheels.yml`,
+  `.github/release-please-config.json`, `pyproject.toml`
+* Scope: NOTICE, complete the pre-publication checklist, reserve PyPI/crates names, release-please
+* Acceptance criteria: All checklist items completed, dry-run publish to TestPyPI succeeds
+* Depends on: M4 completed, #34
+
+---
+
+## Recommended implementation order (parallel lanes)
+
+```
+Lane A (core):      #1 → #4 → #6 → #7 → #8
+Lane B (zenoh):     #2 → #3 → #9 → #10 → #11 → #12 → #18 → #19/#20
+                                            └→ #13 → #15/#16
+                                                #14 → #17
+Lane C (Python):    #22 (any time after #4) → #23/#24/#25 → #26 → #27/#28
+Lane D (quality):   #29/#30, #31/#32, #33, #34/#35 (as dependencies complete)
+```
+
+Each Issue is assumed to correspond to one PR. The PR must describe the corresponding requirement IDs
+and the AC verification results.
+
+Legacy API compatibility layers and migration work for specific products are proprietary-side work,
+so they are not included in this Issue list.
+
+(END OF DOCUMENT)

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -1,0 +1,149 @@
+# sitos — Dependency / Zenoh Compatibility Policy
+
+## 1. Basic policy
+
+sitos **owns its wire specification and thinly isolates zenoh as a transport dependency**.
+
+* The compatibility units for sitos are the `sitos.v1` payload, key space, and batch/ack protocols,
+  not zenoh internal APIs
+* The scope affected by zenoh version upgrades is limited to `src/transport/zenoh_transport.cpp`
+  and CI configuration
+* The semantics of `ParamValue` / `StorageEngine` / `StorageNode` / `ParamStore` / `ParamCache`
+  do not change when the zenoh version changes
+
+## 2. Supported versions
+
+Initial policy:
+
+```
+zenoh >= 1.0, < 2.0
+```
+
+* sitos v1.x supports the zenoh 1.x series
+* If zenoh 2.x support breaks wire/API compatibility, treat it as sitos v2.0
+* After validation by `dependency-upgrade.yml`, zenoh patch/minor updates are incorporated into
+  sitos patch/minor releases
+
+## 3. Transport adapter
+
+Only the transport adapter uses the zenoh-cpp API directly.
+Higher-level components see only the following abstract API.
+
+```cpp
+namespace sitos {
+
+struct TransportSample {
+    std::string key;
+    std::span<const std::byte> payload;
+    Encoding encoding;
+    std::optional<std::string> ack_token;
+    enum class Kind { Put, Delete } kind;
+};
+
+struct TransportQuery {
+    std::string keyexpr;
+    void Reply(std::string_view key,
+               std::span<const std::byte> payload,
+               Encoding encoding);
+};
+
+class Transport {
+public:
+    virtual ~Transport() = default;
+
+    virtual Result<void> Put(std::string_view key,
+                             std::span<const std::byte> payload,
+                             Encoding encoding,
+                             PutOptions options) = 0;
+    virtual Result<void> Delete(std::string_view key, PutOptions options) = 0;
+
+    using QueryResultSink =
+        std::function<bool(std::string_view key,
+                           std::span<const std::byte> payload,
+                           Encoding encoding)>;
+    virtual Result<void> Get(std::string_view keyexpr,
+                             const QueryResultSink& sink,
+                             std::chrono::milliseconds timeout) = 0;
+
+    virtual Subscription DeclareSubscriber(
+        std::string_view keyexpr,
+        std::function<void(const TransportSample&)> callback) = 0;
+
+    virtual Queryable DeclareQueryable(
+        std::string_view keyexpr,
+        std::function<void(TransportQuery&)> callback) = 0;
+};
+
+} // namespace sitos
+```
+
+This abstraction is limited to **only the zenoh features that sitos needs**:
+
+| Feature | Purpose |
+|---|---|
+| put/delete | Writes to base/session |
+| get/queryable/reply | Reads, List, snapshot exposure, ack confirmation |
+| subscriber | Delta delivery, ParamCache updates |
+| Encoding | Identification of `sitos.v1` / `sitos.v1.batch` |
+| attachment | ack token (treated as ack-less put in unsupported environments) |
+
+Do not depend directly on advanced APIs, unstable APIs, routing policies, and similar features.
+
+## 4. CI policy
+
+### 4.1 Normal CI
+
+`ci.yml` runs with the locked default zenoh version.
+This version is fixed per release branch.
+
+### 4.2 dependency-upgrade CI
+
+`dependency-upgrade.yml` runs the following on nightly / manual triggers:
+
+1. **minimum supported**: the minimum version in the supported range
+2. **latest stable**: the latest stable release at execution time
+
+Validation targets:
+
+* C++ build
+* unit / integration / interop
+* wire fixtures (`PayloadV1GoldenFixtures`, `BatchV1GoldenFixture`)
+* `RawZenohClientCanPutAndGet`
+* `RawZenohClientCanSendBatch`
+
+If latest stable fails:
+
+* Do not break the main branch (keep using the locked version)
+* Create an Issue labeled `dependency: zenoh-upgrade` automatically or manually
+* In principle, limit fixes to `src/transport/zenoh_transport.cpp` and build/CI configuration
+
+## 5. Update procedure
+
+1. Check the zenoh release notes and evaluate whether breaking changes affect the transport adapter
+2. Run `dependency-upgrade.yml` manually
+3. If failures can be absorbed inside the transport adapter:
+   - fix the adapter
+   - confirm CI green for both minimum/latest
+   - update the locked version
+   - make a sitos patch/minor release
+4. If wire/API compatibility is affected:
+   - create an ADR for sitos v2
+   - design the `sitos.v2` schema and v1/v2 dual support during the migration period
+
+## 6. Invariants that preserve compatibility
+
+The following must not change after zenoh updates:
+
+* Byte sequences of the `sitos.v1` payload fixtures
+* key paths (`base`, `session`, `snap`, `$batch`, `meta`)
+* The loss-prevention sequence of `ParamCache::Attach`
+* Snapshot isolation semantics
+* Python API exception mapping
+
+## 7. RocksDB / Python dependencies
+
+As with zenoh, monitor RocksDB and Python packaging with locked versions + latest CI.
+However, RocksDB is optional (`sitos-rocksdb`) and must not impair availability of the standard
+wheel.
+
+(END OF DOCUMENT)

--- a/docs/10_adr_process.md
+++ b/docs/10_adr_process.md
@@ -1,0 +1,147 @@
+# sitos — ADR Process
+
+Rules for writing and operating ADRs (Architecture Decision Records) in the
+sitos repository. Public document. In issue #1, this will be moved as
+`docs/adr/README.md`.
+
+## 1. Purpose
+
+* Make it possible for future contributors (both humans and AI) to trace “why
+  this design was chosen”
+* Prevent rehashing discussions (record rejected options and the reasons)
+* Serve as the source of truth for instructions to implementation AI
+
+## 2. Placement and Naming
+
+```
+docs/adr/
+  README.md                     # These rules (English)
+  template.md                   # Template (§5)
+  0001-use-zenoh-as-transport.md
+  0002-embedded-storage-node.md
+  ...
+```
+
+* File name: `NNNN-short-kebab-case-title.md` (4-digit zero-padded sequential number)
+* Gaps in numbers are allowed (rejected proposals also consume numbers)
+* One decision per file. Do not mix multiple independent decisions into one ADR
+
+## 3. Format: MADR-lite
+
+Use the following six-section structure, a simplified form of
+[MADR](https://adr.github.io/madr/).
+
+| Section | Required | Contents |
+|---|---|---|
+| Status | ✔ | Status from §4 + decision date |
+| Context | ✔ | Background and constraints that made the decision necessary. 3–10 lines |
+| Decision | ✔ | Decision content. 1–3 sentences in the active form “We will ...” |
+| Consequences | ✔ | Positive effects, negative effects, and accepted trade-offs |
+| Options Considered | Recommended | Alternatives considered and reasons for rejection (1–3 lines each) |
+| References | Optional | Related issues/PRs, external materials, related ADRs |
+
+## 4. Status Transitions
+
+```
+Proposed ──► Accepted ──► Deprecated
+                │              ▲
+                └── Superseded by ADR-NNNN
+Proposed ──► Rejected
+```
+
+* **Proposed**: Proposed in a PR
+* **Accepted**: Merged = an effective decision
+* **Rejected**: Rejected (kept as a record)
+* **Superseded by ADR-NNNN**: Replaced by a new ADR. Do not edit the old ADR;
+  update only the Status line (history must not be rewritten)
+* **Deprecated**: The target feature itself has been discontinued
+
+**Invariant**: Do not rewrite the Context/Decision/Consequences of an ADR after
+it becomes Accepted. If you want to change the decision, file a new ADR.
+Only typo fixes and broken-link fixes are allowed.
+
+## 5. Template
+
+```markdown
+# ADR-NNNN: <Title in imperative form>
+
+## Status
+
+Accepted — 2026-07-07
+
+## Context
+
+<Why is this decision needed? What constraints apply?>
+
+## Decision
+
+We will <decision>.
+
+## Consequences
+
+* Good: <positive outcomes>
+* Bad: <negative outcomes / accepted trade-offs>
+* Neutral: <side effects worth noting>
+
+## Options Considered
+
+* **<Option A>** — rejected because <reason>
+* **<Option B>** — rejected because <reason>
+
+## References
+
+* Issue #NN / PR #NN
+* Related: ADR-NNNN
+```
+
+## 6. When to Write an ADR
+
+An ADR is required for changes that fall under any of the following:
+
+* Breaking changes to the public API, or changes to the wire protocol (`sitos.v1*`)
+* Addition, removal, or major update of dependency libraries (zenoh, RocksDB,
+  nanobind, etc.)
+* Changes touching the invariants in [09_dependency_policy.md](09_dependency_policy.md) §6
+* Changes to the thread model, consistency model, or snapshot semantics
+* Changes to the build system or supported platforms
+
+ADRs are not needed for implementation details that do not fall under these
+categories (internal refactoring, bug fixes, performance improvements).
+When in doubt, discuss “whether an ADR is needed” in PR review using the
+`needs-adr` label.
+
+## 7. Review Flow
+
+1. Create the ADR as `Proposed` and submit it as a **separate PR** from the
+   implementation PR
+   (small decisions may be bundled with the implementation PR. In that case,
+   include `[ADR]` in the PR title)
+2. Conduct review and discussion on the PR (the discussion record remains in the PR)
+3. At merge time, update Status to `Accepted` + decision date
+4. When implementation AI performs work, always include related ADRs in the
+   prompt context
+
+## 8. Initial ADR Set
+
+At repository creation (issue #1), file D1 through D13 from
+[00_overview.md](00_overview.md) §6 as the following individual ADRs in English
+(Status: Accepted). After that, maintain the table in 00_overview §6 as an
+index to the ADRs.
+
+| ADR | Origin | Proposed title |
+|---|---|---|
+| 0001 | D1 | Use zenoh as the transport layer |
+| 0002 | D2 | Implement an embedded storage node instead of zenoh storage-manager |
+| 0003 | D3 | Ship InMemory and RocksDB engines; do not adopt LevelDB |
+| 0004 | D4 | Expose engine-native snapshots through the zenoh key space |
+| 0005 | D5 | Name the project sitos |
+| 0006 | D6 | C++20 core with Python bindings |
+| 0007 | D7 | Adopt legacy-compatible payload v1 with Encoding-based versioning |
+| 0008 | D8 | License under Apache-2.0 |
+| 0009 | D9 | English as the repository language |
+| 0010 | D10 | Use nanobind for Python bindings |
+| 0011 | D11 | Develop in public from day one |
+| 0012 | D12 | Google C++ style with 100-column limit |
+| 0013 | D13 | Default to zenoh scouting with explicit endpoint override |
+
+(END OF DOCUMENT)

--- a/docs/development_workflow.md
+++ b/docs/development_workflow.md
@@ -1,0 +1,163 @@
+# sitos — Development Workflow
+
+Operation rules for the branching strategy, ticket-driven development (TiDD),
+and test-driven development (TDD). Public document. This is the English edition
+maintained as `docs/development_workflow.md` (or CONTRIBUTING.md).
+
+Because implementation is assumed to be performed by AI coding agents,
+**everything is stated explicitly instead of relying on implicit conventions**.
+
+## 1. Branching Strategy: trunk-based
+
+```
+main ─────●───────●───────●──────●──► (always releasable)
+           \     /  \     /
+            issue/3-param-value
+                     issue/6-in-memory-engine
+```
+
+* **main is always green** (required CI paths). Direct pushes are prohibited;
+  changes go only through PRs
+* Working branches are **short-lived** (guideline: 1 issue = 1 branch = 1 PR,
+  within a few days)
+* Branch name: `issue/<number>-<short-kebab-description>`
+  (example: `issue/3-param-value-codec`)
+* Releases are tags on main (`v0.1.0`, etc.). Do not create release branches
+  until a hotfix is needed
+* Do not create long-lived develop / feature branches
+  (GitFlow is excessive for this project’s scale and team structure)
+
+## 2. Ticket-Driven Development (TiDD)
+
+**No Ticket, No Commit.** Every change starts from a GitHub Issue.
+
+1. Before starting work, confirm that an issue exists
+   (#1 through #23b in [07_issue_breakdown.md](07_issue_breakdown.md) are the initial set)
+2. Include the issue number in the branch name and PR. Write `Closes #NN` in
+   the PR body
+3. Do not mix changes outside the issue scope into the PR.
+   For problems found during work, **file a new issue** and handle them there
+   (drive-by fixes are prohibited. However, trivial fixes such as typos may be
+   allowed at the reviewer’s discretion)
+4. Commit messages follow Conventional Commits + issue references (§2.1)
+
+### 2.1 Commit Message Convention
+
+**Structure**: line 1 = Conventional Commits header, line 2 = blank line,
+line 3 onward = bullet-list body.
+
+```
+<type>(<scope>): <summary> (#<issue>)
+
+- <change 1: what and why>
+- <change 2>
+- <additional notes if any (trade-offs, follow-up issues, etc.)>
+```
+
+Examples:
+
+```
+feat(codec): implement payload v1 encoder (#4)
+
+- Add ParamValue::Encode() producing type-tag + LE byte layout
+- Verify against golden fixtures in tests/fixtures/payload_v1/
+- Reject payloads shorter than 1 byte with Status::Error
+
+fix(cache): prevent missed puts during attach (#18)
+
+- Buffer subscriber samples until initial fetch completes
+- Add race-reproduction test AttachDoesNotMissConcurrentPut
+```
+
+Rules:
+
+* **Header (line 1)**
+  - type: `feat` / `fix` / `docs` / `test` / `refactor` / `build` / `ci` / `chore`
+  - scope: component name (codec, engine, node, store, cache, transport,
+    python, adr, ...). May be omitted if none applies
+  - summary: English, imperative mood, starts with lowercase, no trailing period,
+    within 72 characters. Append issue number `(#N)` to the end of the header
+* **Body (line 3 onward)**
+  - Write only bullet-list items beginning with `- ` (do not write prose paragraphs)
+  - Each item includes “what changed” and, if non-obvious, “why”
+  - One change per item. The body may be omitted for trivial commits (typos, etc.)
+* **Footer (optional)**: For breaking changes, write
+  `BREAKING CHANGE: <description>` after the body (release-please uses this for
+  major version bumps)
+
+### Issue Requirements (for AI Implementers)
+
+Each issue must include at minimum the following (following the format in [07]):
+
+* Reference documents (applicable sections of the design documents)
+* Target implementation files
+* Acceptance criteria (AC) — in a verifiable form
+* Dependent issues
+
+## 3. Test-Driven Development (TDD): Red-Green-Refactor
+
+This project has predefined AC, required test names ([06] §4.1), and golden
+fixtures ([03] §2.3), making it particularly compatible with TDD.
+
+**Implementation steps for each issue (required):**
+
+```
+1. RED    — Write tests corresponding to the AC first and confirm that they fail
+            (for items with golden fixtures, start with fixture verification tests)
+2. GREEN  — Write the minimum implementation that makes the tests pass
+3. REFACTOR — Improve the design while keeping the tests green
+            (naming, duplicate removal, compliance with the style in [06] §2)
+```
+
+Rules:
+
+* **Do not commit production code without tests**
+  (exceptions: build settings, docs, examples)
+* Record in the PR description that the RED-phase tests “failed correctly”
+  (AI implementers must paste the “failure message during Red” into the PR body —
+  if the test passes from the beginning, that is a sign that the test itself is wrong)
+* Use the fixed AC test names from [06] §4.1. Additional tests are unrestricted
+* Do not change the meaning of tests during refactoring (weakening assertions is prohibited)
+* For bug fixes, **write a reproduction test first** (RED) → fix (GREEN)
+
+## 4. PR Rules
+
+* 1 PR = 1 issue. Keep diffs small (guideline: 500 lines or less for
+  implementation + tests. If larger, consider splitting the issue)
+* Required items in the PR template:
+  - `Closes #NN`
+  - Corresponding requirement IDs ([01] F/N/C/P/X)
+  - AC verification results (test execution logs)
+  - RED-phase failure confirmation (§3)
+  - Judgment on whether an ADR is needed (whether [10] §6 applies)
+* CI (build + all tests + clang-format + clang-tidy) must be green
+* Merge to main by squash merge (keep history grouped by issue)
+
+## 5. Instruction Template for AI Implementers
+
+Prompt structure when assigning an issue to implementation AI:
+
+```
+1. Full text of the target issue (reference documents, implementation targets, AC, dependencies)
+2. Applicable sections of reference documents (entire sections)
+3. Related ADRs
+4. Instruction to comply with this workflow (§1–§4)
+5. “First write the AC tests and confirm RED before implementing”
+6. “Copy the issue checklist into the PR body and submit it with completed
+   items checked”
+```
+
+The checklist in the issue body is the **definitive definition of scope** and,
+as a rule, is not changed after issue filing. Progress is visualized using the
+checklist in the PR body, and reviewers compare the PR check state with the
+implementation artifacts. The issue is closed by `Closes #NN` when the PR is
+merged (checkboxes on the issue side may remain unchecked when closed).
+
+## 6. Release Flow
+
+1. All required issues for the release boundary (the table at the beginning of
+   [07]) are closed
+2. release-please generates the CHANGELOG and version PR from Conventional Commits
+3. Merge the version PR → tag → `wheels.yml` publishes to PyPI
+
+(END OF DOCUMENT)


### PR DESCRIPTION
Closes #36

## Summary

Imports the English design document set into `docs/`, making every `docs/...`
path referenced by issues #1–#35 resolve in-repo.

## Checklist (from #36)

- [x] Translate and import: 00_overview, 01_requirements, 02_architecture,
      03_wire_protocol, 04_api_cpp, 05_api_python, 06_build_test_packaging,
      07_issue_breakdown, 09_dependency_policy, 10_adr_process
- [x] Import 11_development_workflow as `docs/development_workflow.md`
      (the path referenced by all implementation issues)
- [x] All content in English; no internal keywords; links between documents
      remain valid

## Verification

- Inline hex fixtures and the batch fixture block in `03_wire_protocol.md`
  compared byte-for-byte against the source: identical (11/11 sequences)
- All 27 inter-document links resolve
- Internal-keyword scan: clean
- Japanese-character scan: clean (single intentional exception: the UTF-8
  test fixture string in `03_wire_protocol.md` §2.3)

## Notes

- ADR requirement check: no new design decisions introduced — translation only
- `docs/adr/README.md` will be derived from `docs/10_adr_process.md` in #1
