### PR TITLE
docs(spec): reflect ADR-0014 session-scoped buffers (#56)

### DIFF
--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -57,6 +57,7 @@ see [03_wire_protocol.md](03_wire_protocol.md).
 <prefix>/base/<key...>                 # master data
 <prefix>/session/<sid>/<key...>        # session overlay (Put during execution)
 <prefix>/snap/<sid>/<key...>           # read view of the session snapshot (read-only)
+<prefix>/buffers/<sid>/<key...>        # session-scoped, disk-backed large values (pull+push) [ADR-0014]
 <prefix>/meta/session/<sid>            # session metadata (state, creation time)
 ```
 
@@ -67,6 +68,13 @@ see [03_wire_protocol.md](03_wire_protocol.md).
 * get to `snap/<sid>/**` → StorageNode responds from the snapshot view.
   put/delete through the library API returns a `ReadOnly` error; raw zenoh put/delete is
   fire-and-forget, so it is ignored + a warning is logged [F05, F08]
+* put to `buffers/<sid>/**` → for a `kDurable` session the StorageNode subscriber writes bytes
+  to the per-session buffer engine, and zenoh distributes the same bytes to live subscribers
+  (full-payload push); for `kEphemeral` nothing is stored [ADR-0014]
+* get to `buffers/<sid>/**` → for `kDurable`, the StorageNode queryable responds from the
+  per-session buffer engine; for `kEphemeral`, not-found. Buffers use no snapshot view [ADR-0014]
+* buffers live for the session lifetime: get-able from `CreateSession` until `CloseSession`,
+  which purges the per-session buffer store [ADR-0014]
 
 ## 3. StorageEngine Abstraction
 
@@ -117,14 +125,18 @@ Conventions:
    - `base/**` → engine
    - `snap/<sid>/**` → view in the snapshot table
    - `session/<sid>/**` → overlay table
+   - `buffers/<sid>/**` → per-session buffer engine (`kDurable`); not-found (`kEphemeral`) [ADR-0014]
 2. Declare zenoh `subscriber`: receive put/delete for `<prefix>/**`
    - `base/**` → apply to engine
    - `session/<sid>/**` → apply to overlay
    - put to `snap/**` → ignore + warning log (read-only)
+   - `buffers/<sid>/**` → per-session buffer engine (`kDurable`); no store (`kEphemeral`) [ADR-0014]
 3. Session lifecycle (via SessionController):
    - `CreateSession(sid)`: obtain `engine->TakeSnapshot()` and register it in
-     `snapshots_[sid]`. Create an empty `overlays_[sid]`
-   - `CloseSession(sid)`: delete both tables (release shared_ptr) [F10]
+     `snapshots_[sid]`. Create an empty `overlays_[sid]`. For buffers, create a
+     per-session disk buffer engine when the session is `kDurable` [ADR-0014]
+   - `CloseSession(sid)`: delete both tables (release shared_ptr) [F10], and purge
+     the per-session buffer engine [ADR-0014]
 
 ### 4.2 Data Structures
 

--- a/docs/03_wire_protocol.md
+++ b/docs/03_wire_protocol.md
@@ -11,6 +11,7 @@ A standard zenoh client can interoperate with sitos simply by following this spe
 <prefix>/base/<key>
 <prefix>/session/<sid>/<key>
 <prefix>/snap/<sid>/<key>
+<prefix>/buffers/<sid>/<key>
 <prefix>/meta/session/<sid>
 <prefix>/meta/ack/<uuid>
 <prefix>/base/$batch
@@ -20,6 +21,9 @@ A standard zenoh client can interoperate with sitos simply by following this spe
 * `<prefix>`: Default is `sitos`. Configurable. One or more zenoh chunks
 * `<sid>`: session ID. `[0-9a-zA-Z_-]+` (UUID recommended). One chunk
 * `<key>`: User key. One or more chunks (hierarchical keys allowed)
+* `buffers/<sid>/<key>`: session-scoped large binary values. `<sid>` and `<key>` follow the
+  same grammar as other scopes. No `$batch` and no `snap` counterpart. The persistence mode
+  (durable/ephemeral) is a host-side session option and is **not** encoded on the wire [ADR-0014]
 
 ### 1.2 User-key grammar
 

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -18,7 +18,7 @@ Milestone = release boundary).
 | **v0.1** | The zenoh-independent core works. Payload fixtures and InMemoryEngine contract tests are green | #1, #4, #5, #6, #7 |
 | **v0.2** | StorageNode/ParamStore/ParamCache work in C++ through same-process zenoh sessions | #2, #3, #9–#13, #15, #18, #19, #21 |
 | **v0.3** | Basic Python APIs work (InMemory, ParamStore, ParamCache, NumPy read) | #22, #23, #24, #25, #27 |
-| **v0.4** | RocksDB, single-value interop, bench, and examples are in place | #8, #29, #31, #32, #33 |
+| **v0.4** | RocksDB, single-value interop, bench, examples, and session-scoped buffers are in place | #8, #29, #31, #32, #33, #56 |
 | **v1.0** | Public OSS quality. docs/release/wheels/ack/batch interop/GIL/custom engine completed | #14, #16, #17, #20, #26, #28, #30, #34, #35 |
 
 `ack`-related work (#14, #17) is useful, but implementation is heavy relative to initial value,
@@ -220,6 +220,21 @@ so it is not a v0.2 blocker. Include it by v1.0.
 * Scope: PutOptions::ack, ack timeout/retry, detailed Status mapping
 * Acceptance criteria: integration tests — ack success/failure/timeout, Disconnected/Timeout when StorageNode is stopped
 * Depends on: #14, #15
+
+### #56 Session-scoped buffers
+* Milestone: v0.4
+* References: ADR-0014, [02] §2/§4, [03] §1
+* Implementation targets: `include/sitos/key.hpp` (`KeyKind::Buffer`, `BuildBufferKey`,
+  `ParseKey`), `src/storage_node.cpp` (`buffers/**` routing), SessionController
+  (`BufferPersistence`, per-session disk engine), `Config`/`SessionOptions`
+* Scope: independent `<prefix>/buffers/<sid>/<key>` scope; single put = full-payload push to
+  live subscribers + store to a per-session disk engine (`kDurable`) / push-only (`kEphemeral`);
+  get from the per-session engine; querying-subscriber late-join; purge on `CloseSession`.
+  No `$batch`, no snapshot
+* Acceptance criteria: key round-trip; push==get byte equality; late-join no-loss;
+  `kEphemeral` no-store/no-get; `CloseSession` purge → not-found; ParamCache scope isolation
+  (`session/**` never receives `buffers/**`); raw-zenoh interop
+* Depends on: #12 (session management), #8 (RocksDBEngine, disk-backed `kDurable`)
 
 ---
 


### PR DESCRIPTION
## Reflect accepted ADR-0014 (session-scoped buffers) in the design specs

Spec-only follow-up to the merged ADR-0014 (#59). No code.

- `docs/02` §2: add `<prefix>/buffers/<sid>/<key>` to the key space + put/get/lifetime bullets.
- `docs/02` §4.1: buffers routing on queryable/subscriber; per-session buffer engine create/purge in session lifecycle.
- `docs/03` §1.1: add the `buffers/<sid>/<key>` path + grammar note (mode not on the wire).
- `docs/07`: v0.4 row + `#56` entry.

Refs #56
Related: ADR-0014
