### PR TITLE
feat(transport): add zenoh-c build integration and smoke test (#2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build
+          sudo apt-get install -y cmake ninja-build libssl-dev
 
       - name: Configure
         run: cmake --preset dev-linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,21 @@ option(SITOS_BUILD_PYTHON "Build Python bindings" OFF)
 option(SITOS_BUILD_TESTS "Build tests" ON)
 option(SITOS_BUILD_EXAMPLES "Build examples" OFF)
 
+# --- zenoh-c build integration ---
+# Only required when building tests or examples that use the transport layer.
+option(SITOS_WITH_ZENOH "Download and link prebuilt zenoh-c" OFF)
+
+if(SITOS_WITH_ZENOH)
+  include(cmake/zenohc.cmake)
+endif()
+
 # Scoped warning flags. Applied per-target (not globally) so vendored deps
 # such as GoogleTest (FetchContent) are not pinned to -Werror and break on a
 # new compiler warning. Callers of sitos get the flags only via PUBLIC when they
 # compile sitos headers; that is fine because sitos headers are warning-clean.
 function(sitos_enable_warnings target)
   if(MSVC)
-    target_compile_options(${target} PRIVATE /W4 /WX /utf-8)
+    target_compile_options(${target} PRIVATE /W4 /WX /utf-8 /EHsc)
   else()
     target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic -Werror)
   endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,7 +8,8 @@
       "binaryDir": "${sourceDir}/build/dev-linux",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "SITOS_BUILD_TESTS": "ON"
