### PR TITLE
feat(codec): implement key validation and key-expression builder (#5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,18 @@ target_include_directories(sitos INTERFACE
   $<INSTALL_INTERFACE:include>
 )
 
+# Implementation library
+add_library(sitos_internal STATIC)
+add_library(sitos::internal ALIAS sitos_internal)
+target_sources(sitos_internal PRIVATE
+  src/key.cpp
+)
+target_include_directories(sitos_internal PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(sitos INTERFACE sitos::internal)
+
 if(SITOS_BUILD_TESTS)
   enable_testing()
   add_subdirectory(tests)

--- a/include/sitos/key.hpp
+++ b/include/sitos/key.hpp
@@ -1,0 +1,38 @@
+// Copyright 2026 Tetsuya Hayashi
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace sitos {
+
+/// Scope classification used by ParamStore/StorageNode APIs.
+enum class ScopeKind { Base, Session, Snap };
+
+/// Parsed representation of a scope string.
+struct Scope {
+  ScopeKind kind;
+  std::string sid;
+};
+
+/// Validates a user key according to wire protocol §1.2.
+bool IsValidKey(std::string_view key);
+
+/// Validates a session id according to wire protocol §1.1.
+bool IsValidSessionId(std::string_view sid);
+
+/// Validates a key prefix (one or more chunks).
+bool IsValidPrefix(std::string_view prefix);
+
+/// Parses scope strings "base", "session/<sid>", or "snap/<sid>".
+std::optional<Scope> ParseScope(std::string_view scope);
+
+/// Builds a full zenoh key: <prefix>/<scope>/<user_key>.
+std::optional<std::string> BuildKey(std::string_view prefix,
+                                    std::string_view scope,
+                                    std::string_view user_key);
+
+}  // namespace sitos

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -3,20 +3,107 @@
 
 #include <sitos/key.hpp>
 
+#include <cctype>
+
 namespace sitos {
+namespace {
 
-bool IsValidKey(std::string_view /*key*/) { return false; }
+bool IsValidChunkChar(char c) {
+  return std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-' || c == '.';
+}
 
-bool IsValidSessionId(std::string_view /*sid*/) { return false; }
+bool IsValidChunk(std::string_view chunk) {
+  if (chunk.empty()) {
+    return false;
+  }
+  for (char c : chunk) {
+    if (!IsValidChunkChar(c)) {
+      return false;
+    }
+  }
+  return true;
+}
 
-bool IsValidPrefix(std::string_view /*prefix*/) { return false; }
+// Validates a slash-separated sequence of one or more chunks.
+bool IsValidChunkSequence(std::string_view value) {
+  if (value.empty()) {
+    return false;
+  }
+  if (value.front() == '/' || value.back() == '/') {
+    return false;
+  }
+  std::size_t start = 0;
+  while (start <= value.size()) {
+    std::size_t end = value.find('/', start);
+    if (end == std::string_view::npos) {
+      end = value.size();
+    }
+    if (!IsValidChunk(value.substr(start, end - start))) {
+      return false;
+    }
+    if (end == value.size()) {
+      break;
+    }
+    start = end + 1;
+  }
+  return true;
+}
 
-std::optional<Scope> ParseScope(std::string_view /*scope*/) { return std::nullopt; }
+}  // namespace
 
-std::optional<std::string> BuildKey(std::string_view /*prefix*/,
-                                    std::string_view /*scope*/,
-                                    std::string_view /*user_key*/) {
+bool IsValidKey(std::string_view key) { return IsValidChunkSequence(key); }
+
+bool IsValidSessionId(std::string_view sid) {
+  if (sid.empty()) {
+    return false;
+  }
+  for (char c : sid) {
+    if (std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-') {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+bool IsValidPrefix(std::string_view prefix) { return IsValidChunkSequence(prefix); }
+
+std::optional<Scope> ParseScope(std::string_view scope) {
+  if (scope == "base") {
+    return Scope{ScopeKind::Base, ""};
+  }
+  constexpr std::string_view kSessionPrefix = "session/";
+  constexpr std::string_view kSnapPrefix = "snap/";
+  if (scope.size() > kSessionPrefix.size() &&
+      scope.substr(0, kSessionPrefix.size()) == kSessionPrefix) {
+    std::string_view sid = scope.substr(kSessionPrefix.size());
+    if (IsValidSessionId(sid)) {
+      return Scope{ScopeKind::Session, std::string(sid)};
+    }
+  }
+  if (scope.size() > kSnapPrefix.size() && scope.substr(0, kSnapPrefix.size()) == kSnapPrefix) {
+    std::string_view sid = scope.substr(kSnapPrefix.size());
+    if (IsValidSessionId(sid)) {
+      return Scope{ScopeKind::Snap, std::string(sid)};
+    }
+  }
   return std::nullopt;
+}
+
+std::optional<std::string> BuildKey(std::string_view prefix,
+                                    std::string_view scope,
+                                    std::string_view user_key) {
+  if (!IsValidPrefix(prefix) || !ParseScope(scope).has_value() || !IsValidKey(user_key)) {
+    return std::nullopt;
+  }
+  std::string result;
+  result.reserve(prefix.size() + 1 + scope.size() + 1 + user_key.size());
+  result.append(prefix);
+  result.push_back('/');
+  result.append(scope);
+  result.push_back('/');
+  result.append(user_key);
+  return result;
 }
 
 }  // namespace sitos

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -1,0 +1,22 @@
+// Copyright 2026 Tetsuya Hayashi
+// SPDX-License-Identifier: Apache-2.0
+
+#include <sitos/key.hpp>
+
+namespace sitos {
+
+bool IsValidKey(std::string_view /*key*/) { return false; }
+
+bool IsValidSessionId(std::string_view /*sid*/) { return false; }
+
+bool IsValidPrefix(std::string_view /*prefix*/) { return false; }
+
+std::optional<Scope> ParseScope(std::string_view /*scope*/) { return std::nullopt; }
+
+std::optional<std::string> BuildKey(std::string_view /*prefix*/,
+                                    std::string_view /*scope*/,
+                                    std::string_view /*user_key*/) {
+  return std::nullopt;
+}
+
+}  // namespace sitos

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,5 +11,9 @@ FetchContent_MakeAvailable(googletest)
 add_executable(sitos_bootstrap_test unit/bootstrap_test.cpp)
 target_link_libraries(sitos_bootstrap_test GTest::gtest_main sitos::sitos)
 
+add_executable(sitos_key_test unit/key_test.cpp)
+target_link_libraries(sitos_key_test GTest::gtest_main sitos::sitos)
+
 include(GoogleTest)
 gtest_discover_tests(sitos_bootstrap_test)
+gtest_discover_tests(sitos_key_test)

--- a/tests/unit/key_test.cpp
+++ b/tests/unit/key_test.cpp
@@ -1,0 +1,180 @@
+// Copyright 2026 Tetsuya Hayashi
+// SPDX-License-Identifier: Apache-2.0
+
+#include <sitos/key.hpp>
+
+#include <gtest/gtest.h>
+
+namespace sitos {
+namespace {
+
+TEST(KeyValidationTest, ValidSingleChunkKey) {
+  EXPECT_TRUE(IsValidKey("fov"));
+  EXPECT_TRUE(IsValidKey("recon"));
+  EXPECT_TRUE(IsValidKey("a"));
+  EXPECT_TRUE(IsValidKey("A"));
+  EXPECT_TRUE(IsValidKey("key_1"));
+  EXPECT_TRUE(IsValidKey("key-1"));
+  EXPECT_TRUE(IsValidKey("key.1"));
+}
+
+TEST(KeyValidationTest, ValidMultiChunkKey) {
+  EXPECT_TRUE(IsValidKey("recon/fov"));
+  EXPECT_TRUE(IsValidKey("a/b/c"));
+  EXPECT_TRUE(IsValidKey("recon/fov/kernel"));
+}
+
+TEST(KeyValidationTest, InvalidEmptyKey) {
+  EXPECT_FALSE(IsValidKey(""));
+}
+
+TEST(KeyValidationTest, InvalidLeadingOrTrailingSlash) {
+  EXPECT_FALSE(IsValidKey("/fov"));
+  EXPECT_FALSE(IsValidKey("fov/"));
+  EXPECT_FALSE(IsValidKey("/recon/fov/"));
+}
+
+TEST(KeyValidationTest, InvalidEmptyChunk) {
+  EXPECT_FALSE(IsValidKey("recon//fov"));
+  EXPECT_FALSE(IsValidKey("/"));
+  EXPECT_FALSE(IsValidKey("a//"));
+  EXPECT_FALSE(IsValidKey("//a"));
+}
+
+TEST(KeyValidationTest, InvalidReservedCharacters) {
+  EXPECT_FALSE(IsValidKey("recon*fov"));
+  EXPECT_FALSE(IsValidKey("recon$fov"));
+  EXPECT_FALSE(IsValidKey("recon?fov"));
+  EXPECT_FALSE(IsValidKey("recon#fov"));
+  EXPECT_FALSE(IsValidKey("recon@fov"));
+}
+
+TEST(KeyValidationTest, InvalidWhitespace) {
+  EXPECT_FALSE(IsValidKey("recon fov"));
+  EXPECT_FALSE(IsValidKey(" recon"));
+  EXPECT_FALSE(IsValidKey("recon\t"));
+  EXPECT_FALSE(IsValidKey("recon\nfov"));
+}
+
+TEST(KeyValidationTest, CaseSensitive) {
+  EXPECT_TRUE(IsValidKey("Recon"));
+  EXPECT_TRUE(IsValidKey("FOV"));
+}
+
+TEST(SessionIdValidationTest, ValidSessionId) {
+  EXPECT_TRUE(IsValidSessionId("session-1"));
+  EXPECT_TRUE(IsValidSessionId("abc123"));
+  EXPECT_TRUE(IsValidSessionId("ABC_123-xyz"));
+  EXPECT_TRUE(IsValidSessionId("a"));
+}
+
+TEST(SessionIdValidationTest, InvalidSessionId) {
+  EXPECT_FALSE(IsValidSessionId(""));
+  EXPECT_FALSE(IsValidSessionId("session/1"));
+  EXPECT_FALSE(IsValidSessionId("session*1"));
+  EXPECT_FALSE(IsValidSessionId("session 1"));
+  EXPECT_FALSE(IsValidSessionId("session.1@"));
+}
+
+TEST(PrefixValidationTest, ValidPrefix) {
+  EXPECT_TRUE(IsValidPrefix("sitos"));
+  EXPECT_TRUE(IsValidPrefix("my/app"));
+  EXPECT_TRUE(IsValidPrefix("a/b/c"));
+}
+
+TEST(PrefixValidationTest, InvalidPrefix) {
+  EXPECT_FALSE(IsValidPrefix(""));
+  EXPECT_FALSE(IsValidPrefix("/sitos"));
+  EXPECT_FALSE(IsValidPrefix("sitos/"));
+  EXPECT_FALSE(IsValidPrefix("sitos//app"));
+  EXPECT_FALSE(IsValidPrefix("sitos app"));
+}
+
+TEST(ScopeParserTest, ParsesBaseScope) {
+  auto scope = ParseScope("base");
+  ASSERT_TRUE(scope.has_value());
+  EXPECT_EQ(scope->kind, ScopeKind::Base);
+  EXPECT_TRUE(scope->sid.empty());
+}
+
+TEST(ScopeParserTest, ParsesSessionScope) {
+  auto scope = ParseScope("session/abc-123");
+  ASSERT_TRUE(scope.has_value());
+  EXPECT_EQ(scope->kind, ScopeKind::Session);
+  EXPECT_EQ(scope->sid, "abc-123");
+}
+
+TEST(ScopeParserTest, ParsesSnapScope) {
+  auto scope = ParseScope("snap/xyz_1");
+  ASSERT_TRUE(scope.has_value());
+  EXPECT_EQ(scope->kind, ScopeKind::Snap);
+  EXPECT_EQ(scope->sid, "xyz_1");
+}
+
+TEST(ScopeParserTest, RejectsInvalidScope) {
+  EXPECT_FALSE(ParseScope(""));
+  EXPECT_FALSE(ParseScope("base/"));
+  EXPECT_FALSE(ParseScope("session"));
+  EXPECT_FALSE(ParseScope("session/"));
+  EXPECT_FALSE(ParseScope("session/a/b"));
+  EXPECT_FALSE(ParseScope("snap"));
+  EXPECT_FALSE(ParseScope("snap/"));
+  EXPECT_FALSE(ParseScope("snap/a/b"));
+  EXPECT_FALSE(ParseScope("invalid/scope"));
+  EXPECT_FALSE(ParseScope("session/a b"));
+  EXPECT_FALSE(ParseScope("session/a*b"));
+}
+
+TEST(KeyBuilderTest, BuildsBaseKey) {
+  auto key = BuildKey("sitos", "base", "recon/fov");
+  ASSERT_TRUE(key.has_value());
+  EXPECT_EQ(*key, "sitos/base/recon/fov");
+}
+
+TEST(KeyBuilderTest, BuildsSessionKey) {
+  auto key = BuildKey("sitos", "session/abc-123", "recon/fov");
+  ASSERT_TRUE(key.has_value());
+  EXPECT_EQ(*key, "sitos/session/abc-123/recon/fov");
+}
+
+TEST(KeyBuilderTest, BuildsSnapKey) {
+  auto key = BuildKey("sitos", "snap/abc-123", "recon/fov");
+  ASSERT_TRUE(key.has_value());
+  EXPECT_EQ(*key, "sitos/snap/abc-123/recon/fov");
+}
+
+TEST(KeyBuilderTest, BuildsWithCustomPrefix) {
+  auto key = BuildKey("my/app", "base", "recon/fov");
+  ASSERT_TRUE(key.has_value());
+  EXPECT_EQ(*key, "my/app/base/recon/fov");
+}
+
+TEST(KeyBuilderTest, RejectsInvalidComponents) {
+  EXPECT_FALSE(BuildKey("", "base", "recon/fov"));
+  EXPECT_FALSE(BuildKey("sitos", "invalid", "recon/fov"));
+  EXPECT_FALSE(BuildKey("sitos", "base", "recon*fov"));
+  EXPECT_FALSE(BuildKey("sitos", "session/bad sid", "recon/fov"));
+  EXPECT_FALSE(BuildKey("sitos prefix", "base", "recon/fov"));
+}
+
+TEST(KeyTest, InvalidKeysAreRejected) {
+  // Required AC test name from docs/06_build_test_packaging.md §4.1.
+  EXPECT_FALSE(IsValidKey(""));
+  EXPECT_FALSE(IsValidKey("/foo"));
+  EXPECT_FALSE(IsValidKey("foo/"));
+  EXPECT_FALSE(IsValidKey("foo//bar"));
+  EXPECT_FALSE(IsValidKey("foo*bar"));
+  EXPECT_FALSE(IsValidKey("foo$bar"));
+  EXPECT_FALSE(IsValidKey("foo?bar"));
+  EXPECT_FALSE(IsValidKey("foo#bar"));
+  EXPECT_FALSE(IsValidKey("foo@bar"));
+  EXPECT_FALSE(IsValidKey("foo bar"));
+  EXPECT_FALSE(IsValidSessionId(""));
+  EXPECT_FALSE(IsValidSessionId("bad/sid"));
+  EXPECT_FALSE(IsValidSessionId("bad sid"));
+  EXPECT_FALSE(ParseScope("session/bad sid"));
+  EXPECT_FALSE(BuildKey("sitos", "base", "bad*key"));
+}
+
+}  // namespace
+}  // namespace sitos


### PR DESCRIPTION
## Summary

Implement key validation and key-expression builder for sitos wire protocol §1.

Closes #5

## Acceptance Criteria

- [x] `IsValidKey` accepts valid hierarchical keys and rejects empty chunks, leading/trailing slashes, reserved characters (`*`, `$`, `?`, `#`, `@`), and whitespace.
- [x] `IsValidSessionId` accepts `[0-9a-zA-Z_-]+` and rejects invalid sids.
- [x] `IsValidPrefix` accepts one or more valid chunks.
- [x] `ParseScope` parses `base`, `session/<sid>`, and `snap/<sid>`.
- [x] `BuildKey` constructs `<prefix>/<scope>/<user_key>` and validates all components.
- [x] Required AC test `InvalidKeysAreRejected` is green.

## RED-phase failure confirmation

```
 2 - KeyValidationTest.ValidSingleChunkKey (Failed)
 3 - KeyValidationTest.ValidMultiChunkKey (Failed)
 9 - KeyValidationTest.CaseSensitive (Failed)
10 - SessionIdValidationTest.ValidSessionId (Failed)
12 - PrefixValidationTest.ValidPrefix (Failed)
14 - ScopeParserTest.ParsesBaseScope (Failed)
15 - ScopeParserTest.ParsesSessionScope (Failed)
16 - ScopeParserTest.ParsesSnapScope (Failed)
18 - KeyBuilderTest.BuildsBaseKey (Failed)
19 - KeyBuilderTest.BuildsSessionKey (Failed)
20 - KeyBuilderTest.BuildsSnapKey (Failed)
21 - KeyBuilderTest.BuildsWithCustomPrefix (Failed)

48% tests passed, 12 tests failed out of 23
```

## Test results

```
100% tests passed, 0 tests failed out of 23
Total Test time (real) =   0.98 sec
```

## Implementation notes

- `Scope` / `ScopeKind` types added for scope parsing.
- Invalid keys return `std::nullopt` for builder APIs; validators return `false`.
- No ADR required: this is a pure wire-protocol implementation detail, not a protocol change.

## Related requirements

- [03_wire_protocol.md] §1 (key space)
- [04_api_cpp.md] §1 (invalid keys produce `Status::InvalidKey` at API boundary)
- [06_build_test_packaging.md] §4.1 (`InvalidKeysAreRejected`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public key and scope handling support, including validation of keys, session IDs, and prefixes.
  * Added parsing for scope strings and building of full keys from a prefix, scope, and user key.
* **Tests**
  * Added unit coverage for valid and invalid key formats, scope parsing, and key construction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->