### PR TITLE
docs(spec): reflect ADR-0015 optional HTTP gateway (#57)

### DIFF
--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -5,7 +5,8 @@
 ```
 sitos/
   CMakeLists.txt              # Top level. Options: SITOS_WITH_ROCKSDB,
-                              #   SITOS_BUILD_PYTHON, SITOS_BUILD_TESTS, SITOS_BUILD_EXAMPLES
+                              #   SITOS_BUILD_PYTHON, SITOS_BUILD_TESTS, SITOS_BUILD_EXAMPLES,
+                              #   SITOS_BUILD_GATEWAY (optional HTTP gateway, ADR-0015)
   cmake/                      # zenoh-c integration (FetchContent/Corrosion/find_package)
   include/sitos/              # Public headers (API from 04_api_cpp.md)
   src/                        # Implementation
@@ -41,6 +42,8 @@ sitos/
     Also provide a Corrosion (Rust) path for environments that need source builds
   - **RocksDB** (when `SITOS_WITH_ROCKSDB=ON`): `find_package(RocksDB)`.
     Supplied by vcpkg / apt / brew
+  - **cpp-httplib** (when `SITOS_BUILD_GATEWAY=ON`): header-only, MIT. Pulled only
+    for the optional `sitos-gateway` component; the core build is unaffected when OFF [ADR-0015]
   - **gtest / benchmark**: FetchContent
 * Presets: define `dev-windows`, `dev-linux`, `release`, and `python-wheel` in
   `CMakePresets.json`

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -19,7 +19,7 @@ Milestone = release boundary).
 | **v0.2** | StorageNode/ParamStore/ParamCache work in C++ through same-process zenoh sessions | #2, #3, #9–#13, #15, #18, #19, #21 |
 | **v0.3** | Basic Python APIs work (InMemory, ParamStore, ParamCache, NumPy read) | #22, #23, #24, #25, #27 |
 | **v0.4** | RocksDB, single-value interop, bench, examples, and session-scoped buffers are in place | #8, #29, #31, #32, #33, #56 |
-| **v1.0** | Public OSS quality. docs/release/wheels/ack/batch interop/GIL/custom engine completed | #14, #16, #17, #20, #26, #28, #30, #34, #35 |
+| **v1.0** | Public OSS quality. docs/release/wheels/ack/batch interop/GIL/custom engine and the optional HTTP gateway completed | #14, #16, #17, #20, #26, #28, #30, #34, #35, #57 |
 
 `ack`-related work (#14, #17) is useful, but implementation is heavy relative to initial value,
 so it is not a v0.2 blocker. Include it by v1.0.
@@ -413,6 +413,23 @@ so it is not a v0.2 blocker. Include it by v1.0.
 * Scope: NOTICE, complete the pre-publication checklist, reserve PyPI/crates names, release-please
 * Acceptance criteria: All checklist items completed, dry-run publish to TestPyPI succeeds
 * Depends on: M4 completed, #34
+
+---
+
+## M6: Optional HTTP gateway (optional component)
+
+### #57 Optional HTTP gateway component
+* Milestone: v1.0 (earliest v0.4)
+* References: ADR-0015, ADR-0003, ADR-0007, ADR-0014, [09]
+* Implementation targets: `sitos-gateway` library + thin binary (cpp-httplib),
+  CMake option `SITOS_BUILD_GATEWAY` (default OFF)
+* Scope: params/sessions/buffers routes typed over `sitos.v1`; SSE session deltas;
+  loopback-default bind + pluggable auth; `Router` extension point for host routes.
+  Core build unaffected when the option is OFF (cpp-httplib not fetched)
+* Acceptance criteria: OFF build unaffected; typed param round-trip; prefix List;
+  buffer GET (durable) / not-found (ephemeral); SSE observable with `curl -N`;
+  host route served on the same port; loopback-default + auth hook invoked
+* Depends on: #15/#16 (ParamStore), #18/#19 (ParamCache), #12 (sessions), #56 (buffers)
 
 ---
 


### PR DESCRIPTION
## Reflect accepted ADR-0015 (optional HTTP gateway) in the design specs

Spec-only follow-up to the merged ADR-0015 (#61). No code.

- `docs/06`: `SITOS_BUILD_GATEWAY` option + optional cpp-httplib dependency (core unaffected when OFF).
- `docs/07`: v1.0 row + new `## M6` section with the `#57` entry.

Refs #57
Related: ADR-0015, ADR-0014

> Note: touches `docs/07` alongside #63 (buffers). Merge #63 first; this branch will be rebased on the updated main to avoid a release-table conflict.
