### PR TITLE
feat(transport): add Transport abstraction and ZenohTransport impl (#3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,12 @@ jobs:
     # confined to src/transport/. Fail if any source file outside that
     # directory includes a zenoh header.
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Verify zenoh headers are confined to src/transport/
         # Acceptance criterion #2 for issue #3: library code (include/ and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,30 @@ on:
     branches: [main]
 
 jobs:
+  transport-isolation:
+    # Acceptance criterion #2 for issue #3: the raw zenoh-c API must stay
+    # confined to src/transport/. Fail if any source file outside that
+    # directory includes a zenoh header.
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Verify zenoh headers are confined to src/transport/
+        # Acceptance criterion #2 for issue #3: library code (include/ and
+        # src/) must not depend on raw zenoh headers except in src/transport/.
+        # Tests may use raw zenoh directly for build-integration smoke checks.
+        run: |
+          set -e
+          matches=$(grep -rnE '^[[:space:]]*#include.*zenoh' \
+                    --include='*.cpp' --include='*.hpp' --include='*.h' --include='*.cc' \
+                    include src | grep -v '^src/transport/' || true)
+          if [ -n "$matches" ]; then
+            echo "::error::Raw zenoh includes found in library code outside src/transport/:"
+            echo "$matches"
+            exit 1
+          fi
+          echo "OK: no zenoh includes in library code outside src/transport/"
+
   build-linux:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/dependency-upgrade.yml
+++ b/.github/workflows/dependency-upgrade.yml
@@ -22,12 +22,13 @@ on:
         required: false
 
 # Least-privilege token: this workflow only reads the repo to build and test.
-permissions:
-  contents: read
+# Declared per job (S8264) rather than at workflow level.
 
 jobs:
   resolve-versions:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     outputs:
       minimum: '1.9.0'
       latest: ${{ steps.latest.outputs.version }}
@@ -48,6 +49,8 @@ jobs:
   test:
     needs: resolve-versions
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dependency-upgrade.yml
+++ b/.github/workflows/dependency-upgrade.yml
@@ -21,6 +21,10 @@ on:
         description: 'zenoh-c version to test as "latest stable" (default: resolve from GitHub releases)'
         required: false
 
+# Least-privilege token: this workflow only reads the repo to build and test.
+permissions:
+  contents: read
+
 jobs:
   resolve-versions:
     runs-on: ubuntu-24.04

--- a/.github/workflows/dependency-upgrade.yml
+++ b/.github/workflows/dependency-upgrade.yml
@@ -30,19 +30,35 @@ jobs:
     permissions:
       contents: read
     outputs:
-      minimum: '1.9.0'
+      minimum: ${{ steps.minimum.outputs.version }}
       latest: ${{ steps.latest.outputs.version }}
     steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Resolve minimum supported zenoh-c version
+        id: minimum
+        run: |
+          version=$(sed -nE 's/^set\(ZENOHC_VERSION "([^"]+)".*/\1/p' cmake/zenohc.cmake)
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Resolve latest stable zenoh-c version
         id: latest
+        env:
+          ZENOH_VERSION_INPUT: ${{ github.event.inputs.zenoh_version }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          if [ -n "${{ github.event.inputs.zenoh_version }}" ]; then
-            version="${{ github.event.inputs.zenoh_version }}"
+          if [ -n "$ZENOH_VERSION_INPUT" ]; then
+            version="$ZENOH_VERSION_INPUT"
           else
             version=$(curl -fsSL \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
               https://api.github.com/repos/eclipse-zenoh/zenoh-c/releases/latest \
               | jq -r .tag_name)
           fi
+          test "$version" != "null"
           echo "Resolved latest stable zenoh-c: $version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
@@ -61,6 +77,8 @@ jobs:
             version: ${{ needs.resolve-versions.outputs.latest }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -68,7 +86,9 @@ jobs:
           sudo apt-get install -y cmake ninja-build libssl-dev
 
       - name: Configure (zenoh-c ${{ matrix.label }} = ${{ matrix.version }})
-        run: cmake --preset dev-linux -DZENOHC_VERSION=${{ matrix.version }}
+        env:
+          ZENOHC_VERSION: ${{ matrix.version }}
+        run: cmake --preset dev-linux -DZENOHC_VERSION="$ZENOHC_VERSION"
 
       - name: Build
         run: cmake --build --preset dev-linux

--- a/.github/workflows/dependency-upgrade.yml
+++ b/.github/workflows/dependency-upgrade.yml
@@ -1,0 +1,73 @@
+# Dependency Upgrade CI — Acceptance criterion #3 for issue #3.
+#
+# Runs the build and tests against both the minimum supported zenoh-c version
+# and the latest stable release, on manual dispatch and nightly. See
+# docs/09_dependency_policy.md §4.2 for the policy.
+#
+# If the latest stable fails, do NOT break main (the locked default in
+# cmake/zenohc.cmake stays put). Open an issue labeled
+# `dependency: zenoh-upgrade` to track the fix, which should be limited to
+# src/transport/zenoh_transport.cpp and build/CI configuration.
+
+name: Dependency Upgrade
+
+on:
+  schedule:
+    # Nightly at 03:00 UTC.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      zenoh_version:
+        description: 'zenoh-c version to test as "latest stable" (default: resolve from GitHub releases)'
+        required: false
+
+jobs:
+  resolve-versions:
+    runs-on: ubuntu-24.04
+    outputs:
+      minimum: '1.9.0'
+      latest: ${{ steps.latest.outputs.version }}
+    steps:
+      - name: Resolve latest stable zenoh-c version
+        id: latest
+        run: |
+          if [ -n "${{ github.event.inputs.zenoh_version }}" ]; then
+            version="${{ github.event.inputs.zenoh_version }}"
+          else
+            version=$(curl -fsSL \
+              https://api.github.com/repos/eclipse-zenoh/zenoh-c/releases/latest \
+              | jq -r .tag_name)
+          fi
+          echo "Resolved latest stable zenoh-c: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  test:
+    needs: resolve-versions
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: minimum-supported
+            version: ${{ needs.resolve-versions.outputs.minimum }}
+          - label: latest-stable
+            version: ${{ needs.resolve-versions.outputs.latest }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build libssl-dev
+
+      - name: Configure (zenoh-c ${{ matrix.label }} = ${{ matrix.version }})
+        run: cmake --preset dev-linux -DZENOHC_VERSION=${{ matrix.version }}
+
+      - name: Build
+        run: cmake --build --preset dev-linux
+
+      - name: Test
+        run: ctest --preset dev-linux
+
+      - name: Fixture validator
+        run: python tests/fixtures/validate_fixtures.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,11 @@ target_include_directories(sitos PUBLIC
 target_compile_features(sitos PUBLIC cxx_std_20)
 sitos_enable_warnings(sitos)
 
+if(SITOS_WITH_ZENOH)
+  target_sources(sitos PRIVATE src/transport/zenoh_transport.cpp)
+  target_link_libraries(sitos PUBLIC zenohc::zenohc)
+endif()
+
 if(SITOS_BUILD_TESTS)
   enable_testing()
   add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ sitos_enable_warnings(sitos)
 
 if(SITOS_WITH_ZENOH)
   target_sources(sitos PRIVATE src/transport/zenoh_transport.cpp)
-  target_link_libraries(sitos PUBLIC zenohc::zenohc)
+  target_link_libraries(sitos PRIVATE zenohc::zenohc)
 endif()
 
 if(SITOS_BUILD_TESTS)

--- a/cmake/zenohc.cmake
+++ b/cmake/zenohc.cmake
@@ -2,7 +2,9 @@
 # an imported target.
 #
 # Pinned zenoh-c version. Update this when upgrading the locked default.
-set(ZENOHC_VERSION "1.9.0")
+# Declared as a CACHE variable so the dependency-upgrade CI can override it
+# with -DZENOHC_VERSION=<version> to test other releases.
+set(ZENOHC_VERSION "1.9.0" CACHE STRING "Pinned zenoh-c standalone version")
 
 # Detect platform and set the archive name.
 if(WIN32)

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -42,7 +42,7 @@ struct TransportSample {
 
 struct TransportQuery {
     std::string keyexpr;
-    void Reply(std::string_view key,
+    Result<void> Reply(std::string_view key,
                std::span<const std::byte> payload,
                Encoding encoding);
 };

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -16,17 +16,17 @@ sitos **owns its wire specification and thinly isolates zenoh as a transport dep
 Initial policy:
 
 ```
-zenoh >= 1.0, < 2.0
+zenoh-c >= 1.9.0, < 2.0
 ```
 
-* sitos v1.x supports the zenoh 1.x series
-* If zenoh 2.x support breaks wire/API compatibility, treat it as sitos v2.0
-* After validation by `dependency-upgrade.yml`, zenoh patch/minor updates are incorporated into
+* sitos v1.x supports zenoh-c 1.9.0 and later compatible 1.x releases
+* If zenoh-c 2.x support breaks wire/API compatibility, treat it as sitos v2.0
+* After validation by `dependency-upgrade.yml`, zenoh-c patch/minor updates are incorporated into
   sitos patch/minor releases
 
 ## 3. Transport adapter
 
-Only the transport adapter uses the zenoh-cpp API directly.
+Only the transport adapter uses the zenoh-c API directly.
 Higher-level components see only the following abstract API.
 
 ```cpp
@@ -100,7 +100,7 @@ This version is fixed per release branch.
 
 `dependency-upgrade.yml` runs the following on nightly / manual triggers:
 
-1. **minimum supported**: the minimum version in the supported range
+1. **minimum supported**: the pinned `ZENOHC_VERSION` in `cmake/zenohc.cmake`
 2. **latest stable**: the latest stable release at execution time
 
 Validation targets:

--- a/include/sitos/transport.hpp
+++ b/include/sitos/transport.hpp
@@ -189,7 +189,7 @@ class Transport {
   /// Declare a queryable that answers queries under keyexpr.
   virtual Queryable DeclareQueryable(
       std::string_view keyexpr,
-      std::function<void(TransportQuery&)> callback) = 0;
+      const std::function<void(TransportQuery&)>& callback) = 0;
 };
 
 }  // namespace sitos

--- a/include/sitos/transport.hpp
+++ b/include/sitos/transport.hpp
@@ -126,7 +126,7 @@ struct TransportQuery {
   TransportQuery(const TransportQuery&) = delete;
   TransportQuery& operator=(const TransportQuery&) = delete;
 
-  void Reply(std::string_view key, std::span<const std::byte> payload,
+  Result<void> Reply(std::string_view key, std::span<const std::byte> payload,
              Encoding encoding);
 
  private:

--- a/include/sitos/transport.hpp
+++ b/include/sitos/transport.hpp
@@ -7,6 +7,7 @@
 #ifndef SITOS_TRANSPORT_HPP
 #define SITOS_TRANSPORT_HPP
 
+#include <cassert>
 #include <chrono>
 #include <functional>
 #include <memory>
@@ -39,10 +40,19 @@ class Result {
   bool IsOk() const { return !error_.has_value(); }
   explicit operator bool() const { return IsOk(); }
 
-  const T& Value() const { return *value_; }
-  T& Value() { return *value_; }
+  const T& Value() const {
+    assert(IsOk());
+    return *value_;
+  }
+  T& Value() {
+    assert(IsOk());
+    return *value_;
+  }
 
-  const std::error_code& Error() const { return *error_; }
+  const std::error_code& Error() const {
+    assert(!IsOk());
+    return *error_;
+  }
 
  private:
   Result() = default;
@@ -67,7 +77,10 @@ class Result<void> {
   bool IsOk() const { return !error_.has_value(); }
   explicit operator bool() const { return IsOk(); }
 
-  const std::error_code& Error() const { return *error_; }
+  const std::error_code& Error() const {
+    assert(!IsOk());
+    return *error_;
+  }
 
  private:
   Result() = default;

--- a/include/sitos/transport.hpp
+++ b/include/sitos/transport.hpp
@@ -40,15 +40,18 @@ class Result {
   bool IsOk() const { return !error_.has_value(); }
   explicit operator bool() const { return IsOk(); }
 
+  /// Requires IsOk().
   const T& Value() const {
     assert(IsOk());
     return *value_;
   }
+  /// Requires IsOk().
   T& Value() {
     assert(IsOk());
     return *value_;
   }
 
+  /// Requires !IsOk().
   const std::error_code& Error() const {
     assert(!IsOk());
     return *error_;
@@ -77,6 +80,7 @@ class Result<void> {
   bool IsOk() const { return !error_.has_value(); }
   explicit operator bool() const { return IsOk(); }
 
+  /// Requires !IsOk().
   const std::error_code& Error() const {
     assert(!IsOk());
     return *error_;
@@ -109,20 +113,22 @@ struct TransportSample {
   enum class Kind { Put, Delete };
 
   std::string key;
+  /// Non-owning payload valid only for the callback that receives this sample.
   std::span<const std::byte> payload;
   Encoding encoding;
   std::optional<std::string> ack_token;
   Kind kind;
 };
 
-/// A query received from the transport layer. The callback fills in replies.
+/// A query received from the transport layer. It is valid only for the
+/// duration of the queryable callback and must not be retained.
 struct TransportQuery {
   std::string keyexpr;
 
   TransportQuery();
   ~TransportQuery();
-  TransportQuery(TransportQuery&&) noexcept;
-  TransportQuery& operator=(TransportQuery&&) noexcept;
+  TransportQuery(TransportQuery&&) = delete;
+  TransportQuery& operator=(TransportQuery&&) = delete;
   TransportQuery(const TransportQuery&) = delete;
   TransportQuery& operator=(const TransportQuery&) = delete;
 

--- a/include/sitos/transport.hpp
+++ b/include/sitos/transport.hpp
@@ -1,0 +1,204 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Transport abstraction — hides zenoh-specific types and API from the rest of
+// the codebase. See docs/09_dependency_policy.md §3 for the design rationale.
+
+#ifndef SITOS_TRANSPORT_HPP
+#define SITOS_TRANSPORT_HPP
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+namespace sitos {
+
+/// A simple result type that holds either a value or an error code.
+/// Modeled after a minimal subset of std::expected (C++23).
+template <typename T>
+class Result {
+ public:
+  static Result Ok(T value) {
+    Result r;
+    r.value_ = std::move(value);
+    return r;
+  }
+
+  static Result Err(std::error_code ec) {
+    Result r;
+    r.error_ = ec;
+    return r;
+  }
+
+  bool IsOk() const { return !error_.has_value(); }
+  explicit operator bool() const { return IsOk(); }
+
+  const T& Value() const { return *value_; }
+  T& Value() { return *value_; }
+
+  const std::error_code& Error() const { return *error_; }
+
+ private:
+  Result() = default;
+  std::optional<T> value_;
+  std::optional<std::error_code> error_;
+};
+
+template <>
+class Result<void> {
+ public:
+  static Result Ok() {
+    Result r;
+    return r;
+  }
+
+  static Result Err(std::error_code ec) {
+    Result r;
+    r.error_ = ec;
+    return r;
+  }
+
+  bool IsOk() const { return !error_.has_value(); }
+  explicit operator bool() const { return IsOk(); }
+
+  const std::error_code& Error() const { return *error_; }
+
+ private:
+  Result() = default;
+  std::optional<std::error_code> error_;
+};
+
+/// Encoding identifiers used on the wire.
+struct Encoding {
+  /// The well-known encoding for single-value sits payloads.
+  static constexpr std::string_view kSitosV1 = "sitos.v1";
+  /// The well-known encoding for batch sits payloads.
+  static constexpr std::string_view kSitosV1Batch = "sitos.v1.batch";
+
+  std::string id;
+};
+
+/// Options for put/delete operations.
+struct PutOptions {
+  /// When set, the transport will report the ack token back via
+  /// TransportSample::ack_token so that higher layers can confirm delivery.
+  bool ack = false;
+};
+
+/// A sample received from a subscriber or query.
+struct TransportSample {
+  enum class Kind { Put, Delete };
+
+  std::string key;
+  std::span<const std::byte> payload;
+  Encoding encoding;
+  std::optional<std::string> ack_token;
+  Kind kind;
+};
+
+/// A query received from the transport layer. The callback fills in replies.
+struct TransportQuery {
+  std::string keyexpr;
+
+  TransportQuery();
+  ~TransportQuery();
+  TransportQuery(TransportQuery&&) noexcept;
+  TransportQuery& operator=(TransportQuery&&) noexcept;
+  TransportQuery(const TransportQuery&) = delete;
+  TransportQuery& operator=(const TransportQuery&) = delete;
+
+  void Reply(std::string_view key, std::span<const std::byte> payload,
+             Encoding encoding);
+
+ private:
+  friend class ZenohTransport;
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+/// An active subscription handle. The subscription is cancelled when this
+/// object is destroyed.
+class Subscription {
+ public:
+  Subscription();
+  ~Subscription();
+  Subscription(Subscription&& other) noexcept;
+  Subscription& operator=(Subscription&& other) noexcept;
+
+  Subscription(const Subscription&) = delete;
+  Subscription& operator=(const Subscription&) = delete;
+
+ private:
+  friend class ZenohTransport;
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+/// An active queryable handle. The queryable is undeclared when this object
+/// is destroyed.
+class Queryable {
+ public:
+  Queryable();
+  ~Queryable();
+  Queryable(Queryable&& other) noexcept;
+  Queryable& operator=(Queryable&& other) noexcept;
+
+  Queryable(const Queryable&) = delete;
+  Queryable& operator=(const Queryable&) = delete;
+
+ private:
+  friend class ZenohTransport;
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+/// Transport is the abstract interface that hides the underlying pub/sub
+/// library (zenoh). All higher-level components (StorageNode, ParamStore,
+/// ParamCache) depend only on this interface.
+class Transport {
+ public:
+  virtual ~Transport() = default;
+
+  /// Put a value at the given key expression.
+  virtual Result<void> Put(std::string_view key, std::span<const std::byte> payload,
+                           Encoding encoding, PutOptions options) = 0;
+
+  /// Delete the value at the given key expression.
+  virtual Result<void> Delete(std::string_view key, PutOptions options) = 0;
+
+  /// Query results for the given key expression.
+  /// The sink is called once per matching key. Return false from the sink to
+  /// stop early.
+  using QueryResultSink =
+      std::function<bool(std::string_view key, std::span<const std::byte> payload,
+                         Encoding encoding)>;
+  virtual Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
+                           std::chrono::milliseconds timeout) = 0;
+
+  /// Declare a subscriber that receives put/delete samples under keyexpr.
+  virtual Subscription DeclareSubscriber(
+      std::string_view keyexpr,
+      std::function<void(const TransportSample&)> callback) = 0;
+
+  /// Declare a queryable that answers queries under keyexpr.
+  virtual Queryable DeclareQueryable(
+      std::string_view keyexpr,
+      std::function<void(TransportQuery&)> callback) = 0;
+};
+
+}  // namespace sitos
+
+/// Factory function for the default zenoh-based transport.
+/// Defined in src/transport/zenoh_transport.cpp; returns nullptr if the
+/// zenoh session cannot be opened.
+namespace sitos {
+std::unique_ptr<Transport> MakeZenohTransport();
+}  // namespace sitos
+
+#endif  // SITOS_TRANSPORT_HPP

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -239,6 +239,7 @@ class ZenohTransport : public Transport {
   Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
                    std::chrono::milliseconds timeout) override {
     if (!session_valid_) return Result<void>::Err(MakeError(-1));
+    if (timeout.count() < 0) return Result<void>::Err(MakeError(-1));
 
     z_owned_keyexpr_t ke;
     z_result_t ke_rc = z_keyexpr_from_str(&ke, std::string(keyexpr).c_str());

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -115,7 +115,7 @@ struct Subscription::Impl {
 
 Subscription::Subscription() = default;
 Subscription::~Subscription() {
-  z_drop(z_move(impl_->subscriber));
+  if (impl_) z_drop(z_move(impl_->subscriber));
 }
 Subscription::Subscription(Subscription&&) noexcept = default;
 Subscription& Subscription::operator=(Subscription&&) noexcept = default;
@@ -131,7 +131,7 @@ struct Queryable::Impl {
 
 Queryable::Queryable() = default;
 Queryable::~Queryable() {
-  z_drop(z_move(impl_->queryable));
+  if (impl_) z_drop(z_move(impl_->queryable));
 }
 Queryable::Queryable(Queryable&&) noexcept = default;
 Queryable& Queryable::operator=(Queryable&&) noexcept = default;

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -27,9 +27,51 @@ namespace sitos {
 
 namespace {
 
+// Error codes for conditions zenoh-c does not distinguish. These are
+// negative so they never collide with z_result_t values (>= 0).
+//
+// NOTE: full migration to the project "Status" enum (docs/04_api_cpp.md §1)
+// is tracked separately; these named sentinels are an interim improvement
+// over the bare MakeError(-1) magic number.
+enum TransportErrc {
+  kErrDisconnected = -1,  // session not opened or already closed
+  kErrInvalidArg = -2,    // invalid argument (e.g. negative timeout)
+  kErrNoQuery = -3,       // queryable destroyed or query unavailable
+};
+
+// A custom error_category so std::error_code::message() produces meaningful
+// text instead of the platform-dependent generic_category() strings.
+class ZenohErrorCategory : public std::error_category {
+ public:
+  const char* name() const noexcept override { return "sitos.zenoh"; }
+
+  std::string message(int ev) const override {
+    switch (ev) {
+      case kErrDisconnected:
+        return "zenoh session is not available";
+      case kErrInvalidArg:
+        return "invalid argument";
+      case kErrNoQuery:
+        return "query is no longer valid (queryable destroyed)";
+      default:
+        if (ev == Z_OK) return "ok";
+        return "zenoh error code " + std::to_string(ev);
+    }
+  }
+};
+
+const std::error_category& ZenohCategory() {
+  static const ZenohErrorCategory kCategory;
+  return kCategory;
+}
+
 std::error_code MakeError(z_result_t rc) {
   if (rc == Z_OK) return {};
-  return {static_cast<int>(rc), std::generic_category()};
+  return {static_cast<int>(rc), ZenohCategory()};
+}
+
+std::error_code MakeError(TransportErrc ec) {
+  return {static_cast<int>(ec), ZenohCategory()};
 }
 
 struct GetReplyCtx {
@@ -88,7 +130,7 @@ TransportQuery& TransportQuery::operator=(TransportQuery&&) noexcept = default;
 Result<void> TransportQuery::Reply(std::string_view key, std::span<const std::byte> payload,
                            Encoding encoding) {
   if (!impl_ || !impl_->query || !*impl_->query_alive_) {
-    return Result<void>::Err(MakeError(-1));
+    return Result<void>::Err(MakeError(kErrNoQuery));
   }
 
   z_owned_encoding_t z_enc;
@@ -192,7 +234,7 @@ class ZenohTransport : public Transport {
 
   Result<void> Put(std::string_view key, std::span<const std::byte> payload,
                    Encoding encoding, PutOptions /*options*/) override {
-    if (!session_valid_) return Result<void>::Err(MakeError(-1));
+    if (!session_valid_) return Result<void>::Err(MakeError(kErrDisconnected));
 
     z_owned_encoding_t z_enc;
     z_result_t enc_rc = z_encoding_from_str(&z_enc, encoding.id.c_str());
@@ -228,7 +270,7 @@ class ZenohTransport : public Transport {
   }
 
   Result<void> Delete(std::string_view key, PutOptions /*options*/) override {
-    if (!session_valid_) return Result<void>::Err(MakeError(-1));
+    if (!session_valid_) return Result<void>::Err(MakeError(kErrDisconnected));
 
     z_owned_keyexpr_t ke;
     z_result_t ke_rc = z_keyexpr_from_str(&ke, std::string(key).c_str());
@@ -247,8 +289,8 @@ class ZenohTransport : public Transport {
 
   Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
                    std::chrono::milliseconds timeout) override {
-    if (!session_valid_) return Result<void>::Err(MakeError(-1));
-    if (timeout.count() < 0) return Result<void>::Err(MakeError(-1));
+    if (!session_valid_) return Result<void>::Err(MakeError(kErrDisconnected));
+    if (timeout.count() < 0) return Result<void>::Err(MakeError(kErrInvalidArg));
 
     z_owned_keyexpr_t ke;
     z_result_t ke_rc = z_keyexpr_from_str(&ke, std::string(keyexpr).c_str());

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -85,19 +85,21 @@ TransportQuery::~TransportQuery() = default;
 TransportQuery::TransportQuery(TransportQuery&&) noexcept = default;
 TransportQuery& TransportQuery::operator=(TransportQuery&&) noexcept = default;
 
-void TransportQuery::Reply(std::string_view key, std::span<const std::byte> payload,
+Result<void> TransportQuery::Reply(std::string_view key, std::span<const std::byte> payload,
                            Encoding encoding) {
-  if (!impl_ || !impl_->query || !*impl_->query_alive_) return;
+  if (!impl_ || !impl_->query || !*impl_->query_alive_) {
+    return Result<void>::Err(MakeError(-1));
+  }
 
   z_owned_encoding_t z_enc;
   z_result_t enc_rc = z_encoding_from_str(&z_enc, encoding.id.c_str());
-  if (enc_rc != Z_OK) return;
+  if (enc_rc != Z_OK) return Result<void>::Err(MakeError(enc_rc));
 
   z_owned_keyexpr_t ke;
   z_result_t ke_rc = z_keyexpr_from_str(&ke, std::string(key).c_str());
   if (ke_rc != Z_OK) {
     z_drop(z_move(z_enc));
-    return;
+    return Result<void>::Err(MakeError(ke_rc));
   }
 
   z_owned_bytes_t p;
@@ -107,15 +109,19 @@ void TransportQuery::Reply(std::string_view key, std::span<const std::byte> payl
   if (bp_rc != Z_OK) {
     z_drop(z_move(ke));
     z_drop(z_move(z_enc));
-    return;
+    return Result<void>::Err(MakeError(bp_rc));
   }
 
   z_query_reply_options_t opts;
   z_query_reply_options_default(&opts);
   opts.encoding = z_move(z_enc);
 
-  z_query_reply(impl_->query, z_keyexpr_loan(&ke), z_move(p), &opts);
+  z_result_t rc =
+      z_query_reply(impl_->query, z_keyexpr_loan(&ke), z_move(p), &opts);
+
   z_drop(z_move(ke));
+  if (rc != Z_OK) return Result<void>::Err(MakeError(rc));
+  return Result<void>::Ok();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -14,6 +14,7 @@
 
 #include "sitos/transport.hpp"
 
+#include <atomic>
 #include <cstddef>
 #include <string>
 
@@ -32,12 +33,12 @@ std::error_code MakeError(z_result_t rc) {
 
 struct GetReplyCtx {
   const Transport::QueryResultSink* sink;
-  bool stop = false;
+  std::atomic<bool> stop{false};
 };
 
 void OnGetReply(z_loaned_reply_t* reply, void* context) {
   auto* c = static_cast<GetReplyCtx*>(context);
-  if (c->stop) return;
+  if (c->stop.load(std::memory_order_relaxed)) return;
 
   const z_loaned_sample_t* sample = z_reply_ok(reply);
   if (!sample) return;
@@ -62,7 +63,7 @@ void OnGetReply(z_loaned_reply_t* reply, void* context) {
   enc.id = "sitos.v1";
 
   if (!(*c->sink)(key_str, std::span<const std::byte>(data, len), enc)) {
-    c->stop = true;
+    c->stop.store(true, std::memory_order_relaxed);
   }
   z_drop(z_move(slice));
 }

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -97,11 +97,15 @@ class ZenohTransport : public Transport {
   ZenohTransport() {
     z_owned_config_t config;
     z_config_default(&config);
-    z_open(&session_, z_move(config), nullptr);
+    session_valid_ = (z_open(&session_, z_move(config), nullptr) == Z_OK);
   }
 
+  bool IsSessionValid() const { return session_valid_; }
+
   ~ZenohTransport() override {
-    z_close(z_session_loan_mut(&session_), nullptr);
+    if (session_valid_) {
+      z_close(z_session_loan_mut(&session_), nullptr);
+    }
     z_drop(z_move(session_));
   }
 
@@ -113,6 +117,8 @@ class ZenohTransport : public Transport {
     z_owned_bytes_t p;
     z_bytes_copy_from_buf(&p, reinterpret_cast<const uint8_t*>(payload.data()),
                           payload.size());
+
+    if (!session_valid_) return Result<void>::Err(MakeError(-1));
 
     z_put_options_t opts;
     z_put_options_default(&opts);
@@ -128,6 +134,8 @@ class ZenohTransport : public Transport {
   Result<void> Delete(std::string_view key, PutOptions /*options*/) override {
     z_owned_keyexpr_t ke;
     z_keyexpr_from_str(&ke, std::string(key).c_str());
+
+    if (!session_valid_) return Result<void>::Err(MakeError(-1));
 
     z_delete_options_t opts;
     z_delete_options_default(&opts);
@@ -184,6 +192,8 @@ class ZenohTransport : public Transport {
         nullptr,  // drop — Ctx is stack-allocated, no cleanup needed
         &ctx);
 
+    if (!session_valid_) return Result<void>::Err(MakeError(-1));
+
     z_get_options_t opts;
     z_get_options_default(&opts);
 
@@ -208,6 +218,7 @@ class ZenohTransport : public Transport {
       std::function<void(TransportQuery&)> callback) override {
     Queryable q;
     q.impl_ = std::make_unique<Queryable::Impl>();
+    if (!session_valid_) return q;
 
     z_owned_keyexpr_t ke;
     z_keyexpr_from_str(&ke, std::string(keyexpr_str).c_str());
@@ -241,10 +252,13 @@ class ZenohTransport : public Transport {
 
  private:
   z_owned_session_t session_;
+  bool session_valid_ = false;
 };
 
 }  // namespace sitos
 
 std::unique_ptr<sitos::Transport> sitos::MakeZenohTransport() {
-  return std::make_unique<sitos::ZenohTransport>();
+  auto t = std::make_unique<sitos::ZenohTransport>();
+  if (!t->IsSessionValid()) return nullptr;
+  return t;
 }

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -12,12 +12,13 @@
 #pragma warning(pop)
 #endif
 
-#include "sitos/transport.hpp"
-
 #include <atomic>
 #include <cstddef>
 #include <memory>
+#include <mutex>
 #include <string>
+
+#include "sitos/transport.hpp"
 
 namespace sitos {
 
@@ -71,9 +72,7 @@ std::error_code MakeError(z_result_t rc) {
   return {static_cast<int>(rc), ZenohCategory()};
 }
 
-std::error_code MakeError(TransportErrc ec) {
-  return {static_cast<int>(ec), ZenohCategory()};
-}
+std::error_code MakeError(TransportErrc ec) { return {static_cast<int>(ec), ZenohCategory()}; }
 
 // RAII wrapper for any z_owned_*_t. Calls z_drop(z_move(obj)) on destruction
 // and on close of the owning scope, removing the manual z_drop chains that
@@ -88,7 +87,7 @@ class ZenohOwned {
   ZenohOwned(const ZenohOwned&) = delete;
   ZenohOwned& operator=(const ZenohOwned&) = delete;
 
-  ZenohOwned(ZenohOwned&& other) noexcept : obj_(other.obj_) {
+  ZenohOwned(ZenohOwned&& other) noexcept : obj_(other.obj_), moved_(other.moved_) {
     other.moved_ = true;
   }
   ZenohOwned& operator=(ZenohOwned&& other) noexcept {
@@ -106,8 +105,11 @@ class ZenohOwned {
   // Lender: returns a pointer suitable for z_move(obj_out) output parameters.
   T* get() { return &obj_; }
 
-  // Lender: returns a moved handle for APIs that take z_moved_*_t*.
-  auto moved() { return z_move(obj_); }
+  // Transfers ownership to an API that takes z_moved_*_t*.
+  auto moved() {
+    moved_ = true;
+    return z_move(obj_);
+  }
 
   // Loan for APIs that take z_loaned_*_t*.
   auto loan() { return z_loan(obj_); }
@@ -151,8 +153,8 @@ Result<ZenohOwned<z_owned_encoding_t>> MakeEncoding(const Encoding& enc) {
 // Build a z_owned_bytes_t from a byte payload.
 Result<ZenohOwned<z_owned_bytes_t>> MakeBytes(std::span<const std::byte> payload) {
   ZenohOwned<z_owned_bytes_t> p;
-  z_result_t rc = z_bytes_copy_from_buf(
-      p.get(), reinterpret_cast<const uint8_t*>(payload.data()), payload.size());
+  z_result_t rc = z_bytes_copy_from_buf(p.get(), reinterpret_cast<const uint8_t*>(payload.data()),
+                                        payload.size());
   if (rc != Z_OK) {
     return Result<ZenohOwned<z_owned_bytes_t>>::Err(MakeError(rc));
   }
@@ -161,7 +163,9 @@ Result<ZenohOwned<z_owned_bytes_t>> MakeBytes(std::span<const std::byte> payload
 }
 
 struct GetReplyCtx {
-  const Transport::QueryResultSink* sink;
+  explicit GetReplyCtx(const Transport::QueryResultSink& result_sink) : sink(result_sink) {}
+
+  Transport::QueryResultSink sink;
   std::atomic<bool> stop{false};
 };
 
@@ -176,8 +180,7 @@ void OnGetReply(z_loaned_reply_t* reply, void* context) {
   z_owned_slice_t slice;
   z_bytes_to_slice(payload, &slice);
 
-  const auto* data =
-      reinterpret_cast<const std::byte*>(z_slice_data(z_slice_loan(&slice)));
+  const auto* data = reinterpret_cast<const std::byte*>(z_slice_data(z_slice_loan(&slice)));
   auto len = z_slice_len(z_slice_loan(&slice));
 
   z_view_string_t ks;
@@ -191,7 +194,7 @@ void OnGetReply(z_loaned_reply_t* reply, void* context) {
   Encoding enc;
   enc.id = "sitos.v1";
 
-  if (!(*c->sink)(key_str, std::span<const std::byte>(data, len), enc)) {
+  if (!c->sink(key_str, std::span<const std::byte>(data, len), enc)) {
     c->stop.store(true, std::memory_order_relaxed);
   }
   z_drop(z_move(slice));
@@ -203,19 +206,33 @@ void OnGetReply(z_loaned_reply_t* reply, void* context) {
 // TransportQuery
 // ---------------------------------------------------------------------------
 
-struct TransportQuery::Impl {
+namespace {
+
+struct QueryableState {
+  z_owned_queryable_t queryable;
+  std::function<void(TransportQuery&)> callback;
+  std::mutex mutex;
+  bool alive = true;
+};
+
+struct QueryCallbackState {
   const z_loaned_query_t* query = nullptr;
-  std::shared_ptr<bool> query_alive_;
+  std::shared_ptr<QueryableState> queryable;
+  bool active = true;
+};
+
+}  // namespace
+
+struct TransportQuery::Impl {
+  std::shared_ptr<QueryCallbackState> callback_state;
 };
 
 TransportQuery::TransportQuery() = default;
 TransportQuery::~TransportQuery() = default;
-TransportQuery::TransportQuery(TransportQuery&&) noexcept = default;
-TransportQuery& TransportQuery::operator=(TransportQuery&&) noexcept = default;
 
 Result<void> TransportQuery::Reply(std::string_view key, std::span<const std::byte> payload,
-                           Encoding encoding) {
-  if (!impl_ || !impl_->query || !*impl_->query_alive_) {
+                                   Encoding encoding) {
+  if (!impl_ || !impl_->callback_state) {
     return Result<void>::Err(MakeError(TransportErrc::kErrNoQuery));
   }
 
@@ -228,12 +245,22 @@ Result<void> TransportQuery::Reply(std::string_view key, std::span<const std::by
   auto p = MakeBytes(payload);
   if (!p.IsOk()) return Result<void>::Err(p.Error());
 
+  auto callback_state = impl_->callback_state;
+  auto queryable = callback_state->queryable;
+  if (!queryable) return Result<void>::Err(MakeError(TransportErrc::kErrNoQuery));
+
+  // Hold the lock through z_query_reply() so Queryable::~Queryable() cannot
+  // drop the underlying queryable while zenoh uses the loaned query.
+  std::lock_guard<std::mutex> lock(queryable->mutex);
+  if (!callback_state->active || !queryable->alive || !callback_state->query) {
+    return Result<void>::Err(MakeError(TransportErrc::kErrNoQuery));
+  }
+
   z_query_reply_options_t opts;
   z_query_reply_options_default(&opts);
   opts.encoding = enc.Value().moved();
 
-  z_result_t rc =
-      z_query_reply(impl_->query, ke.Value().loan(), p.Value().moved(), &opts);
+  z_result_t rc = z_query_reply(callback_state->query, ke.Value().loan(), p.Value().moved(), &opts);
 
   if (rc != Z_OK) return Result<void>::Err(MakeError(rc));
   return Result<void>::Ok();
@@ -259,19 +286,18 @@ Subscription& Subscription::operator=(Subscription&&) noexcept = default;
 // ---------------------------------------------------------------------------
 
 struct Queryable::Impl {
-  z_owned_queryable_t queryable;
-  std::function<void(TransportQuery&)> callback;
-  // Shared with in-flight TransportQuery callbacks to detect
-  // use-after-destruction. Set to false in ~Queryable() before dropping
-  // the queryable, so any late Reply() call becomes a no-op.
-  std::shared_ptr<bool> query_alive_{std::make_shared<bool>(true)};
+  std::shared_ptr<QueryableState> state{std::make_shared<QueryableState>()};
 };
 
 Queryable::Queryable() = default;
 Queryable::~Queryable() {
   if (impl_) {
-    *impl_->query_alive_ = false;
-    z_drop(z_move(impl_->queryable));
+    auto state = impl_->state;
+    {
+      std::lock_guard<std::mutex> lock(state->mutex);
+      state->alive = false;
+    }
+    z_drop(z_move(state->queryable));
   }
 }
 Queryable::Queryable(Queryable&&) noexcept = default;
@@ -285,7 +311,7 @@ namespace {
 
 bool OpenZenohSession(z_owned_session_t* session) {
   z_owned_config_t config;
-  z_config_default(&config);
+  if (z_config_default(&config) != Z_OK) return false;
   return z_open(session, z_move(config), nullptr) == Z_OK;
 }
 
@@ -293,8 +319,7 @@ bool OpenZenohSession(z_owned_session_t* session) {
 
 class ZenohTransport : public Transport {
  public:
-  ZenohTransport()
-      : session_valid_(OpenZenohSession(&session_)) {}
+  ZenohTransport() : session_valid_(OpenZenohSession(&session_)) {}
 
   bool IsSessionValid() const { return session_valid_; }
 
@@ -305,8 +330,8 @@ class ZenohTransport : public Transport {
     z_drop(z_move(session_));
   }
 
-  Result<void> Put(std::string_view key, std::span<const std::byte> payload,
-                   Encoding encoding, PutOptions /*options*/) override {
+  Result<void> Put(std::string_view key, std::span<const std::byte> payload, Encoding encoding,
+                   PutOptions /*options*/) override {
     if (!session_valid_) return Result<void>::Err(MakeError(TransportErrc::kErrDisconnected));
 
     auto enc = MakeEncoding(encoding);
@@ -322,8 +347,7 @@ class ZenohTransport : public Transport {
     z_put_options_default(&opts);
     opts.encoding = enc.Value().moved();
 
-    z_result_t rc =
-        z_put(z_session_loan(&session_), ke.Value().loan(), p.Value().moved(), &opts);
+    z_result_t rc = z_put(z_session_loan(&session_), ke.Value().loan(), p.Value().moved(), &opts);
 
     if (rc != Z_OK) return Result<void>::Err(MakeError(rc));
     return Result<void>::Ok();
@@ -338,8 +362,7 @@ class ZenohTransport : public Transport {
     z_delete_options_t opts;
     z_delete_options_default(&opts);
 
-    z_result_t rc =
-        z_delete(z_session_loan(&session_), ke.Value().loan(), &opts);
+    z_result_t rc = z_delete(z_session_loan(&session_), ke.Value().loan(), &opts);
 
     if (rc != Z_OK) return Result<void>::Err(MakeError(rc));
     return Result<void>::Ok();
@@ -353,18 +376,18 @@ class ZenohTransport : public Transport {
     auto ke = MakeKeyexpr(keyexpr);
     if (!ke.IsOk()) return Result<void>::Err(ke.Error());
 
-    GetReplyCtx reply_ctx{&sink, false};
+    auto* reply_ctx = new GetReplyCtx(sink);
 
     z_owned_closure_reply_t closure;
-    z_closure_reply(&closure, OnGetReply, nullptr, &reply_ctx);
+    z_closure_reply(
+        &closure, OnGetReply, +[](void* context) { delete static_cast<GetReplyCtx*>(context); },
+        reply_ctx);
 
     z_get_options_t opts;
     z_get_options_default(&opts);
     opts.timeout_ms = static_cast<uint64_t>(timeout.count());
 
-    z_result_t rc =
-        z_get(z_session_loan(&session_), ke.Value().loan(), "",
-              z_move(closure), &opts);
+    z_result_t rc = z_get(z_session_loan(&session_), ke.Value().loan(), "", z_move(closure), &opts);
 
     if (rc != Z_OK) return Result<void>::Err(MakeError(rc));
     return Result<void>::Ok();
@@ -379,9 +402,8 @@ class ZenohTransport : public Transport {
     return {};
   }
 
-  Queryable DeclareQueryable(
-      std::string_view keyexpr_str,
-      const std::function<void(TransportQuery&)>& callback) override {
+  Queryable DeclareQueryable(std::string_view keyexpr_str,
+                             const std::function<void(TransportQuery&)>& callback) override {
     Queryable q;
     q.impl_ = std::make_unique<Queryable::Impl>();
     if (!session_valid_) {
@@ -389,7 +411,7 @@ class ZenohTransport : public Transport {
       return q;
     }
 
-    q.impl_->callback = callback;
+    q.impl_->state->callback = callback;
 
     auto ke = MakeKeyexpr(keyexpr_str);
     if (!ke.IsOk()) {
@@ -397,32 +419,42 @@ class ZenohTransport : public Transport {
       return q;
     }
 
+    auto* context = new std::shared_ptr<QueryableState>(q.impl_->state);
     z_owned_closure_query_t closure;
     z_closure_query(
         &closure,
         +[](z_loaned_query_t* query, void* context) {
-          auto* impl = static_cast<Queryable::Impl*>(context);
+          auto state = *static_cast<std::shared_ptr<QueryableState>*>(context);
+          auto callback_state = std::make_shared<QueryCallbackState>();
+          callback_state->query = query;
+          callback_state->queryable = state;
+
+          {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            if (!state->alive) return;
+          }
+
           TransportQuery tq;
           tq.impl_ = std::make_unique<TransportQuery::Impl>();
-          tq.impl_->query = query;
-          tq.impl_->query_alive_ = impl->query_alive_;
+          tq.impl_->callback_state = callback_state;
 
           z_view_string_t qks;
           z_keyexpr_as_view_string(z_query_keyexpr(query), &qks);
           tq.keyexpr = std::string(z_string_data(z_view_string_loan(&qks)),
                                    z_string_len(z_view_string_loan(&qks)));
 
-          (impl->callback)(tq);
+          state->callback(tq);
+          std::lock_guard<std::mutex> lock(state->mutex);
+          callback_state->active = false;
         },
-        nullptr,  // impl is owned by Queryable::Impl, no cleanup
-        q.impl_.get());
+        +[](void* context) { delete static_cast<std::shared_ptr<QueryableState>*>(context); },
+        context);
 
     z_queryable_options_t q_opts;
     z_queryable_options_default(&q_opts);
 
-    z_result_t decl_rc = z_declare_queryable(
-        z_session_loan(&session_), &q.impl_->queryable,
-        ke.Value().loan(), z_move(closure), &q_opts);
+    z_result_t decl_rc = z_declare_queryable(z_session_loan(&session_), &q.impl_->state->queryable,
+                                             ke.Value().loan(), z_move(closure), &q_opts);
 
     if (decl_rc != Z_OK) {
       q.impl_.reset();
@@ -431,7 +463,7 @@ class ZenohTransport : public Transport {
   }
 
  private:
-  z_owned_session_t session_;
+  z_owned_session_t session_{};
   bool session_valid_ = false;
 };
 

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -16,6 +16,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <memory>
 #include <string>
 
 namespace sitos {
@@ -76,6 +77,7 @@ void OnGetReply(z_loaned_reply_t* reply, void* context) {
 
 struct TransportQuery::Impl {
   const z_loaned_query_t* query = nullptr;
+  std::shared_ptr<bool> query_alive_;
 };
 
 TransportQuery::TransportQuery() = default;
@@ -85,7 +87,7 @@ TransportQuery& TransportQuery::operator=(TransportQuery&&) noexcept = default;
 
 void TransportQuery::Reply(std::string_view key, std::span<const std::byte> payload,
                            Encoding encoding) {
-  if (!impl_ || !impl_->query) return;
+  if (!impl_ || !impl_->query || !*impl_->query_alive_) return;
 
   z_owned_encoding_t z_enc;
   z_result_t enc_rc = z_encoding_from_str(&z_enc, encoding.id.c_str());
@@ -138,11 +140,15 @@ Subscription& Subscription::operator=(Subscription&&) noexcept = default;
 struct Queryable::Impl {
   z_owned_queryable_t queryable;
   std::function<void(TransportQuery&)> callback;
+  std::shared_ptr<bool> query_alive_{std::make_shared<bool>(true)};
 };
 
 Queryable::Queryable() = default;
 Queryable::~Queryable() {
-  if (impl_) z_drop(z_move(impl_->queryable));
+  if (impl_) {
+    *impl_->query_alive_ = false;
+    z_drop(z_move(impl_->queryable));
+  }
 }
 Queryable::Queryable(Queryable&&) noexcept = default;
 Queryable& Queryable::operator=(Queryable&&) noexcept = default;
@@ -286,20 +292,21 @@ class ZenohTransport : public Transport {
     z_closure_query(
         &closure,
         +[](z_loaned_query_t* query, void* context) {
-          auto* f = static_cast<std::function<void(TransportQuery&)>*>(context);
+          auto* impl = static_cast<Queryable::Impl*>(context);
           TransportQuery tq;
           tq.impl_ = std::make_unique<TransportQuery::Impl>();
           tq.impl_->query = query;
+          tq.impl_->query_alive_ = impl->query_alive_;
 
           z_view_string_t qks;
           z_keyexpr_as_view_string(z_query_keyexpr(query), &qks);
           tq.keyexpr = std::string(z_string_data(z_view_string_loan(&qks)),
                                    z_string_len(z_view_string_loan(&qks)));
 
-          (*f)(tq);
+          (impl->callback)(tq);
         },
-        nullptr,  // impl_->callback is owned by Queryable::Impl, no cleanup
-        &q.impl_->callback);
+        nullptr,  // impl is owned by Queryable::Impl, no cleanup
+        q.impl_.get());
 
     z_queryable_options_t q_opts;
     z_queryable_options_default(&q_opts);

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -166,14 +166,14 @@ class ZenohTransport : public Transport {
 
   Result<void> Put(std::string_view key, std::span<const std::byte> payload,
                    Encoding encoding, PutOptions /*options*/) override {
+    if (!session_valid_) return Result<void>::Err(MakeError(-1));
+
     z_owned_keyexpr_t ke;
     z_keyexpr_from_str(&ke, std::string(key).c_str());
 
     z_owned_bytes_t p;
     z_bytes_copy_from_buf(&p, reinterpret_cast<const uint8_t*>(payload.data()),
                           payload.size());
-
-    if (!session_valid_) return Result<void>::Err(MakeError(-1));
 
     z_put_options_t opts;
     z_put_options_default(&opts);
@@ -192,10 +192,10 @@ class ZenohTransport : public Transport {
   }
 
   Result<void> Delete(std::string_view key, PutOptions /*options*/) override {
+    if (!session_valid_) return Result<void>::Err(MakeError(-1));
+
     z_owned_keyexpr_t ke;
     z_keyexpr_from_str(&ke, std::string(key).c_str());
-
-    if (!session_valid_) return Result<void>::Err(MakeError(-1));
 
     z_delete_options_t opts;
     z_delete_options_default(&opts);
@@ -210,6 +210,8 @@ class ZenohTransport : public Transport {
 
   Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
                    std::chrono::milliseconds timeout) override {
+    if (!session_valid_) return Result<void>::Err(MakeError(-1));
+
     z_owned_keyexpr_t ke;
     z_keyexpr_from_str(&ke, std::string(keyexpr).c_str());
 
@@ -217,8 +219,6 @@ class ZenohTransport : public Transport {
 
     z_owned_closure_reply_t closure;
     z_closure_reply(&closure, OnGetReply, nullptr, &reply_ctx);
-
-    if (!session_valid_) return Result<void>::Err(MakeError(-1));
 
     z_get_options_t opts;
     z_get_options_default(&opts);

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -30,6 +30,43 @@ std::error_code MakeError(z_result_t rc) {
   return {static_cast<int>(rc), std::generic_category()};
 }
 
+struct GetReplyCtx {
+  const Transport::QueryResultSink* sink;
+  bool stop = false;
+};
+
+void OnGetReply(z_loaned_reply_t* reply, void* context) {
+  auto* c = static_cast<GetReplyCtx*>(context);
+  if (c->stop) return;
+
+  const z_loaned_sample_t* sample = z_reply_ok(reply);
+  if (!sample) return;
+
+  const z_loaned_bytes_t* payload = z_sample_payload(sample);
+  z_owned_slice_t slice;
+  z_bytes_to_slice(payload, &slice);
+
+  const auto* data =
+      reinterpret_cast<const std::byte*>(z_slice_data(z_slice_loan(&slice)));
+  auto len = z_slice_len(z_slice_loan(&slice));
+
+  z_view_string_t ks;
+  z_keyexpr_as_view_string(z_sample_keyexpr(sample), &ks);
+  std::string key_str(z_string_data(z_view_string_loan(&ks)),
+                      z_string_len(z_view_string_loan(&ks)));
+
+  // TODO(#3): Extract encoding from z_sample_encoding(sample).
+  // zenoh-c 1.9.0 does not expose encoding-to-string conversion;
+  // "sitos.v1" is the only encoding used in v0.1.
+  Encoding enc;
+  enc.id = "sitos.v1";
+
+  if (!(*c->sink)(key_str, std::span<const std::byte>(data, len), enc)) {
+    c->stop = true;
+  }
+  z_drop(z_move(slice));
+}
+
 }  // namespace
 
 // ---------------------------------------------------------------------------
@@ -176,48 +213,10 @@ class ZenohTransport : public Transport {
     z_owned_keyexpr_t ke;
     z_keyexpr_from_str(&ke, std::string(keyexpr).c_str());
 
-    struct Ctx {
-      const QueryResultSink* sink;
-      bool stop = false;
-    };
-    Ctx ctx{&sink, false};
+    GetReplyCtx reply_ctx{&sink, false};
 
     z_owned_closure_reply_t closure;
-    z_closure_reply(
-        &closure,
-        +[](z_loaned_reply_t* reply, void* context) {
-          auto* c = static_cast<Ctx*>(context);
-          if (c->stop) return;
-
-          const z_loaned_sample_t* sample = z_reply_ok(reply);
-          if (!sample) return;
-
-          const z_loaned_bytes_t* payload = z_sample_payload(sample);
-          z_owned_slice_t slice;
-          z_bytes_to_slice(payload, &slice);
-
-          const auto* data =
-              reinterpret_cast<const std::byte*>(z_slice_data(z_slice_loan(&slice)));
-          auto len = z_slice_len(z_slice_loan(&slice));
-
-          z_view_string_t ks;
-          z_keyexpr_as_view_string(z_sample_keyexpr(sample), &ks);
-          std::string key_str(z_string_data(z_view_string_loan(&ks)),
-                              z_string_len(z_view_string_loan(&ks)));
-
-          // TODO(#3): Extract encoding from z_sample_encoding(sample).
-          // zenoh-c 1.9.0 does not expose encoding-to-string conversion;
-          // "sitos.v1" is the only encoding used in v0.1.
-          Encoding enc;
-          enc.id = "sitos.v1";
-
-          if (!(*c->sink)(key_str, std::span<const std::byte>(data, len), enc)) {
-            c->stop = true;
-          }
-          z_drop(z_move(slice));
-        },
-        nullptr,  // drop — Ctx is stack-allocated, no cleanup needed
-        &ctx);
+    z_closure_reply(&closure, OnGetReply, nullptr, &reply_ctx);
 
     if (!session_valid_) return Result<void>::Err(MakeError(-1));
 

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -46,12 +46,13 @@ class ZenohErrorCategory : public std::error_category {
   const char* name() const noexcept override { return "sitos.zenoh"; }
 
   std::string message(int ev) const override {
+    using enum TransportErrc;
     switch (static_cast<TransportErrc>(ev)) {
-      case TransportErrc::kErrDisconnected:
+      case kErrDisconnected:
         return "zenoh session is not available";
-      case TransportErrc::kErrInvalidArg:
+      case kErrInvalidArg:
         return "invalid argument";
-      case TransportErrc::kErrNoQuery:
+      case kErrNoQuery:
         return "query is no longer valid (queryable destroyed)";
       default:
         if (ev == Z_OK) return "ok";

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -266,7 +266,9 @@ class ZenohTransport : public Transport {
   Subscription DeclareSubscriber(
       std::string_view /*keyexpr*/,
       std::function<void(const TransportSample&)> /*callback*/) override {
-    // TODO(#3): implement subscriber
+    // TODO(#3): implement subscriber — currently a stub that silently discards
+    // both keyexpr and callback. The caller receives an empty Subscription
+    // (impl_ == nullptr) that never delivers samples.
     return {};
   }
 

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -116,7 +116,7 @@ class ZenohTransport : public Transport {
   }
 
   Result<void> Put(std::string_view key, std::span<const std::byte> payload,
-                   Encoding /*encoding*/, PutOptions /*options*/) override {
+                   Encoding encoding, PutOptions /*options*/) override {
     z_owned_keyexpr_t ke;
     z_keyexpr_from_str(&ke, std::string(key).c_str());
 
@@ -128,6 +128,11 @@ class ZenohTransport : public Transport {
 
     z_put_options_t opts;
     z_put_options_default(&opts);
+
+    z_owned_encoding_t z_enc;
+    if (z_encoding_from_str(&z_enc, encoding.id.c_str()) == Z_OK) {
+      opts.encoding = z_move(z_enc);
+    }
 
     z_result_t rc =
         z_put(z_session_loan(&session_), z_keyexpr_loan(&ke), z_move(p), &opts);

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -149,7 +149,7 @@ class ZenohTransport : public Transport {
   }
 
   Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
-                   std::chrono::milliseconds /*timeout*/) override {
+                   std::chrono::milliseconds timeout) override {
     z_owned_keyexpr_t ke;
     z_keyexpr_from_str(&ke, std::string(keyexpr).c_str());
 
@@ -196,6 +196,7 @@ class ZenohTransport : public Transport {
 
     z_get_options_t opts;
     z_get_options_default(&opts);
+    opts.timeout_ms = static_cast<uint64_t>(timeout.count());
 
     z_result_t rc =
         z_get(z_session_loan(&session_), z_keyexpr_loan(&ke), "",

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -77,7 +77,9 @@ struct Subscription::Impl {
 };
 
 Subscription::Subscription() = default;
-Subscription::~Subscription() = default;
+Subscription::~Subscription() {
+  z_drop(z_move(impl_->subscriber));
+}
 Subscription::Subscription(Subscription&&) noexcept = default;
 Subscription& Subscription::operator=(Subscription&&) noexcept = default;
 
@@ -87,10 +89,13 @@ Subscription& Subscription::operator=(Subscription&&) noexcept = default;
 
 struct Queryable::Impl {
   z_owned_queryable_t queryable;
+  std::function<void(TransportQuery&)> callback;
 };
 
 Queryable::Queryable() = default;
-Queryable::~Queryable() = default;
+Queryable::~Queryable() {
+  z_drop(z_move(impl_->queryable));
+}
 Queryable::Queryable(Queryable&&) noexcept = default;
 Queryable& Queryable::operator=(Queryable&&) noexcept = default;
 
@@ -237,15 +242,15 @@ class ZenohTransport : public Transport {
 
   Queryable DeclareQueryable(
       std::string_view keyexpr_str,
-      std::function<void(TransportQuery&)> callback) override {
+      const std::function<void(TransportQuery&)>& callback) override {
     Queryable q;
     q.impl_ = std::make_unique<Queryable::Impl>();
     if (!session_valid_) return q;
 
+    q.impl_->callback = callback;
+
     z_owned_keyexpr_t ke;
     z_keyexpr_from_str(&ke, std::string(keyexpr_str).c_str());
-
-    auto* cb = new std::function<void(TransportQuery&)>(std::move(callback));
 
     z_owned_closure_query_t closure;
     z_closure_query(
@@ -257,10 +262,8 @@ class ZenohTransport : public Transport {
           tq.impl_->query = query;
           (*f)(tq);
         },
-        +[](void* context) {
-          delete static_cast<std::function<void(TransportQuery&)>*>(context);
-        },
-        cb);
+        nullptr,  // impl_->callback is owned by Queryable::Impl, no cleanup
+        &q.impl_->callback);
 
     z_queryable_options_t q_opts;
     z_queryable_options_default(&q_opts);

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -74,6 +74,91 @@ std::error_code MakeError(TransportErrc ec) {
   return {static_cast<int>(ec), ZenohCategory()};
 }
 
+// RAII wrapper for any z_owned_*_t. Calls z_drop(z_move(obj)) on destruction
+// and on close of the owning scope, removing the manual z_drop chains that
+// were previously duplicated across Put()/Reply(). Move-only; copying is
+// deleted to preserve single ownership.
+template <typename T>
+class ZenohOwned {
+ public:
+  ZenohOwned() = default;
+  explicit ZenohOwned(T obj) : obj_(obj) {}
+
+  ZenohOwned(const ZenohOwned&) = delete;
+  ZenohOwned& operator=(const ZenohOwned&) = delete;
+
+  ZenohOwned(ZenohOwned&& other) noexcept : obj_(other.obj_) {
+    other.moved_ = true;
+  }
+  ZenohOwned& operator=(ZenohOwned&& other) noexcept {
+    if (this != &other) {
+      Drop();
+      obj_ = other.obj_;
+      moved_ = other.moved_;
+      other.moved_ = true;
+    }
+    return *this;
+  }
+
+  ~ZenohOwned() { Drop(); }
+
+  // Lender: returns a pointer suitable for z_move(obj_out) output parameters.
+  T* get() { return &obj_; }
+
+  // Lender: returns a moved handle for APIs that take z_moved_*_t*.
+  auto moved() { return z_move(obj_); }
+
+  // Loan for APIs that take z_loaned_*_t*.
+  auto loan() { return z_loan(obj_); }
+
+  explicit operator bool() const { return !moved_; }
+
+  // Called by helpers after a successful z_*_from_* populates obj_.
+  void mark_valid() { moved_ = false; }
+
+ private:
+  void Drop() {
+    if (!moved_) z_drop(z_move(obj_));
+    moved_ = true;
+  }
+
+  T obj_{};
+  bool moved_ = true;  // default-constructed state is "empty/moved-from"
+};
+
+// Build a z_owned_keyexpr_t from a string. Returns an error Result if zenoh
+// rejects the key.
+Result<ZenohOwned<z_owned_keyexpr_t>> MakeKeyexpr(std::string_view key) {
+  ZenohOwned<z_owned_keyexpr_t> ke;
+  z_result_t rc = z_keyexpr_from_str(ke.get(), std::string(key).c_str());
+  if (rc != Z_OK) return Result<ZenohOwned<z_owned_keyexpr_t>>::Err(MakeError(rc));
+  ke.mark_valid();  // ownership acquired
+  return Result<ZenohOwned<z_owned_keyexpr_t>>::Ok(std::move(ke));
+}
+
+// Build a z_owned_encoding_t from an Encoding id string.
+Result<ZenohOwned<z_owned_encoding_t>> MakeEncoding(const Encoding& enc) {
+  ZenohOwned<z_owned_encoding_t> z_enc;
+  z_result_t rc = z_encoding_from_str(z_enc.get(), enc.id.c_str());
+  if (rc != Z_OK) {
+    return Result<ZenohOwned<z_owned_encoding_t>>::Err(MakeError(rc));
+  }
+  z_enc.mark_valid();
+  return Result<ZenohOwned<z_owned_encoding_t>>::Ok(std::move(z_enc));
+}
+
+// Build a z_owned_bytes_t from a byte payload.
+Result<ZenohOwned<z_owned_bytes_t>> MakeBytes(std::span<const std::byte> payload) {
+  ZenohOwned<z_owned_bytes_t> p;
+  z_result_t rc = z_bytes_copy_from_buf(
+      p.get(), reinterpret_cast<const uint8_t*>(payload.data()), payload.size());
+  if (rc != Z_OK) {
+    return Result<ZenohOwned<z_owned_bytes_t>>::Err(MakeError(rc));
+  }
+  p.mark_valid();
+  return Result<ZenohOwned<z_owned_bytes_t>>::Ok(std::move(p));
+}
+
 struct GetReplyCtx {
   const Transport::QueryResultSink* sink;
   std::atomic<bool> stop{false};
@@ -133,35 +218,22 @@ Result<void> TransportQuery::Reply(std::string_view key, std::span<const std::by
     return Result<void>::Err(MakeError(kErrNoQuery));
   }
 
-  z_owned_encoding_t z_enc;
-  z_result_t enc_rc = z_encoding_from_str(&z_enc, encoding.id.c_str());
-  if (enc_rc != Z_OK) return Result<void>::Err(MakeError(enc_rc));
+  auto enc = MakeEncoding(encoding);
+  if (!enc.IsOk()) return Result<void>::Err(enc.Error());
 
-  z_owned_keyexpr_t ke;
-  z_result_t ke_rc = z_keyexpr_from_str(&ke, std::string(key).c_str());
-  if (ke_rc != Z_OK) {
-    z_drop(z_move(z_enc));
-    return Result<void>::Err(MakeError(ke_rc));
-  }
+  auto ke = MakeKeyexpr(key);
+  if (!ke.IsOk()) return Result<void>::Err(ke.Error());
 
-  z_owned_bytes_t p;
-  z_result_t bp_rc =
-      z_bytes_copy_from_buf(&p, reinterpret_cast<const uint8_t*>(payload.data()),
-                            payload.size());
-  if (bp_rc != Z_OK) {
-    z_drop(z_move(ke));
-    z_drop(z_move(z_enc));
-    return Result<void>::Err(MakeError(bp_rc));
-  }
+  auto p = MakeBytes(payload);
+  if (!p.IsOk()) return Result<void>::Err(p.Error());
 
   z_query_reply_options_t opts;
   z_query_reply_options_default(&opts);
-  opts.encoding = z_move(z_enc);
+  opts.encoding = enc.Value().moved();
 
   z_result_t rc =
-      z_query_reply(impl_->query, z_keyexpr_loan(&ke), z_move(p), &opts);
+      z_query_reply(impl_->query, ke.Value().loan(), p.Value().moved(), &opts);
 
-  z_drop(z_move(ke));
   if (rc != Z_OK) return Result<void>::Err(MakeError(rc));
   return Result<void>::Ok();
 }
@@ -236,35 +308,22 @@ class ZenohTransport : public Transport {
                    Encoding encoding, PutOptions /*options*/) override {
     if (!session_valid_) return Result<void>::Err(MakeError(kErrDisconnected));
 
-    z_owned_encoding_t z_enc;
-    z_result_t enc_rc = z_encoding_from_str(&z_enc, encoding.id.c_str());
-    if (enc_rc != Z_OK) return Result<void>::Err(MakeError(enc_rc));
+    auto enc = MakeEncoding(encoding);
+    if (!enc.IsOk()) return Result<void>::Err(enc.Error());
 
-    z_owned_keyexpr_t ke;
-    z_result_t ke_rc = z_keyexpr_from_str(&ke, std::string(key).c_str());
-    if (ke_rc != Z_OK) {
-      z_drop(z_move(z_enc));
-      return Result<void>::Err(MakeError(ke_rc));
-    }
+    auto ke = MakeKeyexpr(key);
+    if (!ke.IsOk()) return Result<void>::Err(ke.Error());
 
-    z_owned_bytes_t p;
-    z_result_t bp_rc =
-        z_bytes_copy_from_buf(&p, reinterpret_cast<const uint8_t*>(payload.data()),
-                              payload.size());
-    if (bp_rc != Z_OK) {
-      z_drop(z_move(ke));
-      z_drop(z_move(z_enc));
-      return Result<void>::Err(MakeError(bp_rc));
-    }
+    auto p = MakeBytes(payload);
+    if (!p.IsOk()) return Result<void>::Err(p.Error());
 
     z_put_options_t opts;
     z_put_options_default(&opts);
-    opts.encoding = z_move(z_enc);
+    opts.encoding = enc.Value().moved();
 
     z_result_t rc =
-        z_put(z_session_loan(&session_), z_keyexpr_loan(&ke), z_move(p), &opts);
+        z_put(z_session_loan(&session_), ke.Value().loan(), p.Value().moved(), &opts);
 
-    z_drop(z_move(ke));
     if (rc != Z_OK) return Result<void>::Err(MakeError(rc));
     return Result<void>::Ok();
   }
@@ -272,17 +331,15 @@ class ZenohTransport : public Transport {
   Result<void> Delete(std::string_view key, PutOptions /*options*/) override {
     if (!session_valid_) return Result<void>::Err(MakeError(kErrDisconnected));
 
-    z_owned_keyexpr_t ke;
-    z_result_t ke_rc = z_keyexpr_from_str(&ke, std::string(key).c_str());
-    if (ke_rc != Z_OK) return Result<void>::Err(MakeError(ke_rc));
+    auto ke = MakeKeyexpr(key);
+    if (!ke.IsOk()) return Result<void>::Err(ke.Error());
 
     z_delete_options_t opts;
     z_delete_options_default(&opts);
 
     z_result_t rc =
-        z_delete(z_session_loan(&session_), z_keyexpr_loan(&ke), &opts);
+        z_delete(z_session_loan(&session_), ke.Value().loan(), &opts);
 
-    z_drop(z_move(ke));
     if (rc != Z_OK) return Result<void>::Err(MakeError(rc));
     return Result<void>::Ok();
   }
@@ -292,9 +349,8 @@ class ZenohTransport : public Transport {
     if (!session_valid_) return Result<void>::Err(MakeError(kErrDisconnected));
     if (timeout.count() < 0) return Result<void>::Err(MakeError(kErrInvalidArg));
 
-    z_owned_keyexpr_t ke;
-    z_result_t ke_rc = z_keyexpr_from_str(&ke, std::string(keyexpr).c_str());
-    if (ke_rc != Z_OK) return Result<void>::Err(MakeError(ke_rc));
+    auto ke = MakeKeyexpr(keyexpr);
+    if (!ke.IsOk()) return Result<void>::Err(ke.Error());
 
     GetReplyCtx reply_ctx{&sink, false};
 
@@ -306,10 +362,9 @@ class ZenohTransport : public Transport {
     opts.timeout_ms = static_cast<uint64_t>(timeout.count());
 
     z_result_t rc =
-        z_get(z_session_loan(&session_), z_keyexpr_loan(&ke), "",
+        z_get(z_session_loan(&session_), ke.Value().loan(), "",
               z_move(closure), &opts);
 
-    z_drop(z_move(ke));
     if (rc != Z_OK) return Result<void>::Err(MakeError(rc));
     return Result<void>::Ok();
   }
@@ -335,9 +390,8 @@ class ZenohTransport : public Transport {
 
     q.impl_->callback = callback;
 
-    z_owned_keyexpr_t ke;
-    z_result_t ke_rc = z_keyexpr_from_str(&ke, std::string(keyexpr_str).c_str());
-    if (ke_rc != Z_OK) {
+    auto ke = MakeKeyexpr(keyexpr_str);
+    if (!ke.IsOk()) {
       q.impl_.reset();
       return q;
     }
@@ -367,9 +421,8 @@ class ZenohTransport : public Transport {
 
     z_result_t decl_rc = z_declare_queryable(
         z_session_loan(&session_), &q.impl_->queryable,
-        z_keyexpr_loan(&ke), z_move(closure), &q_opts);
+        ke.Value().loan(), z_move(closure), &q_opts);
 
-    z_drop(z_move(ke));
     if (decl_rc != Z_OK) {
       q.impl_.reset();
     }

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -87,9 +87,16 @@ void TransportQuery::Reply(std::string_view key, std::span<const std::byte> payl
                            Encoding encoding) {
   if (!impl_ || !impl_->query) return;
 
+  z_owned_encoding_t z_enc;
+  z_result_t enc_rc = z_encoding_from_str(&z_enc, encoding.id.c_str());
+  if (enc_rc != Z_OK) return;
+
   z_owned_keyexpr_t ke;
   z_result_t ke_rc = z_keyexpr_from_str(&ke, std::string(key).c_str());
-  if (ke_rc != Z_OK) return;
+  if (ke_rc != Z_OK) {
+    z_drop(z_move(z_enc));
+    return;
+  }
 
   z_owned_bytes_t p;
   z_result_t bp_rc =
@@ -97,16 +104,13 @@ void TransportQuery::Reply(std::string_view key, std::span<const std::byte> payl
                             payload.size());
   if (bp_rc != Z_OK) {
     z_drop(z_move(ke));
+    z_drop(z_move(z_enc));
     return;
   }
 
   z_query_reply_options_t opts;
   z_query_reply_options_default(&opts);
-
-  z_owned_encoding_t z_enc;
-  if (z_encoding_from_str(&z_enc, encoding.id.c_str()) == Z_OK) {
-    opts.encoding = z_move(z_enc);
-  }
+  opts.encoding = z_move(z_enc);
 
   z_query_reply(impl_->query, z_keyexpr_loan(&ke), z_move(p), &opts);
   z_drop(z_move(ke));
@@ -175,9 +179,16 @@ class ZenohTransport : public Transport {
                    Encoding encoding, PutOptions /*options*/) override {
     if (!session_valid_) return Result<void>::Err(MakeError(-1));
 
+    z_owned_encoding_t z_enc;
+    z_result_t enc_rc = z_encoding_from_str(&z_enc, encoding.id.c_str());
+    if (enc_rc != Z_OK) return Result<void>::Err(MakeError(enc_rc));
+
     z_owned_keyexpr_t ke;
     z_result_t ke_rc = z_keyexpr_from_str(&ke, std::string(key).c_str());
-    if (ke_rc != Z_OK) return Result<void>::Err(MakeError(ke_rc));
+    if (ke_rc != Z_OK) {
+      z_drop(z_move(z_enc));
+      return Result<void>::Err(MakeError(ke_rc));
+    }
 
     z_owned_bytes_t p;
     z_result_t bp_rc =
@@ -185,16 +196,13 @@ class ZenohTransport : public Transport {
                               payload.size());
     if (bp_rc != Z_OK) {
       z_drop(z_move(ke));
+      z_drop(z_move(z_enc));
       return Result<void>::Err(MakeError(bp_rc));
     }
 
     z_put_options_t opts;
     z_put_options_default(&opts);
-
-    z_owned_encoding_t z_enc;
-    if (z_encoding_from_str(&z_enc, encoding.id.c_str()) == Z_OK) {
-      opts.encoding = z_move(z_enc);
-    }
+    opts.encoding = z_move(z_enc);
 
     z_result_t rc =
         z_put(z_session_loan(&session_), z_keyexpr_loan(&ke), z_move(p), &opts);

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -179,7 +179,8 @@ class ZenohTransport : public Transport {
     struct Ctx {
       const QueryResultSink* sink;
       bool stop = false;
-    } ctx{&sink, false};
+    };
+    Ctx ctx{&sink, false};
 
     z_owned_closure_reply_t closure;
     z_closure_reply(

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -46,7 +46,7 @@ TransportQuery::TransportQuery(TransportQuery&&) noexcept = default;
 TransportQuery& TransportQuery::operator=(TransportQuery&&) noexcept = default;
 
 void TransportQuery::Reply(std::string_view key, std::span<const std::byte> payload,
-                           Encoding /*encoding*/) {
+                           Encoding encoding) {
   if (!impl_ || !impl_->query) return;
 
   z_owned_keyexpr_t ke;
@@ -58,6 +58,12 @@ void TransportQuery::Reply(std::string_view key, std::span<const std::byte> payl
 
   z_query_reply_options_t opts;
   z_query_reply_options_default(&opts);
+
+  z_owned_encoding_t z_enc;
+  if (z_encoding_from_str(&z_enc, encoding.id.c_str()) == Z_OK) {
+    opts.encoding = z_move(z_enc);
+  }
+
   z_query_reply(impl_->query, z_keyexpr_loan(&ke), z_move(p), &opts);
   z_drop(z_move(ke));
 }

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -187,6 +187,9 @@ class ZenohTransport : public Transport {
           std::string key_str(z_string_data(z_view_string_loan(&ks)),
                               z_string_len(z_view_string_loan(&ks)));
 
+          // TODO(#3): Extract encoding from z_sample_encoding(sample).
+          // zenoh-c 1.9.0 does not expose encoding-to-string conversion;
+          // "sitos.v1" is the only encoding used in v0.1.
           Encoding enc;
           enc.id = "sitos.v1";
 

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -87,11 +87,17 @@ void TransportQuery::Reply(std::string_view key, std::span<const std::byte> payl
   if (!impl_ || !impl_->query) return;
 
   z_owned_keyexpr_t ke;
-  z_keyexpr_from_str(&ke, std::string(key).c_str());
+  z_result_t ke_rc = z_keyexpr_from_str(&ke, std::string(key).c_str());
+  if (ke_rc != Z_OK) return;
 
   z_owned_bytes_t p;
-  z_bytes_copy_from_buf(&p, reinterpret_cast<const uint8_t*>(payload.data()),
-                        payload.size());
+  z_result_t bp_rc =
+      z_bytes_copy_from_buf(&p, reinterpret_cast<const uint8_t*>(payload.data()),
+                            payload.size());
+  if (bp_rc != Z_OK) {
+    z_drop(z_move(ke));
+    return;
+  }
 
   z_query_reply_options_t opts;
   z_query_reply_options_default(&opts);
@@ -169,11 +175,17 @@ class ZenohTransport : public Transport {
     if (!session_valid_) return Result<void>::Err(MakeError(-1));
 
     z_owned_keyexpr_t ke;
-    z_keyexpr_from_str(&ke, std::string(key).c_str());
+    z_result_t ke_rc = z_keyexpr_from_str(&ke, std::string(key).c_str());
+    if (ke_rc != Z_OK) return Result<void>::Err(MakeError(ke_rc));
 
     z_owned_bytes_t p;
-    z_bytes_copy_from_buf(&p, reinterpret_cast<const uint8_t*>(payload.data()),
-                          payload.size());
+    z_result_t bp_rc =
+        z_bytes_copy_from_buf(&p, reinterpret_cast<const uint8_t*>(payload.data()),
+                              payload.size());
+    if (bp_rc != Z_OK) {
+      z_drop(z_move(ke));
+      return Result<void>::Err(MakeError(bp_rc));
+    }
 
     z_put_options_t opts;
     z_put_options_default(&opts);
@@ -195,7 +207,8 @@ class ZenohTransport : public Transport {
     if (!session_valid_) return Result<void>::Err(MakeError(-1));
 
     z_owned_keyexpr_t ke;
-    z_keyexpr_from_str(&ke, std::string(key).c_str());
+    z_result_t ke_rc = z_keyexpr_from_str(&ke, std::string(key).c_str());
+    if (ke_rc != Z_OK) return Result<void>::Err(MakeError(ke_rc));
 
     z_delete_options_t opts;
     z_delete_options_default(&opts);
@@ -213,7 +226,8 @@ class ZenohTransport : public Transport {
     if (!session_valid_) return Result<void>::Err(MakeError(-1));
 
     z_owned_keyexpr_t ke;
-    z_keyexpr_from_str(&ke, std::string(keyexpr).c_str());
+    z_result_t ke_rc = z_keyexpr_from_str(&ke, std::string(keyexpr).c_str());
+    if (ke_rc != Z_OK) return Result<void>::Err(MakeError(ke_rc));
 
     GetReplyCtx reply_ctx{&sink, false};
 
@@ -245,12 +259,19 @@ class ZenohTransport : public Transport {
       const std::function<void(TransportQuery&)>& callback) override {
     Queryable q;
     q.impl_ = std::make_unique<Queryable::Impl>();
-    if (!session_valid_) return q;
+    if (!session_valid_) {
+      q.impl_.reset();
+      return q;
+    }
 
     q.impl_->callback = callback;
 
     z_owned_keyexpr_t ke;
-    z_keyexpr_from_str(&ke, std::string(keyexpr_str).c_str());
+    z_result_t ke_rc = z_keyexpr_from_str(&ke, std::string(keyexpr_str).c_str());
+    if (ke_rc != Z_OK) {
+      q.impl_.reset();
+      return q;
+    }
 
     z_owned_closure_query_t closure;
     z_closure_query(
@@ -268,10 +289,14 @@ class ZenohTransport : public Transport {
     z_queryable_options_t q_opts;
     z_queryable_options_default(&q_opts);
 
-    z_declare_queryable(z_session_loan(&session_), &q.impl_->queryable,
-                        z_keyexpr_loan(&ke), z_move(closure), &q_opts);
+    z_result_t decl_rc = z_declare_queryable(
+        z_session_loan(&session_), &q.impl_->queryable,
+        z_keyexpr_loan(&ke), z_move(closure), &q_opts);
 
     z_drop(z_move(ke));
+    if (decl_rc != Z_OK) {
+      q.impl_.reset();
+    }
     return q;
   }
 

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -1,0 +1,250 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// ZenohTransport — wraps the zenoh C API behind the Transport abstraction.
+// All raw zenoh-c headers and types are confined to this translation unit.
+
+#ifdef _MSC_VER
+#pragma warning(push, 0)
+#endif
+#include <zenoh.h>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+#include "sitos/transport.hpp"
+
+#include <cstddef>
+#include <string>
+
+namespace sitos {
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+namespace {
+
+std::error_code MakeError(z_result_t rc) {
+  if (rc == Z_OK) return {};
+  return {static_cast<int>(rc), std::generic_category()};
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// TransportQuery
+// ---------------------------------------------------------------------------
+
+struct TransportQuery::Impl {
+  const z_loaned_query_t* query = nullptr;
+};
+
+TransportQuery::TransportQuery() = default;
+TransportQuery::~TransportQuery() = default;
+TransportQuery::TransportQuery(TransportQuery&&) noexcept = default;
+TransportQuery& TransportQuery::operator=(TransportQuery&&) noexcept = default;
+
+void TransportQuery::Reply(std::string_view key, std::span<const std::byte> payload,
+                           Encoding /*encoding*/) {
+  if (!impl_ || !impl_->query) return;
+
+  z_owned_keyexpr_t ke;
+  z_keyexpr_from_str(&ke, std::string(key).c_str());
+
+  z_owned_bytes_t p;
+  z_bytes_copy_from_buf(&p, reinterpret_cast<const uint8_t*>(payload.data()),
+                        payload.size());
+
+  z_query_reply_options_t opts;
+  z_query_reply_options_default(&opts);
+  z_query_reply(impl_->query, z_keyexpr_loan(&ke), z_move(p), &opts);
+  z_drop(z_move(ke));
+}
+
+// ---------------------------------------------------------------------------
+// Subscription
+// ---------------------------------------------------------------------------
+
+struct Subscription::Impl {
+  z_owned_subscriber_t subscriber;
+};
+
+Subscription::Subscription() = default;
+Subscription::~Subscription() = default;
+Subscription::Subscription(Subscription&&) noexcept = default;
+Subscription& Subscription::operator=(Subscription&&) noexcept = default;
+
+// ---------------------------------------------------------------------------
+// Queryable
+// ---------------------------------------------------------------------------
+
+struct Queryable::Impl {
+  z_owned_queryable_t queryable;
+};
+
+Queryable::Queryable() = default;
+Queryable::~Queryable() = default;
+Queryable::Queryable(Queryable&&) noexcept = default;
+Queryable& Queryable::operator=(Queryable&&) noexcept = default;
+
+// ---------------------------------------------------------------------------
+// ZenohTransport
+// ---------------------------------------------------------------------------
+
+class ZenohTransport : public Transport {
+ public:
+  ZenohTransport() {
+    z_owned_config_t config;
+    z_config_default(&config);
+    z_open(&session_, z_move(config), nullptr);
+  }
+
+  ~ZenohTransport() override {
+    z_close(z_session_loan_mut(&session_), nullptr);
+    z_drop(z_move(session_));
+  }
+
+  Result<void> Put(std::string_view key, std::span<const std::byte> payload,
+                   Encoding /*encoding*/, PutOptions /*options*/) override {
+    z_owned_keyexpr_t ke;
+    z_keyexpr_from_str(&ke, std::string(key).c_str());
+
+    z_owned_bytes_t p;
+    z_bytes_copy_from_buf(&p, reinterpret_cast<const uint8_t*>(payload.data()),
+                          payload.size());
+
+    z_put_options_t opts;
+    z_put_options_default(&opts);
+
+    z_result_t rc =
+        z_put(z_session_loan(&session_), z_keyexpr_loan(&ke), z_move(p), &opts);
+
+    z_drop(z_move(ke));
+    if (rc != Z_OK) return Result<void>::Err(MakeError(rc));
+    return Result<void>::Ok();
+  }
+
+  Result<void> Delete(std::string_view key, PutOptions /*options*/) override {
+    z_owned_keyexpr_t ke;
+    z_keyexpr_from_str(&ke, std::string(key).c_str());
+
+    z_delete_options_t opts;
+    z_delete_options_default(&opts);
+
+    z_result_t rc =
+        z_delete(z_session_loan(&session_), z_keyexpr_loan(&ke), &opts);
+
+    z_drop(z_move(ke));
+    if (rc != Z_OK) return Result<void>::Err(MakeError(rc));
+    return Result<void>::Ok();
+  }
+
+  Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
+                   std::chrono::milliseconds /*timeout*/) override {
+    z_owned_keyexpr_t ke;
+    z_keyexpr_from_str(&ke, std::string(keyexpr).c_str());
+
+    struct Ctx {
+      const QueryResultSink* sink;
+      bool stop = false;
+    } ctx{&sink, false};
+
+    z_owned_closure_reply_t closure;
+    z_closure_reply(
+        &closure,
+        +[](z_loaned_reply_t* reply, void* context) {
+          auto* c = static_cast<Ctx*>(context);
+          if (c->stop) return;
+
+          const z_loaned_sample_t* sample = z_reply_ok(reply);
+          if (!sample) return;
+
+          const z_loaned_bytes_t* payload = z_sample_payload(sample);
+          z_owned_slice_t slice;
+          z_bytes_to_slice(payload, &slice);
+
+          const auto* data =
+              reinterpret_cast<const std::byte*>(z_slice_data(z_slice_loan(&slice)));
+          auto len = z_slice_len(z_slice_loan(&slice));
+
+          z_view_string_t ks;
+          z_keyexpr_as_view_string(z_sample_keyexpr(sample), &ks);
+          std::string key_str(z_string_data(z_view_string_loan(&ks)),
+                              z_string_len(z_view_string_loan(&ks)));
+
+          Encoding enc;
+          enc.id = "sitos.v1";
+
+          if (!(*c->sink)(key_str, std::span<const std::byte>(data, len), enc)) {
+            c->stop = true;
+          }
+          z_drop(z_move(slice));
+        },
+        nullptr,  // drop — Ctx is stack-allocated, no cleanup needed
+        &ctx);
+
+    z_get_options_t opts;
+    z_get_options_default(&opts);
+
+    z_result_t rc =
+        z_get(z_session_loan(&session_), z_keyexpr_loan(&ke), "",
+              z_move(closure), &opts);
+
+    z_drop(z_move(ke));
+    if (rc != Z_OK) return Result<void>::Err(MakeError(rc));
+    return Result<void>::Ok();
+  }
+
+  Subscription DeclareSubscriber(
+      std::string_view /*keyexpr*/,
+      std::function<void(const TransportSample&)> /*callback*/) override {
+    // TODO(#3): implement subscriber
+    return {};
+  }
+
+  Queryable DeclareQueryable(
+      std::string_view keyexpr_str,
+      std::function<void(TransportQuery&)> callback) override {
+    Queryable q;
+    q.impl_ = std::make_unique<Queryable::Impl>();
+
+    z_owned_keyexpr_t ke;
+    z_keyexpr_from_str(&ke, std::string(keyexpr_str).c_str());
+
+    auto* cb = new std::function<void(TransportQuery&)>(std::move(callback));
+
+    z_owned_closure_query_t closure;
+    z_closure_query(
+        &closure,
+        +[](z_loaned_query_t* query, void* context) {
+          auto* f = static_cast<std::function<void(TransportQuery&)>*>(context);
+          TransportQuery tq;
+          tq.impl_ = std::make_unique<TransportQuery::Impl>();
+          tq.impl_->query = query;
+          (*f)(tq);
+        },
+        +[](void* context) {
+          delete static_cast<std::function<void(TransportQuery&)>*>(context);
+        },
+        cb);
+
+    z_queryable_options_t q_opts;
+    z_queryable_options_default(&q_opts);
+
+    z_declare_queryable(z_session_loan(&session_), &q.impl_->queryable,
+                        z_keyexpr_loan(&ke), z_move(closure), &q_opts);
+
+    z_drop(z_move(ke));
+    return q;
+  }
+
+ private:
+  z_owned_session_t session_;
+};
+
+}  // namespace sitos
+
+std::unique_ptr<sitos::Transport> sitos::MakeZenohTransport() {
+  return std::make_unique<sitos::ZenohTransport>();
+}

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -33,7 +33,7 @@ namespace {
 // NOTE: full migration to the project "Status" enum (docs/04_api_cpp.md §1)
 // is tracked separately; these named sentinels are an interim improvement
 // over the bare MakeError(-1) magic number.
-enum TransportErrc {
+enum class TransportErrc {
   kErrDisconnected = -1,  // session not opened or already closed
   kErrInvalidArg = -2,    // invalid argument (e.g. negative timeout)
   kErrNoQuery = -3,       // queryable destroyed or query unavailable
@@ -47,11 +47,11 @@ class ZenohErrorCategory : public std::error_category {
 
   std::string message(int ev) const override {
     switch (ev) {
-      case kErrDisconnected:
+      case static_cast<int>(TransportErrc::kErrDisconnected):
         return "zenoh session is not available";
-      case kErrInvalidArg:
+      case static_cast<int>(TransportErrc::kErrInvalidArg):
         return "invalid argument";
-      case kErrNoQuery:
+      case static_cast<int>(TransportErrc::kErrNoQuery):
         return "query is no longer valid (queryable destroyed)";
       default:
         if (ev == Z_OK) return "ok";
@@ -215,7 +215,7 @@ TransportQuery& TransportQuery::operator=(TransportQuery&&) noexcept = default;
 Result<void> TransportQuery::Reply(std::string_view key, std::span<const std::byte> payload,
                            Encoding encoding) {
   if (!impl_ || !impl_->query || !*impl_->query_alive_) {
-    return Result<void>::Err(MakeError(kErrNoQuery));
+    return Result<void>::Err(MakeError(TransportErrc::kErrNoQuery));
   }
 
   auto enc = MakeEncoding(encoding);
@@ -306,7 +306,7 @@ class ZenohTransport : public Transport {
 
   Result<void> Put(std::string_view key, std::span<const std::byte> payload,
                    Encoding encoding, PutOptions /*options*/) override {
-    if (!session_valid_) return Result<void>::Err(MakeError(kErrDisconnected));
+    if (!session_valid_) return Result<void>::Err(MakeError(TransportErrc::kErrDisconnected));
 
     auto enc = MakeEncoding(encoding);
     if (!enc.IsOk()) return Result<void>::Err(enc.Error());
@@ -329,7 +329,7 @@ class ZenohTransport : public Transport {
   }
 
   Result<void> Delete(std::string_view key, PutOptions /*options*/) override {
-    if (!session_valid_) return Result<void>::Err(MakeError(kErrDisconnected));
+    if (!session_valid_) return Result<void>::Err(MakeError(TransportErrc::kErrDisconnected));
 
     auto ke = MakeKeyexpr(key);
     if (!ke.IsOk()) return Result<void>::Err(ke.Error());
@@ -346,8 +346,8 @@ class ZenohTransport : public Transport {
 
   Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
                    std::chrono::milliseconds timeout) override {
-    if (!session_valid_) return Result<void>::Err(MakeError(kErrDisconnected));
-    if (timeout.count() < 0) return Result<void>::Err(MakeError(kErrInvalidArg));
+    if (!session_valid_) return Result<void>::Err(MakeError(TransportErrc::kErrDisconnected));
+    if (timeout.count() < 0) return Result<void>::Err(MakeError(TransportErrc::kErrInvalidArg));
 
     auto ke = MakeKeyexpr(keyexpr);
     if (!ke.IsOk()) return Result<void>::Err(ke.Error());

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -98,13 +98,20 @@ Queryable& Queryable::operator=(Queryable&&) noexcept = default;
 // ZenohTransport
 // ---------------------------------------------------------------------------
 
+namespace {
+
+bool OpenZenohSession(z_owned_session_t* session) {
+  z_owned_config_t config;
+  z_config_default(&config);
+  return z_open(session, z_move(config), nullptr) == Z_OK;
+}
+
+}  // namespace
+
 class ZenohTransport : public Transport {
  public:
-  ZenohTransport() {
-    z_owned_config_t config;
-    z_config_default(&config);
-    session_valid_ = (z_open(&session_, z_move(config), nullptr) == Z_OK);
-  }
+  ZenohTransport()
+      : session_valid_(OpenZenohSession(&session_)) {}
 
   bool IsSessionValid() const { return session_valid_; }
 

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -146,6 +146,9 @@ Subscription& Subscription::operator=(Subscription&&) noexcept = default;
 struct Queryable::Impl {
   z_owned_queryable_t queryable;
   std::function<void(TransportQuery&)> callback;
+  // Shared with in-flight TransportQuery callbacks to detect
+  // use-after-destruction. Set to false in ~Queryable() before dropping
+  // the queryable, so any late Reply() call becomes a no-op.
   std::shared_ptr<bool> query_alive_{std::make_shared<bool>(true)};
 };
 

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -290,6 +290,12 @@ class ZenohTransport : public Transport {
           TransportQuery tq;
           tq.impl_ = std::make_unique<TransportQuery::Impl>();
           tq.impl_->query = query;
+
+          z_view_string_t qks;
+          z_keyexpr_as_view_string(z_query_keyexpr(query), &qks);
+          tq.keyexpr = std::string(z_string_data(z_view_string_loan(&qks)),
+                                   z_string_len(z_view_string_loan(&qks)));
+
           (*f)(tq);
         },
         nullptr,  // impl_->callback is owned by Queryable::Impl, no cleanup

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -46,12 +46,12 @@ class ZenohErrorCategory : public std::error_category {
   const char* name() const noexcept override { return "sitos.zenoh"; }
 
   std::string message(int ev) const override {
-    switch (ev) {
-      case static_cast<int>(TransportErrc::kErrDisconnected):
+    switch (static_cast<TransportErrc>(ev)) {
+      case TransportErrc::kErrDisconnected:
         return "zenoh session is not available";
-      case static_cast<int>(TransportErrc::kErrInvalidArg):
+      case TransportErrc::kErrInvalidArg:
         return "invalid argument";
-      case static_cast<int>(TransportErrc::kErrNoQuery):
+      case TransportErrc::kErrNoQuery:
         return "query is no longer valid (queryable destroyed)";
       default:
         if (ev == Z_OK) return "ok";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,4 +53,11 @@ if(SITOS_WITH_ZENOH)
   # under -Werror that we cannot fix.
   sitos_copy_zenohc(sitos_zenoh_smoke_test)
   gtest_discover_tests(sitos_zenoh_smoke_test)
+
+  add_executable(sitos_transport_test
+    integration/transport_test.cpp)
+  target_link_libraries(sitos_transport_test
+    PRIVATE GTest::gtest_main sitos::sitos)
+  sitos_copy_zenohc(sitos_transport_test)
+  gtest_discover_tests(sitos_transport_test)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ if(SITOS_WITH_ZENOH)
     integration/transport_test.cpp)
   target_link_libraries(sitos_transport_test
     PRIVATE GTest::gtest_main sitos::sitos)
+  sitos_enable_warnings(sitos_transport_test)
   sitos_copy_zenohc(sitos_transport_test)
   gtest_discover_tests(sitos_transport_test)
 endif()

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -54,4 +54,37 @@ TEST_F(TransportTest, GetCompletesWithoutCrash) {
   // No assertion on callback_called — may or may not receive results.
 }
 
+TEST_F(TransportTest, QueryableRoundTrip) {
+  // Declare a queryable that replies with a known payload, then query it.
+  const std::string kQueryKey = "sitos/test/query/roundtrip";
+  const std::vector<std::byte> kExpectedPayload = {
+      std::byte{0xAA}, std::byte{0xBB}, std::byte{0xCC}};
+
+  sitos::Encoding enc;
+  enc.id = std::string(sitos::Encoding::kSitosV1);
+
+  auto q = transport_->DeclareQueryable(
+      kQueryKey,
+      [&](sitos::TransportQuery& tq) {
+        tq.Reply(kQueryKey, kExpectedPayload, enc);
+      });
+
+  bool received = false;
+  std::vector<std::byte> received_payload;
+
+  auto result = transport_->Get(
+      kQueryKey,
+      [&](std::string_view /*key*/, std::span<const std::byte> payload,
+          const sitos::Encoding& /*enc*/) {
+        received = true;
+        received_payload.assign(payload.begin(), payload.end());
+        return false;  // stop after first result
+      },
+      std::chrono::milliseconds(2000));
+
+  EXPECT_TRUE(result.IsOk()) << "Get failed: " << result.Error().message();
+  EXPECT_TRUE(received) << "Queryable did not respond";
+  EXPECT_EQ(received_payload, kExpectedPayload);
+}
+
 }  // namespace

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -68,7 +68,9 @@ TEST_F(TransportTest, QueryableRoundTrip) {
   auto q = transport_->DeclareQueryable(
       kQueryKey,
       [&](sitos::TransportQuery& tq) {
-        tq.Reply(kQueryKey, kExpectedPayload, enc);
+        auto reply_result = tq.Reply(kQueryKey, kExpectedPayload, enc);
+        EXPECT_TRUE(reply_result.IsOk())
+            << "Queryable reply failed: " << reply_result.Error().message();
       });
 
   std::mutex mtx;

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -1,0 +1,57 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Integration tests for the Transport abstraction using a real zenoh session.
+
+#include "sitos/transport.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace {
+
+class TransportTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    transport_ = sitos::MakeZenohTransport();
+    ASSERT_TRUE(transport_) << "Failed to open zenoh session";
+  }
+
+  void TearDown() override { transport_.reset(); }
+
+  std::unique_ptr<sitos::Transport> transport_;
+};
+
+TEST_F(TransportTest, PutAndDeleteReturnOk) {
+  std::vector<std::byte> payload = {std::byte{0x01}, std::byte{0x02}};
+  sitos::Encoding enc;
+  enc.id = std::string(sitos::Encoding::kSitosV1);
+
+  auto result = transport_->Put("sitos/test/key", payload, enc, {});
+  ASSERT_TRUE(result.IsOk()) << "Put failed: " << result.Error().message();
+
+  auto del_result = transport_->Delete("sitos/test/key", {});
+  ASSERT_TRUE(del_result.IsOk()) << "Delete failed: " << del_result.Error().message();
+}
+
+TEST_F(TransportTest, GetCompletesWithoutCrash) {
+  // Even without a matching queryable, Get should complete without crashing.
+  bool callback_called = false;
+  auto result = transport_->Get(
+      "sitos/test/**",
+      [&](std::string_view /*key*/, std::span<const std::byte> /*payload*/,
+          const sitos::Encoding& /*enc*/) {
+        callback_called = true;
+        return true;
+      },
+      std::chrono::milliseconds(500));
+
+  EXPECT_TRUE(result.IsOk());
+  // No assertion on callback_called — may or may not receive results.
+}
+
+}  // namespace

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -53,7 +53,8 @@ TEST_F(TransportTest, GetCompletesWithoutCrash) {
       std::chrono::milliseconds(500));
 
   EXPECT_TRUE(result.IsOk());
-  // No assertion on callback_called — may or may not receive results.
+  EXPECT_FALSE(callback_called) << "No queryable is registered, so the sink "
+                                   "should not be invoked";
 }
 
 TEST_F(TransportTest, QueryableRoundTrip) {

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -8,7 +8,9 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <condition_variable>
 #include <cstddef>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -69,21 +71,34 @@ TEST_F(TransportTest, QueryableRoundTrip) {
         tq.Reply(kQueryKey, kExpectedPayload, enc);
       });
 
-  bool received = false;
+  std::mutex mtx;
+  std::condition_variable cv;
+  bool done = false;
   std::vector<std::byte> received_payload;
 
   auto result = transport_->Get(
       kQueryKey,
       [&](std::string_view /*key*/, std::span<const std::byte> payload,
           const sitos::Encoding& /*enc*/) {
-        received = true;
-        received_payload.assign(payload.begin(), payload.end());
+        {
+          std::lock_guard<std::mutex> lock(mtx);
+          received_payload.assign(payload.begin(), payload.end());
+          done = true;
+        }
+        cv.notify_one();
         return false;  // stop after first result
       },
       std::chrono::milliseconds(2000));
 
   EXPECT_TRUE(result.IsOk()) << "Get failed: " << result.Error().message();
-  EXPECT_TRUE(received) << "Queryable did not respond";
+
+  {
+    std::unique_lock<std::mutex> lock(mtx);
+    EXPECT_TRUE(cv.wait_for(lock, std::chrono::seconds(3),
+                            [&] { return done; }))
+        << "Timed out waiting for queryable reply";
+  }
+
   EXPECT_EQ(received_payload, kExpectedPayload);
 }
 

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -12,9 +12,15 @@
 #include <cstddef>
 #include <mutex>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace {
+
+TEST(TransportApiTest, TransportQueryCannotOutliveCallback) {
+  static_assert(!std::is_move_constructible_v<sitos::TransportQuery>);
+  static_assert(!std::is_move_assignable_v<sitos::TransportQuery>);
+}
 
 class TransportTest : public ::testing::Test {
  protected:

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -40,8 +40,9 @@ TEST_F(TransportTest, PutAndDeleteReturnOk) {
   ASSERT_TRUE(del_result.IsOk()) << "Delete failed: " << del_result.Error().message();
 }
 
-TEST_F(TransportTest, GetCompletesWithoutCrash) {
-  // Even without a matching queryable, Get should complete without crashing.
+TEST_F(TransportTest, GetWithoutQueryableDoesNotInvokeSink) {
+  // With no matching queryable registered, Get should complete without
+  // crashing and the sink should not be invoked.
   bool callback_called = false;
   auto result = transport_->Get(
       "sitos/test/**",
@@ -53,8 +54,8 @@ TEST_F(TransportTest, GetCompletesWithoutCrash) {
       std::chrono::milliseconds(500));
 
   EXPECT_TRUE(result.IsOk());
-  EXPECT_FALSE(callback_called) << "No queryable is registered, so the sink "
-                                   "should not be invoked";
+  EXPECT_FALSE(callback_called)
+      << "No queryable is registered, so the sink should not be invoked";
 }
 
 TEST_F(TransportTest, QueryableRoundTrip) {


### PR DESCRIPTION
Closes #3

## Summary

Adds the Transport abstraction from docs/09_dependency_policy.md §3 and a zenoh-c backed implementation. All higher-level components (StorageNode, ParamStore, ParamCache) depend only on this interface.

## Scope

- [x] `include/sitos/transport.hpp`: Transport, TransportSample, TransportQuery, Subscription, Queryable, Encoding, PutOptions, Result<T>
- [x] `src/transport/zenoh_transport.cpp`: Put, Delete, Get, DeclareQueryable (DeclareSubscriber is a TODO stub)
- [x] `tests/integration/transport_test.cpp`: transport API and zenoh integration coverage
- [x] Library wiring: sitos links `zenohc::zenohc` when `SITOS_WITH_ZENOH=ON`
- [x] Transport-isolation CI guard: raw zenoh headers are confined to `src/transport/`
- [x] Dependency-upgrade workflow: validates the pinned minimum and latest stable zenoh-c versions
- [x] Callback lifetime hardening: query replies are callback-scoped and reply contexts are closure-owned

## AC verification

- Local build + test (MSVC + Ninja): **92/92 tests pass**
- `TransportApiTest.TransportQueryCannotOutliveCallback`: compile-time regression test rejects moving a callback-scoped `TransportQuery`
- `TransportTest.QueryableRoundTrip`: same-session query/reply path succeeds end-to-end
- `TransportTest.GetWithoutQueryableDoesNotInvokeSink`: no-queryable path does not call the sink
- No raw zenoh-c headers included outside `src/transport/` — enforced by `transport-isolation` CI
- Dependency-upgrade workflow parses the pinned minimum from `cmake/zenohc.cmake`; local parser check resolves `1.9.0`

## Notes

- DeclareSubscriber is stubbed — it will be implemented for StorageNode delivery in #10.
- Cross-session queryable/get round trips remain blocked by the zenoh 1.9.0 multi-session Tokio panic; same-session round trips are covered.
- `PutOptions::ack` remains deferred to #14 because the current zenoh path is ack-less.

## RED phase

`TransportApiTest.TransportQueryCannotOutliveCallback` was added first. Before the implementation, MSVC failed compilation with `C2607` for both `static_assert(!std::is_move_constructible_v<sitos::TransportQuery>)` and `static_assert(!std::is_move_assignable_v<sitos::TransportQuery>)`. The test passes after deleting the move operations.

## ADR needed?

No — the changes preserve the existing Transport interface design and zenoh-c isolation. No wire or protocol behavior changed.