### PR TITLE
docs: reflect ADR-0014 (buffers) and ADR-0015 (gateway) in specs

### DIFF
--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -57,6 +57,7 @@ see [03_wire_protocol.md](03_wire_protocol.md).
 <prefix>/base/<key...>                 # master data
 <prefix>/session/<sid>/<key...>        # session overlay (Put during execution)
 <prefix>/snap/<sid>/<key...>           # read view of the session snapshot (read-only)
+<prefix>/buffers/<sid>/<key...>        # session-scoped, disk-backed large values (pull+push) [ADR-0014]
 <prefix>/meta/session/<sid>            # session metadata (state, creation time)
 ```
 
@@ -67,6 +68,13 @@ see [03_wire_protocol.md](03_wire_protocol.md).
 * get to `snap/<sid>/**` → StorageNode responds from the snapshot view.
   put/delete through the library API returns a `ReadOnly` error; raw zenoh put/delete is
   fire-and-forget, so it is ignored + a warning is logged [F05, F08]
+* put to `buffers/<sid>/**` → for a `kDurable` session the StorageNode subscriber writes bytes
+  to the per-session buffer engine, and zenoh distributes the same bytes to live subscribers
+  (full-payload push); for `kEphemeral` nothing is stored [ADR-0014]
+* get to `buffers/<sid>/**` → for `kDurable`, the StorageNode queryable responds from the
+  per-session buffer engine; for `kEphemeral`, not-found. Buffers use no snapshot view [ADR-0014]
+* buffers live for the session lifetime: get-able from `CreateSession` until `CloseSession`,
+  which purges the per-session buffer store [ADR-0014]
 
 ## 3. StorageEngine Abstraction
 
@@ -117,14 +125,18 @@ Conventions:
    - `base/**` → engine
    - `snap/<sid>/**` → view in the snapshot table
    - `session/<sid>/**` → overlay table
+   - `buffers/<sid>/**` → per-session buffer engine (`kDurable`); not-found (`kEphemeral`) [ADR-0014]
 2. Declare zenoh `subscriber`: receive put/delete for `<prefix>/**`
    - `base/**` → apply to engine
    - `session/<sid>/**` → apply to overlay
    - put to `snap/**` → ignore + warning log (read-only)
+   - `buffers/<sid>/**` → per-session buffer engine (`kDurable`); no store (`kEphemeral`) [ADR-0014]
 3. Session lifecycle (via SessionController):
    - `CreateSession(sid)`: obtain `engine->TakeSnapshot()` and register it in
-     `snapshots_[sid]`. Create an empty `overlays_[sid]`
-   - `CloseSession(sid)`: delete both tables (release shared_ptr) [F10]
+     `snapshots_[sid]`. Create an empty `overlays_[sid]`. For buffers, create a
+     per-session disk buffer engine when the session is `kDurable` [ADR-0014]
+   - `CloseSession(sid)`: delete both tables (release shared_ptr) [F10], and purge
+     the per-session buffer engine [ADR-0014]
 
 ### 4.2 Data Structures
 

--- a/docs/03_wire_protocol.md
+++ b/docs/03_wire_protocol.md
@@ -11,6 +11,7 @@ A standard zenoh client can interoperate with sitos simply by following this spe
 <prefix>/base/<key>
 <prefix>/session/<sid>/<key>
 <prefix>/snap/<sid>/<key>
+<prefix>/buffers/<sid>/<key>
 <prefix>/meta/session/<sid>
 <prefix>/meta/ack/<uuid>
 <prefix>/base/$batch
@@ -20,6 +21,9 @@ A standard zenoh client can interoperate with sitos simply by following this spe
 * `<prefix>`: Default is `sitos`. Configurable. One or more zenoh chunks
 * `<sid>`: session ID. `[0-9a-zA-Z_-]+` (UUID recommended). One chunk
 * `<key>`: User key. One or more chunks (hierarchical keys allowed)
+* `buffers/<sid>/<key>`: session-scoped large binary values. `<sid>` and `<key>` follow the
+  same grammar as other scopes. No `$batch` and no `snap` counterpart. The persistence mode
+  (durable/ephemeral) is a host-side session option and is **not** encoded on the wire [ADR-0014]
 
 ### 1.2 User-key grammar
 

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -5,7 +5,8 @@
 ```
 sitos/
   CMakeLists.txt              # Top level. Options: SITOS_WITH_ROCKSDB,
-                              #   SITOS_BUILD_PYTHON, SITOS_BUILD_TESTS, SITOS_BUILD_EXAMPLES
+                              #   SITOS_BUILD_PYTHON, SITOS_BUILD_TESTS, SITOS_BUILD_EXAMPLES,
+                              #   SITOS_BUILD_GATEWAY (optional HTTP gateway, ADR-0015)
   cmake/                      # zenoh-c integration (FetchContent/Corrosion/find_package)
   include/sitos/              # Public headers (API from 04_api_cpp.md)
   src/                        # Implementation
@@ -41,6 +42,8 @@ sitos/
     Also provide a Corrosion (Rust) path for environments that need source builds
   - **RocksDB** (when `SITOS_WITH_ROCKSDB=ON`): `find_package(RocksDB)`.
     Supplied by vcpkg / apt / brew
+  - **cpp-httplib** (when `SITOS_BUILD_GATEWAY=ON`): header-only, MIT. Pulled only
+    for the optional `sitos-gateway` component; the core build is unaffected when OFF [ADR-0015]
   - **gtest / benchmark**: FetchContent
 * Presets: define `dev-windows`, `dev-linux`, `release`, and `python-wheel` in
   `CMakePresets.json`

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -18,8 +18,8 @@ Milestone = release boundary).
 | **v0.1** | The zenoh-independent core works. Payload fixtures and InMemoryEngine contract tests are green | #1, #4, #5, #6, #7 |
 | **v0.2** | StorageNode/ParamStore/ParamCache work in C++ through same-process zenoh sessions | #2, #3, #9–#13, #15, #18, #19, #21 |
 | **v0.3** | Basic Python APIs work (InMemory, ParamStore, ParamCache, NumPy read) | #22, #23, #24, #25, #27 |
-| **v0.4** | RocksDB, single-value interop, bench, and examples are in place | #8, #29, #31, #32, #33 |
-| **v1.0** | Public OSS quality. docs/release/wheels/ack/batch interop/GIL/custom engine completed | #14, #16, #17, #20, #26, #28, #30, #34, #35 |
+| **v0.4** | RocksDB, single-value interop, bench, examples, and session-scoped buffers are in place | #8, #29, #31, #32, #33, #56 |
+| **v1.0** | Public OSS quality. docs/release/wheels/ack/batch interop/GIL/custom engine and the optional HTTP gateway completed | #14, #16, #17, #20, #26, #28, #30, #34, #35, #57 |
 
 `ack`-related work (#14, #17) is useful, but implementation is heavy relative to initial value,
 so it is not a v0.2 blocker. Include it by v1.0.
@@ -221,6 +221,21 @@ so it is not a v0.2 blocker. Include it by v1.0.
 * Acceptance criteria: integration tests — ack success/failure/timeout, Disconnected/Timeout when StorageNode is stopped
 * Depends on: #14, #15
 
+### #56 Session-scoped buffers
+* Milestone: v0.4
+* References: ADR-0014, [02] §2/§4, [03] §1
+* Implementation targets: `include/sitos/key.hpp` (`KeyKind::Buffer`, `BuildBufferKey`,
+  `ParseKey`), `src/storage_node.cpp` (`buffers/**` routing), SessionController
+  (`BufferPersistence`, per-session disk engine), `Config`/`SessionOptions`
+* Scope: independent `<prefix>/buffers/<sid>/<key>` scope; single put = full-payload push to
+  live subscribers + store to a per-session disk engine (`kDurable`) / push-only (`kEphemeral`);
+  get from the per-session engine; querying-subscriber late-join; purge on `CloseSession`.
+  No `$batch`, no snapshot
+* Acceptance criteria: key round-trip; push==get byte equality; late-join no-loss;
+  `kEphemeral` no-store/no-get; `CloseSession` purge → not-found; ParamCache scope isolation
+  (`session/**` never receives `buffers/**`); raw-zenoh interop
+* Depends on: #12 (session management), #8 (RocksDBEngine, disk-backed `kDurable`)
+
 ---
 
 ## M3: ParamCache and SessionView
@@ -398,6 +413,23 @@ so it is not a v0.2 blocker. Include it by v1.0.
 * Scope: NOTICE, complete the pre-publication checklist, reserve PyPI/crates names, release-please
 * Acceptance criteria: All checklist items completed, dry-run publish to TestPyPI succeeds
 * Depends on: M4 completed, #34
+
+---
+
+## M6: Optional HTTP gateway (optional component)
+
+### #57 Optional HTTP gateway component
+* Milestone: v1.0 (earliest v0.4)
+* References: ADR-0015, ADR-0003, ADR-0007, ADR-0014, [09]
+* Implementation targets: `sitos-gateway` library + thin binary (cpp-httplib),
+  CMake option `SITOS_BUILD_GATEWAY` (default OFF)
+* Scope: params/sessions/buffers routes typed over `sitos.v1`; SSE session deltas;
+  loopback-default bind + pluggable auth; `Router` extension point for host routes.
+  Core build unaffected when the option is OFF (cpp-httplib not fetched)
+* Acceptance criteria: OFF build unaffected; typed param round-trip; prefix List;
+  buffer GET (durable) / not-found (ephemeral); SSE observable with `curl -N`;
+  host route served on the same port; loopback-default + auth hook invoked
+* Depends on: #15/#16 (ParamStore), #18/#19 (ParamCache), #12 (sessions), #56 (buffers)
 
 ---
 


### PR DESCRIPTION
## Reflect accepted ADR-0014 (buffers) and ADR-0015 (gateway) in the design specs

Follows up the now-merged ADR-0014 (#59) and ADR-0015 (#61) by updating the
normative design docs. Spec-only; no code.

**ADR-0014 — session-scoped buffers**
- `docs/02` §2: add `<prefix>/buffers/<sid>/<key>` to the key space + put/get/lifetime bullets.
- `docs/02` §4.1: buffers routing on queryable/subscriber and buffer engine create/purge in session lifecycle.
- `docs/03` §1.1: add the `buffers/<sid>/<key>` path + grammar note (mode not on the wire).
- `docs/07`: v0.4 row + `#56` entry.

**ADR-0015 — optional HTTP gateway**
- `docs/06`: `SITOS_BUILD_GATEWAY` option + optional cpp-httplib dependency (core unaffected when OFF).
- `docs/07`: v1.0 row + new `## M6` section with `#57` entry.

Implementation issues: #56 (buffers), #57 (gateway).
Related: ADR-0014, ADR-0015.
