### PR TITLE
feat(build): add repository skeleton and CI (#1)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Google
+ColumnLimit: 100

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{cpp,hpp,h,c,cmake,txt}]
+indent_style = space
+indent_size = 2
+
+[*.{py,pyi,toml,yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,38 @@
+# Combined from the following gitattributes/gitattributes templates:
+# - Common: https://github.com/gitattributes/gitattributes/blob/master/.gitattributes
+# - C++: https://github.com/gitattributes/gitattributes/blob/master/C%2B%2B.gitattributes
+# - CMake: https://github.com/gitattributes/gitattributes/blob/master/CMake.gitattributes
+# - Python: https://github.com/gitattributes/gitattributes/blob/master/Python.gitattributes
+
+# Auto detect text files and perform LF normalization
+* text=auto eol=lf
+
+# Source code
+*.c text
+*.cc text
+*.cxx text
+*.cpp text
+*.h text
+*.hpp text
+*.py text
+*.cmake text
+CMakeLists.txt text
+
+# Scripts
+*.sh text eol=lf
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Documentation
+*.md text
+*.txt text
+
+# Configs
+*.yml text
+*.yaml text
+*.json text
+*.toml text
+*.ini text
+
+# Denote files that should not be modified
+*.patch -text

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+Closes #
+
+## Requirements
+
+Reference requirement IDs from docs/01_requirements.md (F/N/C/P/X):
+
+## Acceptance Criteria Verification
+
+Paste test execution logs:
+
+## RED-phase Confirmation
+
+Paste the failure output from the initial RED tests:
+
+## ADR Needed?
+
+- [ ] No
+- [ ] Yes — ADR PR: #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build
+
+      - name: Configure
+        run: cmake --preset dev-linux
+
+      - name: Build
+        run: cmake --build --preset dev-linux
+
+      - name: Test
+        run: ctest --preset dev-linux
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure
+        run: cmake --preset dev-windows
+
+      - name: Build
+        run: cmake --build --preset dev-windows
+
+      - name: Test
+        run: ctest --preset dev-windows

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,91 @@
+# Combined from the following github/gitignore templates:
+# - C++: https://github.com/github/gitignore/blob/main/C%2B%2B.gitignore
+# - CMake: https://github.com/github/gitignore/blob/main/CMake.gitignore
+# - Python: https://github.com/github/gitignore/blob/main/Python.gitignore
+
+# === C++ ===
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# === CMake ===
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+build/
+out/
+
+# === Python ===
+__pycache__/
+*.py[cod]
+*$py.class
+.Python
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak
+.mypy_cache/
+.dmypy.json
+dmypy.json
+.pytest_cache/
+.ruff_cache/
+
+# === Project-specific ===
+# Private handoff document is kept out of the public repository.
+HANDOFF.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md — AI Implementer Entry Point
+
+This file is the entry point for AI coding agents working on the **sitos**
+project.
+
+## Essential Pointers
+
+- Development workflow: [docs/development_workflow.md](docs/development_workflow.md)
+- Issue breakdown: [docs/07_issue_breakdown.md](docs/07_issue_breakdown.md)
+- Requirements: [docs/01_requirements.md](docs/01_requirements.md)
+- Build / test / packaging: [docs/06_build_test_packaging.md](docs/06_build_test_packaging.md)
+- ADR process: [docs/10_adr_process.md](docs/10_adr_process.md)
+- Dependency policy: [docs/09_dependency_policy.md](docs/09_dependency_policy.md)
+
+## Absolute Rules (Summary)
+
+1. **One issue, one branch, one PR**: branch name
+   `issue/<n>-<short-kebab-description>`, PR body contains `Closes #<n>`.
+2. **TDD**: write the AC tests first and confirm RED before implementation.
+   Record the RED-phase failure output in the PR description.
+3. **Conventional Commits**: header line
+   `<type>(<scope>): <summary> (#<issue>)`; body is `- ` bullet list only.
+4. **English only** in code, comments, commit messages, issues, PRs, and docs.
+5. **No internal keywords**: never commit `xcynthia`, `paramdb`, `demeter`, or
+   similar internal project names to the public repository.
+6. **Transport isolation**: raw zenoh-cpp API is allowed only under
+   `src/transport/`.
+7. **Wire / protocol changes require an ADR**: see
+   [docs/10_adr_process.md](docs/10_adr_process.md) §6.
+
+## Starting a Task
+
+1. Read the full target issue from
+   [docs/07_issue_breakdown.md](docs/07_issue_breakdown.md).
+2. Read the referenced design sections.
+3. Read related ADRs from [docs/adr/](docs/adr/).
+4. Follow the workflow and TDD steps above.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.20)
+project(sitos VERSION 0.1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+include(FetchContent)
+
+# Options
+option(SITOS_WITH_ROCKSDB "Build with RocksDB storage engine support" OFF)
+option(SITOS_BUILD_PYTHON "Build Python bindings" OFF)
+option(SITOS_BUILD_TESTS "Build tests" ON)
+option(SITOS_BUILD_EXAMPLES "Build examples" OFF)
+
+# Warnings as errors
+if(MSVC)
+  add_compile_options(/W4 /WX)
+else()
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+endif()
+
+# Public interface target
+add_library(sitos INTERFACE)
+add_library(sitos::sitos ALIAS sitos)
+target_include_directories(sitos INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+if(SITOS_BUILD_TESTS)
+  enable_testing()
+  add_subdirectory(tests)
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,80 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "dev-linux",
+      "displayName": "Linux development build",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/dev-linux",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "SITOS_BUILD_TESTS": "ON"
+      }
+    },
+    {
+      "name": "dev-windows",
+      "displayName": "Windows development build",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/dev-windows",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "SITOS_BUILD_TESTS": "ON"
+      }
+    },
+    {
+      "name": "release",
+      "displayName": "Release build",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "SITOS_BUILD_TESTS": "OFF"
+      }
+    },
+    {
+      "name": "python-wheel",
+      "displayName": "Python wheel build",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/python-wheel",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "SITOS_BUILD_PYTHON": "ON",
+        "SITOS_BUILD_TESTS": "OFF"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "dev-linux",
+      "configurePreset": "dev-linux"
+    },
+    {
+      "name": "dev-windows",
+      "configurePreset": "dev-windows"
+    },
+    {
+      "name": "release",
+      "configurePreset": "release"
+    },
+    {
+      "name": "python-wheel",
+      "configurePreset": "python-wheel"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "dev-linux",
+      "configurePreset": "dev-linux",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "dev-windows",
+      "configurePreset": "dev-windows",
+      "output": {
+        "outputOnFailure": true
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ See the [design documents](docs/) and the
 [issue tracker](https://github.com/tetsuh/sitos/issues) for the roadmap
 (v0.1 → v1.0 milestones).
 
+## Building
+
+```bash
+# Linux
+cmake --preset dev-linux
+cmake --build --preset dev-linux
+ctest --preset dev-linux
+
+# Windows (Ninja)
+cmake --preset dev-windows
+cmake --build --preset dev-windows
+ctest --preset dev-windows
+```
+
+See [docs/06_build_test_packaging.md](docs/06_build_test_packaging.md) for
+full build options.
+
 ## License
 
 Apache-2.0

--- a/docs/adr/0001-use-zenoh-as-the-transport-layer.md
+++ b/docs/adr/0001-use-zenoh-as-the-transport-layer.md
@@ -1,0 +1,39 @@
+# ADR-0001: Use zenoh as the transport layer
+
+## Status
+
+Accepted — 2026-07-07
+
+## Context
+
+sitos needs a communication layer that can distribute typed parameters and
+lookup tables to multiple compute processes. The legacy system used a custom
+synchronization protocol over ZeroMQ and required significant maintenance.
+A replacement must provide publish/subscribe, request/reply, and distributed
+storage semantics without custom low-level networking code.
+
+## Decision
+
+We will use Eclipse zenoh as the transport layer for sitos.
+
+## Consequences
+
+* Good: zenoh unifies pub/sub, queries, and storage semantics in one protocol.
+* Good: Existing zenoh clients in any language can interoperate with sitos
+  without a sitos-specific library.
+* Good: Routing, discovery, and reliability are handled by the zenoh project.
+* Neutral: The project must track zenoh release cadence and API changes.
+
+## Options Considered
+
+* **Custom protocol over ZeroMQ** — rejected because it recreates the
+  synchronization and discovery problems of the legacy system.
+* **MQTT + separate RPC layer** — rejected because it would require stitching
+  together two protocols and does not provide distributed queries natively.
+* **zenoh** — selected because it combines pub/sub, query, and storage-like
+  access patterns in a single, actively maintained open-source project.
+
+## References
+
+* Issue #1
+* Related: ADR-0002, ADR-0013

--- a/docs/adr/0002-implement-an-embedded-storage-node.md
+++ b/docs/adr/0002-implement-an-embedded-storage-node.md
@@ -1,0 +1,38 @@
+# ADR-0002: Implement an embedded storage node instead of zenoh storage-manager
+
+## Status
+
+Accepted — 2026-07-07
+
+## Context
+
+zenoh provides a storage-manager plugin that can persist keys. However, sitos
+requires fine-grained control over storage engines and, crucially, the ability
+to expose engine-native snapshots (for example, RocksDB snapshots) to readers
+without copying data. The storage-manager trait does not expose this capability.
+
+## Decision
+
+We will implement our own StorageNode in C++ instead of relying on the zenoh
+storage-manager plugin.
+
+## Consequences
+
+* Good: Storage engines can expose native snapshots directly to queryables.
+* Good: New storage engines can be added without writing Rust plugins.
+* Good: Snapshot semantics are under sitos control and remain O(1).
+* Bad: We are responsible for persistence, replication, and recovery logic
+  that the storage-manager would otherwise provide.
+
+## Options Considered
+
+* **zenoh storage-manager plugin** — rejected because the storage trait does
+  not expose engine snapshots, and adding new engines would require Rust plugin
+  development.
+* **Embedded StorageNode in C++** — selected because it keeps engine abstraction
+  and snapshot semantics entirely within the sitos codebase.
+
+## References
+
+* Issue #1
+* Related: ADR-0001, ADR-0004

--- a/docs/adr/0003-ship-in-memory-and-rocksdb-engines.md
+++ b/docs/adr/0003-ship-in-memory-and-rocksdb-engines.md
@@ -1,0 +1,41 @@
+# ADR-0003: Ship InMemory and RocksDB engines; do not adopt LevelDB
+
+## Status
+
+Accepted — 2026-07-07
+
+## Context
+
+sitos needs at least one zero-dependency storage engine for ease of use and
+one persistent engine for production deployments. The legacy system used
+LevelDB, which has become effectively frozen upstream (stagnant since v1.23
+in 2024) and is therefore a poor long-term dependency for a public OSS
+project.
+
+## Decision
+
+We will ship an InMemory engine as the default and a RocksDB engine as an
+opt-in component. We will not adopt LevelDB.
+
+## Consequences
+
+* Good: InMemory requires no external dependencies, simplifying development
+  and testing.
+* Good: RocksDB is actively maintained and widely packaged.
+* Good: Avoiding LevelDB removes a dependency with an uncertain future.
+* Neutral: Existing LevelDB-based data must be migrated through an external
+  adapter rather than by sitos itself.
+
+## Options Considered
+
+* **LevelDB** — rejected because upstream development has stalled and it is
+  unsuitable as a bundled dependency for public OSS.
+* **RocksDB** — selected for persistence because it is actively maintained and
+  license-compatible.
+* **InMemory** — selected as the default because it has zero dependencies and
+  covers testing and lightweight deployments.
+
+## References
+
+* Issue #1
+* Related: ADR-0002

--- a/docs/adr/0004-expose-engine-native-snapshots.md
+++ b/docs/adr/0004-expose-engine-native-snapshots.md
@@ -1,0 +1,38 @@
+# ADR-0004: Expose engine-native snapshots through the zenoh key space
+
+## Status
+
+Accepted — 2026-07-07
+
+## Context
+
+Compute pipelines must see a consistent point-in-time view of parameters for
+the duration of a session, even when external writers are updating values.
+The legacy system achieved this with LevelDB snapshots. sitos must preserve
+the same semantics while operating over zenoh.
+
+## Decision
+
+We will expose engine-native snapshots through the zenoh key space using
+queryables. Each session snapshot is created in O(1) and read in-process
+without copying the underlying data.
+
+## Consequences
+
+* Good: Session semantics remain consistent with the legacy system.
+* Good: Snapshots are cheap to create and do not block writers.
+* Good: External zenoh clients can inspect historical snapshots through the
+  queryable interface.
+* Bad: Snapshot lifecycle and cleanup must be managed by sitos.
+
+## Options Considered
+
+* **Copy-on-read snapshots** — rejected because it reintroduces copies on the
+  hot path and conflicts with the zero-copy goal.
+* **Engine-native snapshots exposed via queryables** — selected because it is
+  O(1), copy-free, and inspectable from zenoh.
+
+## References
+
+* Issue #1
+* Related: ADR-0002, ADR-0003

--- a/docs/adr/0005-name-the-project-sitos.md
+++ b/docs/adr/0005-name-the-project-sitos.md
@@ -1,0 +1,35 @@
+# ADR-0005: Name the project sitos
+
+## Status
+
+Accepted — 2026-07-07
+
+## Context
+
+The project needed a public name that is short, distinctive, and free of
+internal project references. The name must also be available in major package
+registries such as PyPI.
+
+## Decision
+
+We will name the project **sitos** (from the Greek σῖτος, meaning grain or
+food). The demo storage-node binary will be named **sitobolon** (σιτοβολών,
+granary).
+
+## Consequences
+
+* Good: The name is distinctive and unused in major registries at decision time.
+* Good: It avoids any internal keywords that must not appear in the public
+  repository.
+* Neutral: Pronunciation and spelling may require explanation for some users.
+
+## Options Considered
+
+* **Names derived from internal projects** — rejected because internal keywords
+  must not appear in the public repository.
+* **sitos** — selected because it is short, available, and symbolizes
+  "provisioning food for distributed computation."
+
+## References
+
+* Issue #1

--- a/docs/adr/0006-cpp20-core-with-python-bindings.md
+++ b/docs/adr/0006-cpp20-core-with-python-bindings.md
@@ -1,0 +1,36 @@
+# ADR-0006: C++20 core with Python bindings
+
+## Status
+
+Accepted — 2026-07-07
+
+## Context
+
+sitos needs a high-performance core with zero-copy access to parameter values,
+plus an easy-to-install Python interface for compute pipelines. The design
+must avoid heavy legacy dependencies such as Boost and should leverage modern
+standard-library features.
+
+## Decision
+
+We will implement the core in C++20 and provide Python bindings via nanobind.
+
+## Consequences
+
+* Good: C++20 provides `std::span` for zero-copy views without a Boost dependency.
+* Good: nanobind is lightweight and offers good buffer-protocol and GIL control.
+* Good: A single `pip install` can deliver both C++ and Python users.
+* Neutral: Build tooling must support both C++ and Python wheel packaging.
+
+## Options Considered
+
+* **C++17 + pybind11** — rejected because it misses `std::span` and pybind11
+  is heavier than nanobind.
+* **C++20 + Boost** — rejected to avoid the Boost dependency.
+* **C++20 + nanobind** — selected for modern standard-library features and a
+  lightweight binding layer.
+
+## References
+
+* Issue #1
+* Related: ADR-0010

--- a/docs/adr/0007-adopt-legacy-compatible-payload-v1.md
+++ b/docs/adr/0007-adopt-legacy-compatible-payload-v1.md
@@ -1,0 +1,40 @@
+# ADR-0007: Adopt legacy-compatible payload v1 with Encoding-based versioning
+
+## Status
+
+Accepted — 2026-07-07
+
+## Context
+
+sitos must be able to exchange parameter values with existing systems that use
+a specific byte layout (one-byte type tag followed by little-endian data). At
+the same time, the wire format must be versioned so that future formats such
+as CBOR can be introduced without breaking interoperability.
+
+## Decision
+
+We will adopt the legacy-compatible byte layout as payload v1 and register it
+under the zenoh Encoding schema name `sitos.v1`. Future formats will use
+separate schema names.
+
+## Consequences
+
+* Good: Migration from existing systems is straightforward.
+* Good: Encoding-based versioning keeps wire-format selection explicit and
+  extensible.
+* Bad: The v1 format is less compact than some alternatives; future schemas
+  can address this.
+
+## Options Considered
+
+* **CBOR only** — rejected because it would force an immediate migration of
+  existing data producers.
+* **Legacy layout with no versioning** — rejected because it would lock the
+  project into one format forever.
+* **Legacy layout as `sitos.v1` with Encoding-based versioning** — selected for
+  compatibility and future extensibility.
+
+## References
+
+* Issue #1
+* Related: ADR-0001

--- a/docs/adr/0008-license-under-apache-2.0.md
+++ b/docs/adr/0008-license-under-apache-2.0.md
@@ -1,0 +1,35 @@
+# ADR-0008: License under Apache-2.0
+
+## Status
+
+Accepted — 2026-07-07
+
+## Context
+
+sitos is a public OSS project that depends on zenoh (EPL-2.0 / Apache-2.0
+dual-licensed) and may optionally link with RocksDB (Apache-2.0 / GPLv2
+dual-licensed). The chosen license must be compatible with these dependencies
+and permissive enough for both academic and commercial users.
+
+## Decision
+
+We will license sitos under the Apache License, Version 2.0.
+
+## Consequences
+
+* Good: Apache-2.0 is compatible with zenoh's Apache-2.0 option and with
+  RocksDB's Apache-2.0 option.
+* Good: It is a permissive, widely understood license suitable for public OSS.
+* Neutral: Contributors must accept the license terms for submitted patches.
+
+## Options Considered
+
+* **GPLv3** — rejected because it would restrict downstream users and conflict
+  with the goal of broad adoption.
+* **MIT** — rejected because it lacks an explicit patent grant, which Apache-2.0
+  provides.
+* **Apache-2.0** — selected for permissiveness, patent grant, and compatibility.
+
+## References
+
+* Issue #1

--- a/docs/adr/0009-english-as-the-repository-language.md
+++ b/docs/adr/0009-english-as-the-repository-language.md
@@ -1,0 +1,34 @@
+# ADR-0009: English as the repository language
+
+## Status
+
+Accepted — 2026-07-07
+
+## Context
+
+sitos is intended as an international public OSS project. Design documents,
+code, commit messages, issues, and PRs must be accessible to contributors and
+users worldwide.
+
+## Decision
+
+All repository artifacts — code, comments, commit messages, issues, PRs, and
+design documents — will be written in English.
+
+## Consequences
+
+* Good: The project is accessible to the widest possible audience.
+* Good: Translation is not required for participation.
+* Neutral: Internal planning documents may be maintained separately in other
+  languages, but they must not be committed to the public repository.
+
+## Options Considered
+
+* **Bilingual repository** — rejected because it complicates maintenance and
+  searchability.
+* **English only** — selected because it is the standard language for
+  international open-source projects.
+
+## References
+
+* Issue #1

--- a/docs/adr/0010-use-nanobind-for-python-bindings.md
+++ b/docs/adr/0010-use-nanobind-for-python-bindings.md
@@ -1,0 +1,36 @@
+# ADR-0010: Use nanobind for Python bindings
+
+## Status
+
+Accepted — 2026-07-07
+
+## Context
+
+The Python bindings must expose C++ types with minimal overhead, support the
+buffer protocol for NumPy zero-copy views, and allow precise control over the
+GIL to avoid deadlocks when Python callbacks invoke sitos methods.
+
+## Decision
+
+We will use nanobind for the Python bindings.
+
+## Consequences
+
+* Good: nanobind is smaller and faster than pybind11.
+* Good: It supports buffer protocol and explicit GIL release as first-class
+  features.
+* Good: It integrates cleanly with scikit-build-core for wheel builds.
+* Neutral: The team must learn nanobind-specific idioms.
+
+## Options Considered
+
+* **pybind11** — rejected because it is larger and slower, and GIL control is
+  less explicit.
+* **Cython** — rejected because it would require maintaining a separate Cython
+  layer and does not reuse the C++ header definitions as directly.
+* **nanobind** — selected for performance, size, and GIL/buffer control.
+
+## References
+
+* Issue #1
+* Related: ADR-0006

--- a/docs/adr/0011-develop-in-public-from-day-one.md
+++ b/docs/adr/0011-develop-in-public-from-day-one.md
@@ -1,0 +1,35 @@
+# ADR-0011: Develop in public from day one
+
+## Status
+
+Accepted — 2026-07-07
+
+## Context
+
+sitos is a public OSS project. Development history, issues, and design
+discussions will be visible from the first commit. This requires operational
+discipline to prevent internal identifiers, customer data, or proprietary
+context from entering the public repository.
+
+## Decision
+
+We will develop sitos in public from day one. The repository will remain public,
+and all commits, issues, and PRs will be written accordingly.
+
+## Consequences
+
+* Good: Transparency builds community trust.
+* Good: External contributors can follow and participate from the start.
+* Bad: Every change must be reviewed for accidental inclusion of internal
+  keywords or confidential information.
+
+## Options Considered
+
+* **Private development then open-sourcing** — rejected because it would
+  require a costly cleanup of commit history and issues.
+* **Public from day one** — selected because it enforces clean operational
+  discipline from the start.
+
+## References
+
+* Issue #1

--- a/docs/adr/0012-google-cpp-style-with-100-column-limit.md
+++ b/docs/adr/0012-google-cpp-style-with-100-column-limit.md
@@ -1,0 +1,38 @@
+# ADR-0012: Google C++ style with 100-column limit
+
+## Status
+
+Accepted — 2026-07-07
+
+## Context
+
+A consistent code style is essential for a project that will be implemented
+partly by AI coding agents. The style should be well documented, easy to
+enforce with tools, and compatible with the naming conventions already used in
+the design documents.
+
+## Decision
+
+We will use the Google C++ Style Guide as the base, with the column limit set
+to 100 characters. Formatting will be enforced with clang-format.
+
+## Consequences
+
+* Good: Google style is widely known and well supported by clang-format.
+* Good: The design documents already use Google-style naming (PascalCase
+  methods, trailing `_` members, snake_case variables).
+* Good: A 100-column limit balances readability with the need to keep lines
+  short enough for side-by-side review.
+
+## Options Considered
+
+* **LLVM style** — rejected because its naming conventions differ from the
+  design documents.
+* **Google style with 80 columns** — rejected because 80 columns is overly
+  restrictive for modern displays and template-heavy C++ code.
+* **Google style with 100 columns** — selected for compatibility and
+  practicality.
+
+## References
+
+* Issue #1

--- a/docs/adr/0013-default-to-zenoh-scouting-with-explicit-endpoint-override.md
+++ b/docs/adr/0013-default-to-zenoh-scouting-with-explicit-endpoint-override.md
@@ -1,0 +1,36 @@
+# ADR-0013: Default to zenoh scouting with explicit endpoint override
+
+## Status
+
+Accepted — 2026-07-07
+
+## Context
+
+sitos must work out of the box in development environments where multicast is
+available, while also supporting production environments such as medical
+devices where multicast may be prohibited and explicit endpoints are required.
+
+## Decision
+
+By default, sitos will rely on zenoh scouting for peer discovery. Users can
+override this by providing explicit endpoints through the zenoh Config.
+
+## Consequences
+
+* Good: Zero-configuration setup in typical development networks.
+* Good: Works in restricted networks when endpoints are configured.
+* Neutral: Users in restricted environments must supply configuration.
+
+## Options Considered
+
+* **Explicit endpoints only** — rejected because it adds friction to local
+  development and testing.
+* **Scouting only** — rejected because it fails in environments that block
+  multicast.
+* **Scouting default with explicit endpoint override** — selected for a balance
+  between convenience and flexibility.
+
+## References
+
+* Issue #1
+* Related: ADR-0001

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,20 @@
+# Architecture Decision Records (ADRs)
+
+This directory contains the ADRs for sitos.
+See [docs/10_adr_process.md](../10_adr_process.md) for the process.
+
+| ADR | Title |
+|-----|-------|
+| [0001](0001-use-zenoh-as-the-transport-layer.md) | Use zenoh as the transport layer |
+| [0002](0002-implement-an-embedded-storage-node.md) | Implement an embedded storage node instead of zenoh storage-manager |
+| [0003](0003-ship-in-memory-and-rocksdb-engines.md) | Ship InMemory and RocksDB engines; do not adopt LevelDB |
+| [0004](0004-expose-engine-native-snapshots.md) | Expose engine-native snapshots through the zenoh key space |
+| [0005](0005-name-the-project-sitos.md) | Name the project sitos |
+| [0006](0006-cpp20-core-with-python-bindings.md) | C++20 core with Python bindings |
+| [0007](0007-adopt-legacy-compatible-payload-v1.md) | Adopt legacy-compatible payload v1 with Encoding-based versioning |
+| [0008](0008-license-under-apache-2.0.md) | License under Apache-2.0 |
+| [0009](0009-english-as-the-repository-language.md) | English as the repository language |
+| [0010](0010-use-nanobind-for-python-bindings.md) | Use nanobind for Python bindings |
+| [0011](0011-develop-in-public-from-day-one.md) | Develop in public from day one |
+| [0012](0012-google-cpp-style-with-100-column-limit.md) | Google C++ style with 100-column limit |
+| [0013](0013-default-to-zenoh-scouting-with-explicit-endpoint-override.md) | Default to zenoh scouting with explicit endpoint override |

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["scikit-build-core>=0.9", "nanobind>=2.0"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "sitos"
+version = "0.0.1"
+description = "A distributed parameter store for compute pipelines"
+readme = "../README.md"
+license = {text = "Apache-2.0"}
+requires-python = ">=3.10"
+dependencies = [
+  "numpy>=1.24",
+]
+
+[project.urls]
+Homepage = "https://github.com/tetsuh/sitos"
+Repository = "https://github.com/tetsuh/sitos"
+Documentation = "https://github.com/tetsuh/sitos/tree/main/docs"
+
+[tool.scikit-build]
+build-dir = "../build/python-wheel"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,15 @@
+include(FetchContent)
+
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
+  DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+add_executable(sitos_bootstrap_test unit/bootstrap_test.cpp)
+target_link_libraries(sitos_bootstrap_test GTest::gtest_main sitos::sitos)
+
+include(GoogleTest)
+gtest_discover_tests(sitos_bootstrap_test)

--- a/tests/unit/bootstrap_test.cpp
+++ b/tests/unit/bootstrap_test.cpp
@@ -1,0 +1,8 @@
+// Copyright 2026 Tetsuya Hayashi
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+TEST(BootstrapTest, ProjectSkeletonLoads) {
+  EXPECT_TRUE(true);
+}


### PR DESCRIPTION
## Summary

Closes #1

## Requirements

- C01: wire compatibility (future issues)
- N10: session lifecycle (future issues)
- P03: Python wheel build support (scaffolded)
- F05/N02/N03: snapshot semantics (future issues)
- X03: key validation (future issues)

## Acceptance Criteria Verification

Local Linux build (WSL2 Ubuntu 24.04.1 LTS):

```bash
cmake --preset dev-linux
cmake --build --preset dev-linux
ctest --preset dev-linux
```

Result:

```
100% tests passed, 0 tests failed out of 1
Total Test time (real) =  0.11 sec
```

CI is expected to run Linux (gcc) and Windows (MSVC + Ninja) builds.

## RED-phase Confirmation

Before the CMake skeleton was added, running `ctest --preset dev-linux` failed
because the preset did not exist and no tests were defined. After adding
`tests/unit/bootstrap_test.cpp` and `tests/CMakeLists.txt` but before the
first successful configure, CMake reported that the build directory did not
contain a CMake cache. The bootstrap test now passes.

## ADR Needed?

- [x] No. This issue files the initial ADR set (0001-0013) as prescribed by
  [docs/10_adr_process.md](docs/10_adr_process.md) §8.

## Notes

- Branch protection on `main` (CI required, direct push prohibited) and the
  PyPI placeholder release still require human action with repository owner
  credentials.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project packaging and build presets for Linux, Windows, and Python wheel builds.
  * Introduced a standardized project setup for C++20 builds and optional test execution.

* **Documentation**
  * Added build instructions, a PR template, and an ADR index.
  * Expanded project guidance with architecture decisions, naming, licensing, formatting, and language conventions.

* **Tests**
  * Added automated CI for Linux and Windows.
  * Set up a test suite with an initial placeholder unit test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->