### PR TITLE
chore(core): address SonarCloud maintainability findings (#53)

### DIFF
--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -50,7 +50,7 @@ std::vector<std::byte> EncodeBatch(std::span<const std::pair<std::string, ParamV
 std::optional<std::vector<BatchEntry>> DecodeBatch(std::span<const std::byte> payload) {
   std::size_t off = 0;
   auto count = ReadLeU32(payload, off);
-  if (!count) return std::nullopt;
+  if (!count.has_value()) return std::nullopt;
   // A single entry is at least 4 (kLen) + 0 (key) + 1 (tag) + 4 (vLen) = 9 bytes.
   if (*count > payload.size() / 9 + 1) return std::nullopt;
 
@@ -58,7 +58,7 @@ std::optional<std::vector<BatchEntry>> DecodeBatch(std::span<const std::byte> pa
   result.reserve(std::min<std::size_t>(*count, payload.size()));
   for (std::uint32_t i = 0; i < *count; ++i) {
     auto k_len = ReadLeU32(payload, off);
-    if (!k_len) return std::nullopt;
+    if (!k_len.has_value()) return std::nullopt;
     // Use remaining-capacity form to avoid unsigned wraparound on `off + *k_len`.
     if (*k_len > payload.size() - off) return std::nullopt;
     std::string key(reinterpret_cast<const char*>(payload.data() + off), *k_len);
@@ -69,7 +69,7 @@ std::optional<std::vector<BatchEntry>> DecodeBatch(std::span<const std::byte> pa
     off += 1;
 
     auto v_len = ReadLeU32(payload, off);
-    if (!v_len) return std::nullopt;
+    if (!v_len.has_value()) return std::nullopt;
     // Same remaining-capacity form for `off + *v_len`.
     if (*v_len > payload.size() - off) return std::nullopt;
 

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -89,13 +89,13 @@ std::optional<Scope> ParseScope(std::string_view scope) {
   constexpr std::string_view kSessionPrefix = "session/";
   constexpr std::string_view kSnapPrefix = "snap/";
   if (scope.size() > kSessionPrefix.size() &&
-      scope.substr(0, kSessionPrefix.size()) == kSessionPrefix) {
+      scope.starts_with(kSessionPrefix)) {
     std::string_view sid = scope.substr(kSessionPrefix.size());
     if (IsValidSessionId(sid)) {
       return Scope{ScopeKind::Session, std::string(sid)};
     }
   }
-  if (scope.size() > kSnapPrefix.size() && scope.substr(0, kSnapPrefix.size()) == kSnapPrefix) {
+  if (scope.size() > kSnapPrefix.size() && scope.starts_with(kSnapPrefix)) {
     std::string_view sid = scope.substr(kSnapPrefix.size());
     if (IsValidSessionId(sid)) {
       return Scope{ScopeKind::Snap, std::string(sid)};
@@ -136,7 +136,7 @@ std::optional<std::string> BuildBatchKey(std::string_view prefix, std::string_vi
   }
   constexpr std::string_view kSessionPrefix = "session/";
   if (scope.size() > kSessionPrefix.size() &&
-      scope.substr(0, kSessionPrefix.size()) == kSessionPrefix) {
+      scope.starts_with(kSessionPrefix)) {
     std::string_view sid = scope.substr(kSessionPrefix.size());
     if (!IsValidSessionId(sid)) {
       return std::nullopt;
@@ -192,7 +192,7 @@ std::optional<std::string_view> StripPrefix(std::string_view prefix, std::string
   if (full_key.size() <= prefix.size() || full_key[prefix.size()] != '/') {
     return std::nullopt;
   }
-  if (full_key.substr(0, prefix.size()) != prefix) {
+  if (!full_key.starts_with(prefix)) {
     return std::nullopt;
   }
   return full_key.substr(prefix.size() + 1);

--- a/src/param_value.cpp
+++ b/src/param_value.cpp
@@ -5,6 +5,7 @@
 
 #include "sitos/param_value.hpp"
 
+#include <array>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
@@ -22,9 +23,9 @@ void AppendLeU64(std::uint64_t u, std::vector<std::byte>& out) {
 
 // Canonical quiet-NaN body bytes (docs/03 §2.3 dp_nan). Already in LE order.
 // Corresponds to the bit pattern 0x7ff8000000000000.
-constexpr std::byte kCanonicalNanBody[8] = {std::byte{0x00}, std::byte{0x00}, std::byte{0x00},
-                                            std::byte{0x00}, std::byte{0x00}, std::byte{0x00},
-                                            std::byte{0xf8}, std::byte{0x7f}};
+constexpr std::array<std::byte, 8> kCanonicalNanBody = {
+    std::byte{0x00}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00},
+    std::byte{0x00}, std::byte{0x00}, std::byte{0xf8}, std::byte{0x7f}};
 
 }  // namespace
 
@@ -45,7 +46,7 @@ std::vector<std::byte> ParamValue::EncodeBody() const {
     case 2: {  // DP (normalize NaN to canonical pattern)
       double d = std::get<double>(value_);
       if (std::isnan(d)) {
-        body.insert(body.end(), kCanonicalNanBody, kCanonicalNanBody + sizeof(kCanonicalNanBody));
+        body.insert(body.end(), kCanonicalNanBody.begin(), kCanonicalNanBody.end());
       } else {
         std::uint64_t u = 0;
         std::memcpy(&u, &d, sizeof(u));

--- a/src/param_value.cpp
+++ b/src/param_value.cpp
@@ -65,6 +65,8 @@ std::vector<std::byte> ParamValue::EncodeBody() const {
       body.insert(body.end(), b.begin(), b.end());
       break;
     }
+    default:
+      break;  // Unreachable: variant holds one of the 5 documented types.
   }
   return body;
 }


### PR DESCRIPTION
Closes #53

## Summary

SonarCloud reports 41 OPEN issues on the v0.1 codebase. After judgment, 9 are addressed (4 rules); 32 are skipped with documented rationale.

## Scope — addressed (4 commits)

- [x] cpp:S6178 (4): `starts_with()` in `src/key.cpp` (lines 92, 98, 139, 195)
- [x] cpp:S7172 (3): `.has_value()` in `src/batch.cpp` (lines 53, 61, 72)
- [x] cpp:S5945 (1): `std::array` for NaN body in `src/param_value.cpp` (line 25)
- [x] cpp:S3562 (1): `default` case in `EncodeBody` switch in `src/param_value.cpp`

## Skipped (32 issues)

- cpp:S7035 (7): `std::to_underlying` is C++23-only
- cpp:S6181 (4): `std::bit_cast` unnecessary; `memcpy` idiomatic
- cpp:S6032 (4): `string_view` by-value is appropriate
- cpp:S3776+S134 (4): CRITICAL complexity in `ParseKey` — separate refactor issue
- cpp:S6022 (2): `std::byte` arithmetic needs integer casts
- cpp:S3630 (1): `reinterpret_cast` in `AsSpan` unavoidable, guarded
- cpp:S5827/S6003/S6000/S6004/S5566 (9): style/readability tradeoffs, current code clearer
- python lock file (1): v0.3 scope

## AC verification

- Local build + test (MSVC + Ninja): **87/87 tests pass**
- No behavioral change; no C++23 APIs

## RED phase

N/A — refactor only, no new tests.

## ADR needed?

No.