+        "SITOS_BUILD_TESTS": "ON",
+        "SITOS_WITH_ZENOH": "ON"
       }
     },
     {
@@ -18,7 +19,8 @@
       "binaryDir": "${sourceDir}/build/dev-windows",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "SITOS_BUILD_TESTS": "ON"
+        "SITOS_BUILD_TESTS": "ON",
+        "SITOS_WITH_ZENOH": "ON"
       }
     },
     {

--- a/cmake/zenohc.cmake
+++ b/cmake/zenohc.cmake
@@ -16,19 +16,16 @@ set(ZENOHC_ARCHIVE "zenoh-c-${ZENOHC_VERSION}-${ZENOHC_PLATFORM}-standalone.zip"
 set(ZENOHC_URL "https://github.com/eclipse-zenoh/zenoh-c/releases/download/${ZENOHC_VERSION}/${ZENOHC_ARCHIVE}")
 
 include(FetchContent)
-# FetchContent_Populate is used because zenoh-c standalone does not provide a
-# CMakeLists.txt; we only need the extracted archive.
-cmake_policy(SET CMP0169 OLD)
+# zenoh-c standalone has no CMakeLists.txt; MakeAvailable populates the archive
+# and, on encountering no CMakeLists.txt at the source directory, does not call
+# add_subdirectory() — so no CMakeLists.txt is required.
 FetchContent_Declare(
   zenohc
   URL ${ZENOHC_URL}
   SOURCE_DIR ${CMAKE_BINARY_DIR}/_deps/zenohc-src
   DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
-FetchContent_GetProperties(zenohc)
-if(NOT zenohc_POPULATED)
-  FetchContent_Populate(zenohc)
-endif()
+FetchContent_MakeAvailable(zenohc)
 
 # Paths resolved after Populate (zenohc_SOURCE_DIR is set by Populate).
 set(ZENOHC_INCLUDE_DIR "${zenohc_SOURCE_DIR}/include")

--- a/cmake/zenohc.cmake
+++ b/cmake/zenohc.cmake
@@ -1,0 +1,65 @@
+# cmake/zenohc.cmake — Download prebuilt zenoh-c standalone package and create
+# an imported target.
+#
+# Pinned zenoh-c version. Update this when upgrading the locked default.
+set(ZENOHC_VERSION "1.9.0")
+
+# Detect platform and set the archive name.
+if(WIN32)
+  set(ZENOHC_PLATFORM "x86_64-pc-windows-msvc")
+elseif(APPLE)
+  set(ZENOHC_PLATFORM "x86_64-apple-darwin")
+else()
+  set(ZENOHC_PLATFORM "x86_64-unknown-linux-gnu")
+endif()
+set(ZENOHC_ARCHIVE "zenoh-c-${ZENOHC_VERSION}-${ZENOHC_PLATFORM}-standalone.zip")
+set(ZENOHC_URL "https://github.com/eclipse-zenoh/zenoh-c/releases/download/${ZENOHC_VERSION}/${ZENOHC_ARCHIVE}")
+
+include(FetchContent)
+# FetchContent_Populate is used because zenoh-c standalone does not provide a
+# CMakeLists.txt; we only need the extracted archive.
+cmake_policy(SET CMP0169 OLD)
+FetchContent_Declare(
+  zenohc
+  URL ${ZENOHC_URL}
+  SOURCE_DIR ${CMAKE_BINARY_DIR}/_deps/zenohc-src
+  DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+)
+FetchContent_GetProperties(zenohc)
+if(NOT zenohc_POPULATED)
+  FetchContent_Populate(zenohc)
+endif()
+
+# Paths resolved after Populate (zenohc_SOURCE_DIR is set by Populate).
+set(ZENOHC_INCLUDE_DIR "${zenohc_SOURCE_DIR}/include")
+set(ZENOHC_LIB_DIR "${zenohc_SOURCE_DIR}/lib")
+
+# Create imported library target.
+if(WIN32)
+  add_library(zenohc::zenohc SHARED IMPORTED)
+  set_target_properties(zenohc::zenohc PROPERTIES
+    IMPORTED_LOCATION "${zenohc_SOURCE_DIR}/bin/zenohc.dll"
+    IMPORTED_IMPLIB   "${ZENOHC_LIB_DIR}/zenohc.dll.lib"
+  )
+  target_link_libraries(zenohc::zenohc INTERFACE ws2_32 iphlpapi userenv bcrypt)
+else()
+  add_library(zenohc::zenohc SHARED IMPORTED)
+  set_target_properties(zenohc::zenohc PROPERTIES
+    IMPORTED_LOCATION "${ZENOHC_LIB_DIR}/libzenohc.so"
+  )
+endif()
+
+target_include_directories(zenohc::zenohc INTERFACE "${ZENOHC_INCLUDE_DIR}")
+
+# Helper: copy the zenohc shared library alongside a test executable so it can
+# be found at runtime on Windows. On Linux, LD_LIBRARY_PATH is handled via the
+# ctest environment.
+function(sitos_copy_zenohc target)
+  if(WIN32)
+    add_custom_command(TARGET ${target} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${zenohc_SOURCE_DIR}/bin/zenohc.dll"
+        "$<TARGET_FILE_DIR:${target}>"
+    )
+  endif()
+endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,3 +42,15 @@ target_link_libraries(sitos_in_memory_engine_test
   PRIVATE GTest::gtest_main sitos::sitos)
 sitos_enable_warnings(sitos_in_memory_engine_test)
 gtest_discover_tests(sitos_in_memory_engine_test)
+
+# --- Zenoh smoke test (integration) ---
+if(SITOS_WITH_ZENOH)
+  add_executable(sitos_zenoh_smoke_test
+    integration/zenoh_smoke_test.cpp)
+  target_link_libraries(sitos_zenoh_smoke_test
+    PRIVATE GTest::gtest_main zenohc::zenohc)
+  # Do NOT apply sitos_enable_warnings: the zenoh C header may trigger warnings
+  # under -Werror that we cannot fix.
+  sitos_copy_zenohc(sitos_zenoh_smoke_test)
+  gtest_discover_tests(sitos_zenoh_smoke_test)
+endif()

--- a/tests/integration/zenoh_smoke_test.cpp
+++ b/tests/integration/zenoh_smoke_test.cpp
@@ -1,0 +1,30 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Smoke test: opens and closes a zenoh session to verify the build integration.
+
+#ifdef _MSC_VER
+#pragma warning(push, 0)
+#endif
+#include <zenoh.h>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+#include <gtest/gtest.h>
+
+namespace {
+
+TEST(ZenohSmokeTest, OpenAndCloseSession) {
+  z_owned_config_t config;
+  ASSERT_EQ(z_config_default(&config), Z_OK);
+
+  z_owned_session_t session;
+  ASSERT_EQ(z_open(&session, z_move(config), nullptr), Z_OK);
+
+  ASSERT_EQ(z_close(z_session_loan_mut(&session), nullptr), Z_OK);
+
+  z_drop(z_move(session));
+}
+
+}  // namespace


### PR DESCRIPTION
Closes #2

## Summary

Adds zenoh-c prebuilt download integration via FetchContent, a smoke test that opens/closes a zenoh session, and CI updates.

## Scope

- [x] `cmake/zenohc.cmake`: download zenoh-c 1.9.0 standalone, create `zenohc::zenohc` target
- [x] `SITOS_WITH_ZENOH` option (ON in dev presets, OFF by default)
- [x] Smoke test: `tests/integration/zenoh_smoke_test.cpp` (open + close session)
- [x] CI: install `libssl-dev` on Linux; Windows links `ws2_32 iphlpapi userenv bcrypt`
- [x] Explicit `/EHsc` for MSVC (CMake 4.3 compatibility)

## AC verification

- Local build + test (MSVC + Ninja): **88/88 tests pass** (87 existing + 1 new zenoh smoke test)
- Zenoh smoke test opens and closes a zenoh session successfully

## RED phase

N/A — build integration, no production code to test-fail against.

## ADR needed?

No — zenoh version pin (1.9.0) is within [09_dependency_policy.md](docs/09_dependency_policy.md) §2 range (zenoh >= 1.0, < 2.0). This is a build tooling change, not a wire/protocol change.

## Dependencies

- #1 (closed) — repository skeleton and CI