### PR TITLE
docs: update branch naming convention from issue/ to feat/ (#44)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ project.
 ## Absolute Rules (Summary)
 
 1. **One issue, one branch, one PR**: branch name
-   `issue/<n>-<short-kebab-description>`, PR body contains `Closes #<n>`.
+   `feat/<n>-<short-kebab-description>`, PR body contains `Closes #<n>`.
 2. **TDD**: write the AC tests first and confirm RED before implementation.
    Record the RED-phase failure output in the PR description.
 3. **Conventional Commits**: header line

--- a/docs/development_workflow.md
+++ b/docs/development_workflow.md
@@ -20,8 +20,8 @@ main ─────●───────●───────●───
   changes go only through PRs
 * Working branches are **short-lived** (guideline: 1 issue = 1 branch = 1 PR,
   within a few days)
-* Branch name: `issue/<number>-<short-kebab-description>`
-  (example: `issue/3-param-value-codec`)
+* Branch name: `feat/<number>-<short-kebab-description>`
+  (example: `feat/3-param-value-codec`)
 * Releases are tags on main (`v0.1.0`, etc.). Do not create release branches
   until a hotfix is needed
 * Do not create long-lived develop / feature branches


### PR DESCRIPTION
Closes #44

## Changes

- `docs/development_workflow.md` §1: branch name rule changed from `issue/<number>-...` to `feat/<number>-...`
- `AGENTS.md`: absolute rules summary updated accordingly

## Verification

```bash
git grep "issue/<" -- docs/ AGENTS.md
# no output
```

## Scope note

`docs/07_issue_breakdown.md` does not contain branch-name examples, so no changes were needed there.
