### PR TITLE
feat(codec): implement key validation and key-expression builder (#5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ endfunction()
 add_library(sitos STATIC
   src/param_value.cpp
   src/batch.cpp
+  src/key.cpp
 )
 add_library(sitos::sitos ALIAS sitos)
 target_include_directories(sitos PUBLIC

--- a/include/sitos/key.hpp
+++ b/include/sitos/key.hpp
@@ -1,0 +1,38 @@
+// Copyright 2026 Tetsuya Hayashi
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace sitos {
+
+/// Scope classification used by ParamStore/StorageNode APIs.
+enum class ScopeKind { Base, Session, Snap };
+
+/// Parsed representation of a scope string.
+struct Scope {
+  ScopeKind kind;
+  std::string sid;
+};
+
+/// Validates a user key according to wire protocol §1.2.
+bool IsValidKey(std::string_view key);
+
+/// Validates a session id according to wire protocol §1.1.
+bool IsValidSessionId(std::string_view sid);
+
+/// Validates a key prefix (one or more chunks).
+bool IsValidPrefix(std::string_view prefix);
+
+/// Parses scope strings "base", "session/<sid>", or "snap/<sid>".
+std::optional<Scope> ParseScope(std::string_view scope);
+
+/// Builds a full zenoh key: <prefix>/<scope>/<user_key>.
+std::optional<std::string> BuildKey(std::string_view prefix,
+                                    std::string_view scope,
+                                    std::string_view user_key);
+
+}  // namespace sitos

--- a/include/sitos/key.hpp
+++ b/include/sitos/key.hpp
@@ -1,7 +1,12 @@
-// Copyright 2026 Tetsuya Hayashi
+// Copyright 2026 sitos contributors
 // SPDX-License-Identifier: Apache-2.0
+//
+// User-key grammar validation, scope parsing, key-expression building, and
+// incoming key parsing for the sitos key space.
+// See docs/03_wire_protocol.md §1 and docs/02_architecture.md §2.
 
-#pragma once
+#ifndef SITOS_KEY_HPP
+#define SITOS_KEY_HPP
 
 #include <optional>
 #include <string>
@@ -18,21 +23,74 @@ struct Scope {
   std::string sid;
 };
 
-/// Validates a user key according to wire protocol §1.2.
+/// Key kind, used by the incoming-key parser for StorageNode routing.
+/// See docs/03_wire_protocol.md §1.1.
+enum class KeyKind {
+  Base,         ///< <prefix>/base/<key> (or <prefix>/base/$batch)
+  Session,      ///< <prefix>/session/<sid>/<key> (or $batch)
+  Snapshot,     ///< <prefix>/snap/<sid>/<key> (read-only; no $batch)
+  MetaSession,  ///< <prefix>/meta/session/<sid>
+  MetaAck,      ///< <prefix>/meta/ack/<uuid>
+};
+
+/// Result of parsing an incoming zenoh key expression. The inverse of the
+/// Build*Key functions. See docs/03_wire_protocol.md §1.1.
+struct ParsedKey {
+  KeyKind kind;
+  /// Session id for Session / Snapshot / MetaSession. Empty for Base / MetaAck.
+  std::string sid;
+  /// Ack UUID for MetaAck. Empty for all other kinds.
+  std::string uuid;
+  /// Relative user key for Base / Session / Snapshot. Empty for Meta paths and
+  /// for $batch paths (where is_batch is true instead).
+  std::string relative_key;
+  /// True for the special <prefix>/base/$batch and <prefix>/session/<sid>/$batch
+  /// paths. Only Base and Session may be batch.
+  bool is_batch = false;
+};
+
+/// Validates a user key according to wire protocol §1.2. Rejects empty
+/// chunks, leading/trailing '/', and zenoh-reserved characters (*$?#@ and
+/// whitespace).
 bool IsValidKey(std::string_view key);
 
-/// Validates a session id according to wire protocol §1.1.
+/// Validates a session id according to wire protocol §1.1 ([0-9a-zA-Z_-]+,
+/// single chunk).
 bool IsValidSessionId(std::string_view sid);
 
 /// Validates a key prefix (one or more chunks).
 bool IsValidPrefix(std::string_view prefix);
 
+/// Validates an ack UUID. Accepts the canonical 8-4-4-4-12 hex form and any
+/// non-empty sequence of [0-9a-zA-Z_-] (a safe superset); rejects zenoh-reserved
+/// characters.
+bool IsValidAckUuid(std::string_view uuid);
+
 /// Parses scope strings "base", "session/<sid>", or "snap/<sid>".
 std::optional<Scope> ParseScope(std::string_view scope);
 
-/// Builds a full zenoh key: <prefix>/<scope>/<user_key>.
-std::optional<std::string> BuildKey(std::string_view prefix,
-                                    std::string_view scope,
+/// Builds a full zenoh key for a user value: <prefix>/<scope>/<key>.
+/// Returns std::nullopt if any component is invalid.
+std::optional<std::string> BuildKey(std::string_view prefix, std::string_view scope,
                                     std::string_view user_key);
 
+/// Builds a $batch key for the given scope: <prefix>/base/$batch or
+/// <prefix>/session/<sid>/$batch. Batch is not defined for snap; returns
+/// std::nullopt for a snap scope.
+std::optional<std::string> BuildBatchKey(std::string_view prefix, std::string_view scope);
+
+/// Builds the session-metadata key <prefix>/meta/session/<sid>.
+std::optional<std::string> BuildMetaSessionKey(std::string_view prefix, std::string_view sid);
+
+/// Builds the ack key <prefix>/meta/ack/<uuid>.
+std::optional<std::string> BuildMetaAckKey(std::string_view prefix, std::string_view uuid);
+
+/// Parses an incoming zenoh key expression that is expected to live under the
+/// given prefix. Strips the prefix and classifies the remainder according to
+/// docs/03 §1.1. Returns std::nullopt if the prefix does not match or the
+/// remainder is not a valid sitos key.
+std::optional<ParsedKey> ParseKey(std::string_view prefix, std::string_view full_key);
+
 }  // namespace sitos
+
+#endif  // SITOS_KEY_HPP

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -3,20 +3,107 @@
 
 #include <sitos/key.hpp>
 
+#include <cctype>
+
 namespace sitos {
+namespace {
 
-bool IsValidKey(std::string_view /*key*/) { return false; }
+bool IsValidChunkChar(char c) {
+  return std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-' || c == '.';
+}
 
-bool IsValidSessionId(std::string_view /*sid*/) { return false; }
+bool IsValidChunk(std::string_view chunk) {
+  if (chunk.empty()) {
+    return false;
+  }
+  for (char c : chunk) {
+    if (!IsValidChunkChar(c)) {
+      return false;
+    }
+  }
+  return true;
+}
 
-bool IsValidPrefix(std::string_view /*prefix*/) { return false; }
+// Validates a slash-separated sequence of one or more chunks.
+bool IsValidChunkSequence(std::string_view value) {
+  if (value.empty()) {
+    return false;
+  }
+  if (value.front() == '/' || value.back() == '/') {
+    return false;
+  }
+  std::size_t start = 0;
+  while (start <= value.size()) {
+    std::size_t end = value.find('/', start);
+    if (end == std::string_view::npos) {
+      end = value.size();
+    }
+    if (!IsValidChunk(value.substr(start, end - start))) {
+      return false;
+    }
+    if (end == value.size()) {
+      break;
+    }
+    start = end + 1;
+  }
+  return true;
+}
 
-std::optional<Scope> ParseScope(std::string_view /*scope*/) { return std::nullopt; }
+}  // namespace
 
-std::optional<std::string> BuildKey(std::string_view /*prefix*/,
-                                    std::string_view /*scope*/,
-                                    std::string_view /*user_key*/) {
+bool IsValidKey(std::string_view key) { return IsValidChunkSequence(key); }
+
+bool IsValidSessionId(std::string_view sid) {
+  if (sid.empty()) {
+    return false;
+  }
+  for (char c : sid) {
+    if (std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-') {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+bool IsValidPrefix(std::string_view prefix) { return IsValidChunkSequence(prefix); }
+
+std::optional<Scope> ParseScope(std::string_view scope) {
+  if (scope == "base") {
+    return Scope{ScopeKind::Base, ""};
+  }
+  constexpr std::string_view kSessionPrefix = "session/";
+  constexpr std::string_view kSnapPrefix = "snap/";
+  if (scope.size() > kSessionPrefix.size() &&
+      scope.substr(0, kSessionPrefix.size()) == kSessionPrefix) {
+    std::string_view sid = scope.substr(kSessionPrefix.size());
+    if (IsValidSessionId(sid)) {
+      return Scope{ScopeKind::Session, std::string(sid)};
+    }
+  }
+  if (scope.size() > kSnapPrefix.size() && scope.substr(0, kSnapPrefix.size()) == kSnapPrefix) {
+    std::string_view sid = scope.substr(kSnapPrefix.size());
+    if (IsValidSessionId(sid)) {
+      return Scope{ScopeKind::Snap, std::string(sid)};
+    }
+  }
   return std::nullopt;
+}
+
+std::optional<std::string> BuildKey(std::string_view prefix,
+                                    std::string_view scope,
+                                    std::string_view user_key) {
+  if (!IsValidPrefix(prefix) || !ParseScope(scope).has_value() || !IsValidKey(user_key)) {
+    return std::nullopt;
+  }
+  std::string result;
+  result.reserve(prefix.size() + 1 + scope.size() + 1 + user_key.size());
+  result.append(prefix);
+  result.push_back('/');
+  result.append(scope);
+  result.push_back('/');
+  result.append(user_key);
+  return result;
 }
 
 }  // namespace sitos

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -1,9 +1,8 @@
-// Copyright 2026 Tetsuya Hayashi
+// Copyright 2026 sitos contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <sitos/key.hpp>
-
 #include <cctype>
+#include <sitos/key.hpp>
 
 namespace sitos {
 namespace {
@@ -49,24 +48,39 @@ bool IsValidChunkSequence(std::string_view value) {
   return true;
 }
 
-}  // namespace
+// The special batch segment, always the last chunk of a batch key.
+constexpr std::string_view kBatchSegment = "$batch";
 
-bool IsValidKey(std::string_view key) { return IsValidChunkSequence(key); }
+bool IsValidIdChar(char c) {
+  return std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-';
+}
 
-bool IsValidSessionId(std::string_view sid) {
-  if (sid.empty()) {
+bool IsValidId(std::string_view id) {
+  if (id.empty()) {
     return false;
   }
-  for (char c : sid) {
-    if (std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-') {
-      continue;
+  for (char c : id) {
+    if (!IsValidIdChar(c)) {
+      return false;
     }
-    return false;
   }
   return true;
 }
 
+}  // namespace
+
+bool IsValidKey(std::string_view key) { return IsValidChunkSequence(key); }
+
+bool IsValidSessionId(std::string_view sid) { return IsValidId(sid); }
+
 bool IsValidPrefix(std::string_view prefix) { return IsValidChunkSequence(prefix); }
+
+bool IsValidAckUuid(std::string_view uuid) {
+  // Lenient: accept any non-empty [0-9a-zA-Z_-] sequence. The canonical UUID
+  // form (8-4-4-4-12 hex) is a subset; we stay strict about zenoh-reserved
+  // characters and reject '/' so meta/ack/<uuid> cannot smuggle extra chunks.
+  return IsValidId(uuid);
+}
 
 std::optional<Scope> ParseScope(std::string_view scope) {
   if (scope == "base") {
@@ -90,8 +104,7 @@ std::optional<Scope> ParseScope(std::string_view scope) {
   return std::nullopt;
 }
 
-std::optional<std::string> BuildKey(std::string_view prefix,
-                                    std::string_view scope,
+std::optional<std::string> BuildKey(std::string_view prefix, std::string_view scope,
                                     std::string_view user_key) {
   if (!IsValidPrefix(prefix) || !ParseScope(scope).has_value() || !IsValidKey(user_key)) {
     return std::nullopt;
@@ -104,6 +117,180 @@ std::optional<std::string> BuildKey(std::string_view prefix,
   result.push_back('/');
   result.append(user_key);
   return result;
+}
+
+std::optional<std::string> BuildBatchKey(std::string_view prefix, std::string_view scope) {
+  if (!IsValidPrefix(prefix)) {
+    return std::nullopt;
+  }
+  // Batch is defined for base and session scopes only (docs/03 §1.1).
+  if (scope == "base") {
+    std::string result;
+    result.reserve(prefix.size() + 1 + scope.size() + 1 + kBatchSegment.size());
+    result.append(prefix);
+    result.push_back('/');
+    result.append(scope);
+    result.push_back('/');
+    result.append(kBatchSegment);
+    return result;
+  }
+  constexpr std::string_view kSessionPrefix = "session/";
+  if (scope.size() > kSessionPrefix.size() &&
+      scope.substr(0, kSessionPrefix.size()) == kSessionPrefix) {
+    std::string_view sid = scope.substr(kSessionPrefix.size());
+    if (!IsValidSessionId(sid)) {
+      return std::nullopt;
+    }
+    std::string result;
+    result.reserve(prefix.size() + 1 + scope.size() + 1 + kBatchSegment.size());
+    result.append(prefix);
+    result.push_back('/');
+    result.append(scope);
+    result.push_back('/');
+    result.append(kBatchSegment);
+    return result;
+  }
+  // snap (and any other) has no batch path.
+  return std::nullopt;
+}
+
+std::optional<std::string> BuildMetaSessionKey(std::string_view prefix, std::string_view sid) {
+  if (!IsValidPrefix(prefix) || !IsValidSessionId(sid)) {
+    return std::nullopt;
+  }
+  constexpr std::string_view kMeta = "meta/session";
+  std::string result;
+  result.reserve(prefix.size() + 1 + kMeta.size() + 1 + sid.size());
+  result.append(prefix);
+  result.push_back('/');
+  result.append(kMeta);
+  result.push_back('/');
+  result.append(sid);
+  return result;
+}
+
+std::optional<std::string> BuildMetaAckKey(std::string_view prefix, std::string_view uuid) {
+  if (!IsValidPrefix(prefix) || !IsValidAckUuid(uuid)) {
+    return std::nullopt;
+  }
+  constexpr std::string_view kMeta = "meta/ack";
+  std::string result;
+  result.reserve(prefix.size() + 1 + kMeta.size() + 1 + uuid.size());
+  result.append(prefix);
+  result.push_back('/');
+  result.append(kMeta);
+  result.push_back('/');
+  result.append(uuid);
+  return result;
+}
+
+namespace {
+
+// Returns the remainder of `full_key` after `<prefix>/`, or std::nullopt if
+// `full_key` does not start with `prefix` followed by '/'.
+std::optional<std::string_view> StripPrefix(std::string_view prefix, std::string_view full_key) {
+  if (full_key.size() <= prefix.size() || full_key[prefix.size()] != '/') {
+    return std::nullopt;
+  }
+  if (full_key.substr(0, prefix.size()) != prefix) {
+    return std::nullopt;
+  }
+  return full_key.substr(prefix.size() + 1);
+}
+
+// Splits `rest` at the first '/' into (head, tail). Returns std::nullopt if
+// there is no '/' (tail would be empty).
+std::optional<std::pair<std::string_view, std::string_view>> SplitFirst(std::string_view rest) {
+  std::size_t slash = rest.find('/');
+  if (slash == std::string_view::npos) {
+    return std::nullopt;
+  }
+  return std::pair{rest.substr(0, slash), rest.substr(slash + 1)};
+}
+
+}  // namespace
+
+std::optional<ParsedKey> ParseKey(std::string_view prefix, std::string_view full_key) {
+  if (!IsValidPrefix(prefix)) {
+    return std::nullopt;
+  }
+  auto rest_opt = StripPrefix(prefix, full_key);
+  if (!rest_opt) {
+    return std::nullopt;
+  }
+  std::string_view rest = *rest_opt;
+
+  // base/<key...> and base/$batch
+  if (rest == "base") {
+    // <prefix>/base with no user key is not a valid value key.
+    return std::nullopt;
+  }
+  if (auto split = SplitFirst(rest)) {
+    auto [head, tail] = *split;
+    if (head == "base") {
+      if (tail == kBatchSegment) {
+        return ParsedKey{KeyKind::Base, "", "", "", true};
+      }
+      if (!IsValidKey(tail)) {
+        return std::nullopt;
+      }
+      return ParsedKey{KeyKind::Base, "", "", std::string(tail), false};
+    }
+    if (head == "session") {
+      // session/<sid>/<key...> or session/<sid>/$batch
+      auto sid_split = SplitFirst(tail);
+      if (!sid_split) {
+        return std::nullopt;  // session/ with no sid/key
+      }
+      auto [sid, value] = *sid_split;
+      if (!IsValidSessionId(sid)) {
+        return std::nullopt;
+      }
+      if (value == kBatchSegment) {
+        return ParsedKey{KeyKind::Session, std::string(sid), "", "", true};
+      }
+      if (!IsValidKey(value)) {
+        return std::nullopt;
+      }
+      return ParsedKey{KeyKind::Session, std::string(sid), "", std::string(value), false};
+    }
+    if (head == "snap") {
+      // snap/<sid>/<key...> — read-only, no $batch.
+      auto sid_split = SplitFirst(tail);
+      if (!sid_split) {
+        return std::nullopt;
+      }
+      auto [sid, value] = *sid_split;
+      if (!IsValidSessionId(sid)) {
+        return std::nullopt;
+      }
+      if (!IsValidKey(value)) {
+        return std::nullopt;  // rejects snap/<sid>/$batch too ($ fails IsValidKey)
+      }
+      return ParsedKey{KeyKind::Snapshot, std::string(sid), "", std::string(value), false};
+    }
+    if (head == "meta") {
+      // meta/session/<sid> or meta/ack/<uuid>
+      auto meta_split = SplitFirst(tail);
+      if (!meta_split) {
+        return std::nullopt;
+      }
+      auto [meta_kind, id] = *meta_split;
+      if (meta_kind == "session") {
+        if (!IsValidSessionId(id)) {
+          return std::nullopt;
+        }
+        return ParsedKey{KeyKind::MetaSession, std::string(id), "", "", false};
+      }
+      if (meta_kind == "ack") {
+        if (!IsValidAckUuid(id)) {
+          return std::nullopt;
+        }
+        return ParsedKey{KeyKind::MetaAck, "", std::string(id), "", false};
+      }
+    }
+  }
+  return std::nullopt;
 }
 
 }  // namespace sitos

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -1,0 +1,22 @@
+// Copyright 2026 Tetsuya Hayashi
+// SPDX-License-Identifier: Apache-2.0
+
+#include <sitos/key.hpp>
+
+namespace sitos {
+
+bool IsValidKey(std::string_view /*key*/) { return false; }
+
+bool IsValidSessionId(std::string_view /*sid*/) { return false; }
+
+bool IsValidPrefix(std::string_view /*prefix*/) { return false; }
+
+std::optional<Scope> ParseScope(std::string_view /*scope*/) { return std::nullopt; }
+
+std::optional<std::string> BuildKey(std::string_view /*prefix*/,
+                                    std::string_view /*scope*/,
+                                    std::string_view /*user_key*/) {
+  return std::nullopt;
+}
+
+}  // namespace sitos

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,3 +23,8 @@ target_compile_definitions(sitos_param_value_test PRIVATE
   SITOS_FIXTURE_DIR="${SITOS_FIXTURE_DIR}")
 sitos_enable_warnings(sitos_param_value_test)
 gtest_discover_tests(sitos_param_value_test)
+
+add_executable(sitos_key_test unit/key_test.cpp)
+target_link_libraries(sitos_key_test PRIVATE GTest::gtest_main sitos::sitos)
+sitos_enable_warnings(sitos_key_test)
+gtest_discover_tests(sitos_key_test)

--- a/tests/unit/key_test.cpp
+++ b/tests/unit/key_test.cpp
@@ -1,0 +1,180 @@
+// Copyright 2026 Tetsuya Hayashi
+// SPDX-License-Identifier: Apache-2.0
+
+#include <sitos/key.hpp>
+
+#include <gtest/gtest.h>
+
+namespace sitos {
+namespace {
+
+TEST(KeyValidationTest, ValidSingleChunkKey) {
+  EXPECT_TRUE(IsValidKey("fov"));
+  EXPECT_TRUE(IsValidKey("recon"));
+  EXPECT_TRUE(IsValidKey("a"));
+  EXPECT_TRUE(IsValidKey("A"));
+  EXPECT_TRUE(IsValidKey("key_1"));
+  EXPECT_TRUE(IsValidKey("key-1"));
+  EXPECT_TRUE(IsValidKey("key.1"));
+}
+
+TEST(KeyValidationTest, ValidMultiChunkKey) {
+  EXPECT_TRUE(IsValidKey("recon/fov"));
+  EXPECT_TRUE(IsValidKey("a/b/c"));
+  EXPECT_TRUE(IsValidKey("recon/fov/kernel"));
+}
+
+TEST(KeyValidationTest, InvalidEmptyKey) {
+  EXPECT_FALSE(IsValidKey(""));
+}
+
+TEST(KeyValidationTest, InvalidLeadingOrTrailingSlash) {
+  EXPECT_FALSE(IsValidKey("/fov"));
+  EXPECT_FALSE(IsValidKey("fov/"));
+  EXPECT_FALSE(IsValidKey("/recon/fov/"));
+}
+
+TEST(KeyValidationTest, InvalidEmptyChunk) {
+  EXPECT_FALSE(IsValidKey("recon//fov"));
+  EXPECT_FALSE(IsValidKey("/"));
+  EXPECT_FALSE(IsValidKey("a//"));
+  EXPECT_FALSE(IsValidKey("//a"));
+}
+
+TEST(KeyValidationTest, InvalidReservedCharacters) {
+  EXPECT_FALSE(IsValidKey("recon*fov"));
+  EXPECT_FALSE(IsValidKey("recon$fov"));
+  EXPECT_FALSE(IsValidKey("recon?fov"));
+  EXPECT_FALSE(IsValidKey("recon#fov"));
+  EXPECT_FALSE(IsValidKey("recon@fov"));
+}
+
+TEST(KeyValidationTest, InvalidWhitespace) {
+  EXPECT_FALSE(IsValidKey("recon fov"));
+  EXPECT_FALSE(IsValidKey(" recon"));
+  EXPECT_FALSE(IsValidKey("recon\t"));
+  EXPECT_FALSE(IsValidKey("recon\nfov"));
+}
+
+TEST(KeyValidationTest, CaseSensitive) {
+  EXPECT_TRUE(IsValidKey("Recon"));
+  EXPECT_TRUE(IsValidKey("FOV"));
+}
+
+TEST(SessionIdValidationTest, ValidSessionId) {
+  EXPECT_TRUE(IsValidSessionId("session-1"));
+  EXPECT_TRUE(IsValidSessionId("abc123"));
+  EXPECT_TRUE(IsValidSessionId("ABC_123-xyz"));
+  EXPECT_TRUE(IsValidSessionId("a"));
+}
+
+TEST(SessionIdValidationTest, InvalidSessionId) {
+  EXPECT_FALSE(IsValidSessionId(""));
+  EXPECT_FALSE(IsValidSessionId("session/1"));
+  EXPECT_FALSE(IsValidSessionId("session*1"));
+  EXPECT_FALSE(IsValidSessionId("session 1"));
+  EXPECT_FALSE(IsValidSessionId("session.1@"));
+}
+
+TEST(PrefixValidationTest, ValidPrefix) {
+  EXPECT_TRUE(IsValidPrefix("sitos"));
+  EXPECT_TRUE(IsValidPrefix("my/app"));
+  EXPECT_TRUE(IsValidPrefix("a/b/c"));
+}
+
+TEST(PrefixValidationTest, InvalidPrefix) {
+  EXPECT_FALSE(IsValidPrefix(""));
+  EXPECT_FALSE(IsValidPrefix("/sitos"));
+  EXPECT_FALSE(IsValidPrefix("sitos/"));
+  EXPECT_FALSE(IsValidPrefix("sitos//app"));
+  EXPECT_FALSE(IsValidPrefix("sitos app"));
+}
+
+TEST(ScopeParserTest, ParsesBaseScope) {
+  auto scope = ParseScope("base");
+  ASSERT_TRUE(scope.has_value());
+  EXPECT_EQ(scope->kind, ScopeKind::Base);
+  EXPECT_TRUE(scope->sid.empty());
+}
+
+TEST(ScopeParserTest, ParsesSessionScope) {
+  auto scope = ParseScope("session/abc-123");
+  ASSERT_TRUE(scope.has_value());
+  EXPECT_EQ(scope->kind, ScopeKind::Session);
+  EXPECT_EQ(scope->sid, "abc-123");
+}
+
+TEST(ScopeParserTest, ParsesSnapScope) {
+  auto scope = ParseScope("snap/xyz_1");
+  ASSERT_TRUE(scope.has_value());
+  EXPECT_EQ(scope->kind, ScopeKind::Snap);
+  EXPECT_EQ(scope->sid, "xyz_1");
+}
+
+TEST(ScopeParserTest, RejectsInvalidScope) {
+  EXPECT_FALSE(ParseScope(""));
+  EXPECT_FALSE(ParseScope("base/"));
+  EXPECT_FALSE(ParseScope("session"));
+  EXPECT_FALSE(ParseScope("session/"));
+  EXPECT_FALSE(ParseScope("session/a/b"));
+  EXPECT_FALSE(ParseScope("snap"));
+  EXPECT_FALSE(ParseScope("snap/"));
+  EXPECT_FALSE(ParseScope("snap/a/b"));
+  EXPECT_FALSE(ParseScope("invalid/scope"));
+  EXPECT_FALSE(ParseScope("session/a b"));
+  EXPECT_FALSE(ParseScope("session/a*b"));
+}
+
+TEST(KeyBuilderTest, BuildsBaseKey) {
+  auto key = BuildKey("sitos", "base", "recon/fov");
+  ASSERT_TRUE(key.has_value());
+  EXPECT_EQ(*key, "sitos/base/recon/fov");
+}
+
+TEST(KeyBuilderTest, BuildsSessionKey) {
+  auto key = BuildKey("sitos", "session/abc-123", "recon/fov");
+  ASSERT_TRUE(key.has_value());
+  EXPECT_EQ(*key, "sitos/session/abc-123/recon/fov");
+}
+
+TEST(KeyBuilderTest, BuildsSnapKey) {
+  auto key = BuildKey("sitos", "snap/abc-123", "recon/fov");
+  ASSERT_TRUE(key.has_value());
+  EXPECT_EQ(*key, "sitos/snap/abc-123/recon/fov");
+}
+
+TEST(KeyBuilderTest, BuildsWithCustomPrefix) {
+  auto key = BuildKey("my/app", "base", "recon/fov");
+  ASSERT_TRUE(key.has_value());
+  EXPECT_EQ(*key, "my/app/base/recon/fov");
+}
+
+TEST(KeyBuilderTest, RejectsInvalidComponents) {
+  EXPECT_FALSE(BuildKey("", "base", "recon/fov"));
+  EXPECT_FALSE(BuildKey("sitos", "invalid", "recon/fov"));
+  EXPECT_FALSE(BuildKey("sitos", "base", "recon*fov"));
+  EXPECT_FALSE(BuildKey("sitos", "session/bad sid", "recon/fov"));
+  EXPECT_FALSE(BuildKey("sitos prefix", "base", "recon/fov"));
+}
+
+TEST(KeyTest, InvalidKeysAreRejected) {
+  // Required AC test name from docs/06_build_test_packaging.md §4.1.
+  EXPECT_FALSE(IsValidKey(""));
+  EXPECT_FALSE(IsValidKey("/foo"));
+  EXPECT_FALSE(IsValidKey("foo/"));
+  EXPECT_FALSE(IsValidKey("foo//bar"));
+  EXPECT_FALSE(IsValidKey("foo*bar"));
+  EXPECT_FALSE(IsValidKey("foo$bar"));
+  EXPECT_FALSE(IsValidKey("foo?bar"));
+  EXPECT_FALSE(IsValidKey("foo#bar"));
+  EXPECT_FALSE(IsValidKey("foo@bar"));
+  EXPECT_FALSE(IsValidKey("foo bar"));
+  EXPECT_FALSE(IsValidSessionId(""));
+  EXPECT_FALSE(IsValidSessionId("bad/sid"));
+  EXPECT_FALSE(IsValidSessionId("bad sid"));
+  EXPECT_FALSE(ParseScope("session/bad sid"));
+  EXPECT_FALSE(BuildKey("sitos", "base", "bad*key"));
+}
+
+}  // namespace
+}  // namespace sitos

--- a/tests/unit/key_test.cpp
+++ b/tests/unit/key_test.cpp
@@ -1,9 +1,11 @@
-// Copyright 2026 Tetsuya Hayashi
+// Copyright 2026 sitos contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <sitos/key.hpp>
-
 #include <gtest/gtest.h>
+
+#include <sitos/key.hpp>
+#include <string>
+#include <string_view>
 
 namespace sitos {
 namespace {
@@ -24,9 +26,7 @@ TEST(KeyValidationTest, ValidMultiChunkKey) {
   EXPECT_TRUE(IsValidKey("recon/fov/kernel"));
 }
 
-TEST(KeyValidationTest, InvalidEmptyKey) {
-  EXPECT_FALSE(IsValidKey(""));
-}
+TEST(KeyValidationTest, InvalidEmptyKey) { EXPECT_FALSE(IsValidKey("")); }
 
 TEST(KeyValidationTest, InvalidLeadingOrTrailingSlash) {
   EXPECT_FALSE(IsValidKey("/fov"));
@@ -155,6 +155,231 @@ TEST(KeyBuilderTest, RejectsInvalidComponents) {
   EXPECT_FALSE(BuildKey("sitos", "base", "recon*fov"));
   EXPECT_FALSE(BuildKey("sitos", "session/bad sid", "recon/fov"));
   EXPECT_FALSE(BuildKey("sitos prefix", "base", "recon/fov"));
+}
+
+// --- $batch builders (docs/03 §1.1) ---
+
+TEST(BatchKeyBuilderTest, BuildsBaseBatch) {
+  auto key = BuildBatchKey("sitos", "base");
+  ASSERT_TRUE(key.has_value());
+  EXPECT_EQ(*key, "sitos/base/$batch");
+}
+
+TEST(BatchKeyBuilderTest, BuildsSessionBatch) {
+  auto key = BuildBatchKey("sitos", "session/abc-123");
+  ASSERT_TRUE(key.has_value());
+  EXPECT_EQ(*key, "sitos/session/abc-123/$batch");
+}
+
+TEST(BatchKeyBuilderTest, BuildsBatchWithCustomPrefix) {
+  auto key = BuildBatchKey("my/app", "base");
+  ASSERT_TRUE(key.has_value());
+  EXPECT_EQ(*key, "my/app/base/$batch");
+}
+
+TEST(BatchKeyBuilderTest, RejectsSnapBatch) {
+  // Snap batch is not defined by the wire protocol.
+  EXPECT_FALSE(BuildBatchKey("sitos", "snap/abc-123"));
+}
+
+TEST(BatchKeyBuilderTest, RejectsInvalidBatchScope) {
+  EXPECT_FALSE(BuildBatchKey("", "base"));
+  EXPECT_FALSE(BuildBatchKey("sitos", "invalid"));
+  EXPECT_FALSE(BuildBatchKey("sitos", "session/bad sid"));
+  EXPECT_FALSE(BuildBatchKey("sitos prefix", "base"));
+}
+
+TEST(BatchKeyBuilderTest, UserKeyCannotSmuggleBatch) {
+  // '$' is reserved, so BuildKey rejects "$batch" as a user key. Batch paths
+  // can only be produced through BuildBatchKey.
+  EXPECT_FALSE(BuildKey("sitos", "base", "$batch"));
+}
+
+// --- meta builders (docs/03 §1.1) ---
+
+TEST(MetaKeyBuilderTest, BuildsMetaSession) {
+  auto key = BuildMetaSessionKey("sitos", "abc-123");
+  ASSERT_TRUE(key.has_value());
+  EXPECT_EQ(*key, "sitos/meta/session/abc-123");
+}
+
+TEST(MetaKeyBuilderTest, BuildsMetaAck) {
+  auto key = BuildMetaAckKey("sitos", "550e8400-e29b-41d4-a716-446655440000");
+  ASSERT_TRUE(key.has_value());
+  EXPECT_EQ(*key, "sitos/meta/ack/550e8400-e29b-41d4-a716-446655440000");
+}
+
+TEST(MetaKeyBuilderTest, RejectsInvalidMeta) {
+  EXPECT_FALSE(BuildMetaSessionKey("", "abc-123"));
+  EXPECT_FALSE(BuildMetaSessionKey("sitos", ""));
+  EXPECT_FALSE(BuildMetaSessionKey("sitos", "bad/sid"));
+  EXPECT_FALSE(BuildMetaSessionKey("sitos", "bad sid"));
+  EXPECT_FALSE(BuildMetaAckKey("", "uuid"));
+  EXPECT_FALSE(BuildMetaAckKey("sitos", "bad/uuid"));
+}
+
+// --- incoming-key parser (docs/03 §1.1, inverse of Build*) ---
+
+TEST(ParseKeyTest, ParsesBaseKey) {
+  auto p = ParseKey("sitos", "sitos/base/recon/fov");
+  ASSERT_TRUE(p.has_value());
+  EXPECT_EQ(p->kind, KeyKind::Base);
+  EXPECT_TRUE(p->sid.empty());
+  EXPECT_TRUE(p->uuid.empty());
+  EXPECT_EQ(p->relative_key, "recon/fov");
+  EXPECT_FALSE(p->is_batch);
+}
+
+TEST(ParseKeyTest, ParsesBaseBatchKey) {
+  auto p = ParseKey("sitos", "sitos/base/$batch");
+  ASSERT_TRUE(p.has_value());
+  EXPECT_EQ(p->kind, KeyKind::Base);
+  EXPECT_TRUE(p->relative_key.empty());
+  EXPECT_TRUE(p->is_batch);
+}
+
+TEST(ParseKeyTest, ParsesSessionKey) {
+  auto p = ParseKey("sitos", "sitos/session/abc-123/recon/fov");
+  ASSERT_TRUE(p.has_value());
+  EXPECT_EQ(p->kind, KeyKind::Session);
+  EXPECT_EQ(p->sid, "abc-123");
+  EXPECT_EQ(p->relative_key, "recon/fov");
+  EXPECT_FALSE(p->is_batch);
+}
+
+TEST(ParseKeyTest, ParsesSessionBatchKey) {
+  auto p = ParseKey("sitos", "sitos/session/abc-123/$batch");
+  ASSERT_TRUE(p.has_value());
+  EXPECT_EQ(p->kind, KeyKind::Session);
+  EXPECT_EQ(p->sid, "abc-123");
+  EXPECT_TRUE(p->relative_key.empty());
+  EXPECT_TRUE(p->is_batch);
+}
+
+TEST(ParseKeyTest, ParsesSnapshotKey) {
+  auto p = ParseKey("sitos", "sitos/snap/abc-123/recon/fov");
+  ASSERT_TRUE(p.has_value());
+  EXPECT_EQ(p->kind, KeyKind::Snapshot);
+  EXPECT_EQ(p->sid, "abc-123");
+  EXPECT_EQ(p->relative_key, "recon/fov");
+  EXPECT_FALSE(p->is_batch);
+}
+
+TEST(ParseKeyTest, ParsesMetaSession) {
+  auto p = ParseKey("sitos", "sitos/meta/session/abc-123");
+  ASSERT_TRUE(p.has_value());
+  EXPECT_EQ(p->kind, KeyKind::MetaSession);
+  EXPECT_EQ(p->sid, "abc-123");
+  EXPECT_TRUE(p->relative_key.empty());
+  EXPECT_FALSE(p->is_batch);
+}
+
+TEST(ParseKeyTest, ParsesMetaAck) {
+  auto p = ParseKey("sitos", "sitos/meta/ack/550e8400-e29b-41d4-a716-446655440000");
+  ASSERT_TRUE(p.has_value());
+  EXPECT_EQ(p->kind, KeyKind::MetaAck);
+  EXPECT_EQ(p->uuid, "550e8400-e29b-41d4-a716-446655440000");
+  EXPECT_TRUE(p->relative_key.empty());
+  EXPECT_FALSE(p->is_batch);
+}
+
+TEST(ParseKeyTest, ParsesWithCustomPrefix) {
+  auto p = ParseKey("my/app", "my/app/base/recon/fov");
+  ASSERT_TRUE(p.has_value());
+  EXPECT_EQ(p->kind, KeyKind::Base);
+  EXPECT_EQ(p->relative_key, "recon/fov");
+}
+
+TEST(ParseKeyTest, RejectsPrefixMismatchAndBarePrefix) {
+  EXPECT_FALSE(ParseKey("sitos", "other/base/recon/fov"));  // wrong prefix
+  EXPECT_FALSE(ParseKey("sitos", "sitos"));                 // prefix only
+  EXPECT_FALSE(ParseKey("sitos", "sitos/base"));            // base with no key
+  EXPECT_FALSE(ParseKey("sitos", "sitos/session/abc"));     // session/sid with no key
+  EXPECT_FALSE(ParseKey("sitos", "sitos/snap/abc"));        // snap/sid with no key
+}
+
+TEST(ParseKeyTest, RejectsInvalidKinds) {
+  EXPECT_FALSE(ParseKey("sitos", "sitos/unknown/recon/fov"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/meta/unknown/abc"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/meta/session/bad sid"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/meta/ack/bad/uuid"));
+}
+
+TEST(ParseKeyTest, RejectsSnapshotBatch) {
+  // snap has no $batch path; $ fails IsValidKey so the parse is rejected.
+  EXPECT_FALSE(ParseKey("sitos", "sitos/snap/abc-123/$batch"));
+}
+
+TEST(ParseKeyTest, RejectsInvalidRelativeKey) {
+  EXPECT_FALSE(ParseKey("sitos", "sitos/base/recon*fov"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/base/recon//fov"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/session/abc-123/recon$fov"));
+}
+
+// AC #2: round-trip build -> parse returns the original components.
+TEST(KeyRoundTripTest, BuildThenParseRecoversBase) {
+  auto built = BuildKey("sitos", "base", "recon/fov");
+  ASSERT_TRUE(built.has_value());
+  auto p = ParseKey("sitos", *built);
+  ASSERT_TRUE(p.has_value());
+  EXPECT_EQ(p->kind, KeyKind::Base);
+  EXPECT_EQ(p->relative_key, "recon/fov");
+  EXPECT_FALSE(p->is_batch);
+}
+
+TEST(KeyRoundTripTest, BuildThenParseRecoversSession) {
+  auto built = BuildKey("sitos", "session/abc-123", "recon/fov");
+  ASSERT_TRUE(built.has_value());
+  auto p = ParseKey("sitos", *built);
+  ASSERT_TRUE(p.has_value());
+  EXPECT_EQ(p->kind, KeyKind::Session);
+  EXPECT_EQ(p->sid, "abc-123");
+  EXPECT_EQ(p->relative_key, "recon/fov");
+}
+
+TEST(KeyRoundTripTest, BuildThenParseRecoversSnapshot) {
+  auto built = BuildKey("sitos", "snap/abc-123", "recon/fov");
+  ASSERT_TRUE(built.has_value());
+  auto p = ParseKey("sitos", *built);
+  ASSERT_TRUE(p.has_value());
+  EXPECT_EQ(p->kind, KeyKind::Snapshot);
+  EXPECT_EQ(p->sid, "abc-123");
+  EXPECT_EQ(p->relative_key, "recon/fov");
+  EXPECT_FALSE(p->is_batch);
+}
+
+TEST(KeyRoundTripTest, BuildThenParseRecoversBatch) {
+  auto built = BuildBatchKey("sitos", "base");
+  ASSERT_TRUE(built.has_value());
+  auto p = ParseKey("sitos", *built);
+  ASSERT_TRUE(p.has_value());
+  EXPECT_EQ(p->kind, KeyKind::Base);
+  EXPECT_TRUE(p->is_batch);
+
+  auto built2 = BuildBatchKey("sitos", "session/abc-123");
+  ASSERT_TRUE(built2.has_value());
+  auto p2 = ParseKey("sitos", *built2);
+  ASSERT_TRUE(p2.has_value());
+  EXPECT_EQ(p2->kind, KeyKind::Session);
+  EXPECT_EQ(p2->sid, "abc-123");
+  EXPECT_TRUE(p2->is_batch);
+}
+
+TEST(KeyRoundTripTest, BuildThenParseRecoversMeta) {
+  auto built = BuildMetaSessionKey("sitos", "abc-123");
+  ASSERT_TRUE(built.has_value());
+  auto p = ParseKey("sitos", *built);
+  ASSERT_TRUE(p.has_value());
+  EXPECT_EQ(p->kind, KeyKind::MetaSession);
+  EXPECT_EQ(p->sid, "abc-123");
+
+  const std::string uuid = "550e8400-e29b-41d4-a716-446655440000";
+  auto built2 = BuildMetaAckKey("sitos", uuid);
+  ASSERT_TRUE(built2.has_value());
+  auto p2 = ParseKey("sitos", *built2);
+  ASSERT_TRUE(p2.has_value());
+  EXPECT_EQ(p2->kind, KeyKind::MetaAck);
+  EXPECT_EQ(p2->uuid, uuid);
 }
 
 TEST(KeyTest, InvalidKeysAreRejected) {


### PR DESCRIPTION
## Summary

Closes #5

Implement the user-key grammar, scope parsing, key-expression building, and the
incoming-key parser for the sitos key space (docs/03_wire_protocol.md §1,
docs/02_architecture.md §2).

## Checklist (from #5)

- [x] `include/sitos/key.hpp` + `src/key.cpp`
- [x] User-key validation per the ABNF in `docs/03` §1.2
      (allowed chars, no empty chunks, no leading/trailing `/`,
      reject zenoh-reserved chars `* $ ? # @` and whitespace)
- [x] Session-id validation (`[0-9a-zA-Z_-]+`, single chunk)
- [x] Scope parser: `base` / `session/<sid>` / `snap/<sid>`
- [x] Key-expression builder: `<prefix>/<scope>/<key>`, `$batch` paths,
      `meta/...` paths (configurable prefix, requirement X03)
- [x] Parser for incoming key expressions (the inverse mapping used by
      StorageNode routing): kind (Base/Session/Snapshot/MetaAck/MetaSession),
      sid, relative key, is_batch
- [x] `tests/unit/key_test.cpp` including `InvalidKeysAreRejected`

## API

```cpp
enum class ScopeKind { Base, Session, Snap };
struct Scope { ScopeKind kind; std::string sid; };

enum class KeyKind { Base, Session, Snapshot, MetaSession, MetaAck };
struct ParsedKey {
  KeyKind kind;
  std::string sid;          // Session / Snapshot / MetaSession
  std::string uuid;         // MetaAck
  std::string relative_key; // Base / Session / Snapshot (empty for batch / meta)
  bool is_batch;            // <prefix>/base/$batch or <prefix>/session/<sid>/$batch
};

bool IsValidKey(std::string_view key);
bool IsValidSessionId(std::string_view sid);
bool IsValidPrefix(std::string_view prefix);
bool IsValidAckUuid(std::string_view uuid);
std::optional<Scope>     ParseScope(std::string_view scope);
std::optional<std::string> BuildKey(std::string_view prefix, std::string_view scope,
                                    std::string_view user_key);
std::optional<std::string> BuildBatchKey(std::string_view prefix, std::string_view scope);
std::optional<std::string> BuildMetaSessionKey(std::string_view prefix, std::string_view sid);
std::optional<std::string> BuildMetaAckKey(std::string_view prefix, std::string_view uuid);
std::optional<ParsedKey>  ParseKey(std::string_view prefix, std::string_view full_key);
```

## Design notes

- `$` is a zenoh-reserved character, so `$batch` cannot be produced via
  `BuildKey` (it is rejected by `IsValidKey`). Batch paths are produced only by
  the dedicated `BuildBatchKey`, and only for `base` and `session/<sid>`
  scopes — `snap` has no `$batch` path per `docs/03` §1.1.
- `ParseKey` strips the configured prefix and classifies the remainder. The
  inverse of the Build* functions: build → parse returns the original
  components (AC #2).
- Snap is read-only and has no batch path; `ParseKey` rejects
  `<prefix>/snap/<sid>/$batch`.

## Acceptance Criteria Verification

### AC1 — `InvalidKeysAreRejected` covers reserved chars, empty chunks, bad sid, bad scope

`tests/unit/key_test.cpp::KeyTest.InvalidKeysAreRejected` plus
`KeyValidationTest.Invalid*`, `SessionIdValidationTest.InvalidSessionId`,
`PrefixValidationTest.InvalidPrefix`, `ScopeParserTest.RejectsInvalidScope`,
`BatchKeyBuilderTest.RejectsInvalidBatchScope`, `MetaKeyBuilderTest.RejectsInvalidMeta`,
`ParseKeyTest.Rejects*`.

### AC2 — round-trip build → parse returns original components

`KeyRoundTripTest.*` covers base / session / snapshot / batch (base & session)
/ meta-session / meta-ack round-trips.

### Build verification (3 toolchains)

| Toolchain | Result |
|---|---|
| WSL2 Ubuntu 24.04 (gcc) | 47/47 passed |
| clang-18 + ASan/UBSan | 48/48 passed (UB-clean) |
| Windows MSVC 19.44 + Ninja | 57/57 passed (incl. #4 tests) |

GitHub Actions on this PR: `build-linux` ✅, `build-windows` ✅, CodeQL ✅.

## ADR Needed?

- [x] No. The key space is already specified in `docs/03_wire_protocol.md` §1
  and `docs/02_architecture.md` §2; this implements that specification. No new
  wire or key-space decisions were introduced.

## Notes for review

- Rebased onto `main` (which now contains the merged #4) and folded `key.cpp`
  into the single `sitos` STATIC library, removing the separate `sitos_internal`
  target introduced earlier in this branch — this keeps the library design
  consistent with #4.
- The per-target `sitos_enable_warnings` helper (from #4) is now applied to
  `sitos_key_test` (was missing), and the public header `key.hpp` uses the
  `#ifndef` include guard and `sitos contributors` copyright used by the rest
  of the public headers.
- CodeRabbit nitpick on `BuildKey` calling `ParseScope(scope).has_value()` and
  discarding the result: intentionally kept. `ParseScope` is the single source
  of truth for scope validity; the `std::string sid` allocation only happens
  for valid `session/<sid>` / `snap/<sid>` scopes (and usually stays in SSO),
  so a separate non-allocating `IsValidScope` would duplicate the prefix-matching
  logic for negligible gain. `BuildKey` is an API call site, not a per-byte hot
  loop.