### PR TITLE
docs(adr): add ADR-0015 optional HTTP gateway component

### DIFF
--- a/docs/adr/0015-optional-http-gateway-component.md
+++ b/docs/adr/0015-optional-http-gateway-component.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed — 2026-07-09
+Accepted — 2026-07-09
 
 ## Context
 

--- a/docs/adr/0015-optional-http-gateway-component.md
+++ b/docs/adr/0015-optional-http-gateway-component.md
@@ -1,0 +1,89 @@
+# ADR-0015: Ship an optional HTTP gateway component on cpp-httplib
+
+## Status
+
+Proposed — 2026-07-09
+
+## Context
+
+sitos exposes parameters, sessions, and buffers over zenoh. Browsers and
+generic HTTP tooling cannot speak zenoh, and operators frequently want to
+inspect or drive a store from a browser or `curl` for debugging. zenoh ships a
+generic REST plugin, but it requires a router daemon, is untyped with respect to
+the `sitos.v1` payload, and is unaware of sessions, snapshots, and buffers.
+
+sitos follows a minimal-dependency policy (`docs/09_dependency_policy.md`): the
+core must not gain a heavy HTTP framework dependency. A gateway is therefore an
+**optional** component, in the same spirit as the opt-in RocksDB engine
+(ADR-0003).
+
+## Decision
+
+We will ship an optional `sitos-gateway` component, gated by a CMake option
+(`SITOS_BUILD_GATEWAY`, default OFF) and built on **cpp-httplib**
+(header-only, MIT). It exposes params/sessions/buffers over HTTP with
+Server-Sent Events for subscriptions, understands the `sitos.v1` payload types,
+binds to loopback by default with pluggable authentication, and publishes a
+`Router` extension point so a host application can register additional routes on
+the same server.
+
+## Consequences
+
+* Good: Browser and `curl` access to a sitos store without a zenoh client and
+  without a router daemon.
+* Good: Typed over `sitos.v1` (Bool/S64/Dp/Str/Bytes), session- and
+  buffers-aware, with SSE for delta subscription — value beyond the generic
+  zenoh REST plugin.
+* Good: The core keeps zero HTTP dependencies; cpp-httplib is pulled only when
+  `SITOS_BUILD_GATEWAY=ON`, exactly like the RocksDB engine.
+* Good: The `Router` extension point lets host applications mount their own
+  routes on one server/port (one origin), so they do not need a second HTTP
+  stack.
+* Neutral: cpp-httplib is thread-per-connection and has no WebSocket; SSE covers
+  the subscription use case. Binary WebSocket push, if ever needed, is a
+  separate follow-up.
+* Neutral: Positioned as a gateway/debug surface. It is not a hardened public
+  endpoint; deployments must add authentication and network controls.
+* Trade-off: A new optional SOUP (cpp-httplib) enters the build matrix and must
+  be tracked with locked-version + latest CI, like RocksDB and Python.
+
+## Design notes (normative for the implementation)
+
+* Component: `sitos-gateway` library + a thin standalone binary. The library
+  form is what host applications embed.
+* Dependency: cpp-httplib, optional, `SITOS_BUILD_GATEWAY` gated. TLS is
+  provided by cpp-httplib's OpenSSL backend only when explicitly enabled.
+* Client: the gateway is a sitos client and depends on ParamStore / ParamCache /
+  SessionController, so it lands after those exist.
+* Surface (indicative): GET/PUT a parameter, GET/List parameters, session
+  create/close/list, GET a buffer, and an SSE stream for session deltas. Typed
+  values map to/from `sitos.v1`. For `kEphemeral` buffer sessions (ADR-0014),
+  GET returns not-found by design; the mode is surfaced in session metadata.
+* Security: default bind `127.0.0.1`; authentication is a pluggable hook, not a
+  built-in identity system.
+* Extension point: `Router& router()` (or equivalent) so host code can register
+  additional routes handled in-process. The gateway itself contains no
+  application-specific control logic.
+* API stability and threading are validated with locked-version + latest CI, per
+  `docs/09_dependency_policy.md`.
+
+## Options Considered
+
+* **zenoh REST plugin only** — rejected: requires a router daemon, is untyped
+  over `sitos.v1`, and is unaware of sessions/snapshots/buffers.
+* **Poco or a full HTTP framework in the core** — rejected: violates the
+  minimal-dependency policy; a heavy always-on dependency for an optional
+  feature.
+* **A separate standalone gateway process only (no embeddable library)** —
+  rejected: host applications that want one server/origin would need a second
+  HTTP stack or a reverse proxy.
+* **Optional `sitos-gateway` library on cpp-httplib with a `Router` extension
+  point** — selected: minimal optional dependency, embeddable, one origin,
+  SSE-capable.
+
+## References
+
+* Related: ADR-0003 (optional component precedent), ADR-0006 (C++20 core),
+  ADR-0007 (`sitos.v1` payload), ADR-0014 (buffers)
+* Docs: `docs/09_dependency_policy.md`
+* Issue: #57 (implementation)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,3 +19,4 @@ See [docs/10_adr_process.md](../10_adr_process.md) for the process.
 | [0012](0012-google-cpp-style-with-100-column-limit.md) | Google C++ style with 100-column limit |
 | [0013](0013-default-to-zenoh-scouting-with-explicit-endpoint-override.md) | Default to zenoh scouting with explicit endpoint override |
 | [0014](0014-session-scoped-buffers.md) | Add a session-scoped, disk-backed buffers key space |
+| [0015](0015-optional-http-gateway-component.md) | Ship an optional HTTP gateway component on cpp-httplib |


### PR DESCRIPTION
## ADR-0015: Optional HTTP gateway component on cpp-httplib (Proposed)

Adds an optional `sitos-gateway` component (library + thin binary) built on
cpp-httplib, gated by `SITOS_BUILD_GATEWAY` (default OFF). It exposes
params/sessions/buffers over HTTP with SSE, typed over `sitos.v1`, binds to
loopback by default, and publishes a `Router` extension point so host
applications can mount their own routes on one origin. Differentiated from the
generic zenoh REST plugin (typed, session/buffers-aware, no router daemon).

- **Status: Proposed** (MADR-lite).
- **Scope of this PR:** ADR file + ADR index row only.
- **Stacked on #56's ADR branch** (`docs/adr-0014-session-scoped-buffers`)
  because the gateway ADR references ADR-0014. After ADR-0014 merges, this PR's
  base will be retargeted to `main`.

Implementation issue: #57
Related: ADR-0003, ADR-0006, ADR-0007, ADR-0014
