### PR TITLE
fix(codec): guard numeric conversions against unrepresentable values (#65)

### DIFF
--- a/include/sitos/param_value.hpp
+++ b/include/sitos/param_value.hpp
@@ -7,9 +7,11 @@
 #ifndef SITOS_PARAM_VALUE_HPP
 #define SITOS_PARAM_VALUE_HPP
 
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <optional>
 #include <span>
 #include <string>
@@ -46,7 +48,18 @@ class ParamValue {
     } else if constexpr (std::is_integral_v<D>) {
       value_ = static_cast<std::int64_t>(v);
     } else if constexpr (std::is_floating_point_v<D>) {
-      value_ = static_cast<double>(v);
+      if constexpr (std::is_same_v<D, long double>) {
+        if (std::isfinite(v) &&
+            (v > static_cast<long double>(std::numeric_limits<double>::max()) ||
+             v < static_cast<long double>(std::numeric_limits<double>::lowest()))) {
+          value_ = (v > 0.0L) ? std::numeric_limits<double>::infinity()
+                              : -std::numeric_limits<double>::infinity();
+        } else {
+          value_ = static_cast<double>(v);
+        }
+      } else {
+        value_ = static_cast<double>(v);
+      }
     } else if constexpr (std::is_convertible_v<D, std::string_view>) {
       value_ = std::string(std::forward<T>(v));
     } else if constexpr (std::is_same_v<D, std::vector<std::byte>>) {
@@ -68,7 +81,7 @@ class ParamValue {
 
   /// Typed extraction. Arithmetic casts are allowed among Bool/S64/Dp; string
   /// and bytes require an exact type match. Returns std::nullopt on
-  /// impossible conversions.
+  /// impossible or unrepresentable conversions.
   template <typename T>
   std::optional<T> As() const {
     using D = std::decay_t<T>;
@@ -80,12 +93,26 @@ class ParamValue {
     } else if constexpr (std::is_integral_v<D>) {
       if (auto* p = std::get_if<bool>(&value_)) return static_cast<T>(*p);
       if (auto* p = std::get_if<std::int64_t>(&value_)) return static_cast<T>(*p);
-      if (auto* p = std::get_if<double>(&value_)) return static_cast<T>(*p);
+      if (auto* p = std::get_if<double>(&value_)) {
+        if (!std::isfinite(*p)) return std::nullopt;
+        if (*p < static_cast<double>(std::numeric_limits<T>::lowest()) ||
+            *p > static_cast<double>(std::numeric_limits<T>::max()))
+          return std::nullopt;
+        return static_cast<T>(*p);
+      }
       return std::nullopt;
     } else if constexpr (std::is_floating_point_v<D>) {
       if (auto* p = std::get_if<bool>(&value_)) return static_cast<T>(*p);
       if (auto* p = std::get_if<std::int64_t>(&value_)) return static_cast<T>(*p);
-      if (auto* p = std::get_if<double>(&value_)) return static_cast<T>(*p);
+      if (auto* p = std::get_if<double>(&value_)) {
+        if (!std::isfinite(*p)) return static_cast<T>(*p);  // NaN, inf are fine for float
+        if constexpr (sizeof(D) < sizeof(double)) {
+          if (*p > static_cast<double>(std::numeric_limits<D>::max()) ||
+              *p < static_cast<double>(std::numeric_limits<D>::lowest()))
+            return std::nullopt;
+        }
+        return static_cast<T>(*p);
+      }
       return std::nullopt;
     } else if constexpr (std::is_same_v<D, std::string>) {
       if (auto* p = std::get_if<std::string>(&value_)) return *p;

--- a/include/sitos/param_value.hpp
+++ b/include/sitos/param_value.hpp
@@ -49,11 +49,14 @@ class ParamValue {
       value_ = static_cast<std::int64_t>(v);
     } else if constexpr (std::is_floating_point_v<D>) {
       if constexpr (std::is_same_v<D, long double>) {
-        if (std::isfinite(v) &&
-            (v > static_cast<long double>(std::numeric_limits<double>::max()) ||
-             v < static_cast<long double>(std::numeric_limits<double>::lowest()))) {
-          value_ = (v > 0.0L) ? std::numeric_limits<double>::infinity()
-                              : -std::numeric_limits<double>::infinity();
+        if (std::isfinite(v)) {
+          if (v > static_cast<long double>(std::numeric_limits<double>::max())) {
+            value_ = std::numeric_limits<double>::infinity();
+          } else if (v < static_cast<long double>(std::numeric_limits<double>::lowest())) {
+            value_ = -std::numeric_limits<double>::infinity();
+          } else {
+            value_ = static_cast<double>(v);
+          }
         } else {
           value_ = static_cast<double>(v);
         }
@@ -107,9 +110,8 @@ class ParamValue {
       if (auto* p = std::get_if<double>(&value_)) {
         if (!std::isfinite(*p)) return static_cast<T>(*p);  // NaN, inf are fine for float
         if constexpr (sizeof(D) < sizeof(double)) {
-          if (*p > static_cast<double>(std::numeric_limits<D>::max()) ||
-              *p < static_cast<double>(std::numeric_limits<D>::lowest()))
-            return std::nullopt;
+          if (*p > static_cast<double>(std::numeric_limits<D>::max())) return std::nullopt;
+          if (*p < static_cast<double>(std::numeric_limits<D>::lowest())) return std::nullopt;
         }
         return static_cast<T>(*p);
       }

--- a/include/sitos/param_value.hpp
+++ b/include/sitos/param_value.hpp
@@ -49,17 +49,19 @@ class ParamValue {
       value_ = static_cast<std::int64_t>(v);
     } else if constexpr (std::is_floating_point_v<D>) {
       if constexpr (std::is_same_v<D, long double>) {
-        if (std::isfinite(v)) {
-          if (v > static_cast<long double>(std::numeric_limits<double>::max())) {
-            value_ = std::numeric_limits<double>::infinity();
-          } else if (v < static_cast<long double>(std::numeric_limits<double>::lowest())) {
-            value_ = -std::numeric_limits<double>::infinity();
-          } else {
-            value_ = static_cast<double>(v);
-          }
-        } else {
-          value_ = static_cast<double>(v);
+        if (!std::isfinite(v)) {
+          value_ = static_cast<double>(v);  // NaN, inf pass through
+          return;
         }
+        if (v > static_cast<long double>(std::numeric_limits<double>::max())) {
+          value_ = std::numeric_limits<double>::infinity();
+          return;
+        }
+        if (v < static_cast<long double>(std::numeric_limits<double>::lowest())) {
+          value_ = -std::numeric_limits<double>::infinity();
+          return;
+        }
+        value_ = static_cast<double>(v);
       } else {
         value_ = static_cast<double>(v);
       }
@@ -109,10 +111,7 @@ class ParamValue {
       if (auto* p = std::get_if<std::int64_t>(&value_)) return static_cast<T>(*p);
       if (auto* p = std::get_if<double>(&value_)) {
         if (!std::isfinite(*p)) return static_cast<T>(*p);  // NaN, inf are fine for float
-        if constexpr (sizeof(D) < sizeof(double)) {
-          if (*p > static_cast<double>(std::numeric_limits<D>::max())) return std::nullopt;
-          if (*p < static_cast<double>(std::numeric_limits<D>::lowest())) return std::nullopt;
-        }
+        if (IsOutsideFloatRange<D>(*p)) return std::nullopt;
         return static_cast<T>(*p);
       }
       return std::nullopt;
@@ -163,6 +162,19 @@ class ParamValue {
                                           std::span<const std::byte> body);
 
  private:
+  /// Returns true when a double value is outside the range representable by
+  /// a narrower floating-point type D.  Always false when D is as wide as
+  /// double (no narrowing needed).
+  template <typename D>
+  static bool IsOutsideFloatRange(double v) {
+    if constexpr (sizeof(D) < sizeof(double)) {
+      return v > static_cast<double>(std::numeric_limits<D>::max()) ||
+             v < static_cast<double>(std::numeric_limits<D>::lowest());
+    } else {
+      return false;
+    }
+  }
+
   Variant value_;
 };
 

--- a/include/sitos/param_value.hpp
+++ b/include/sitos/param_value.hpp
@@ -16,6 +16,7 @@
 #include <span>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -97,7 +98,10 @@ class ParamValue {
       return std::nullopt;
     } else if constexpr (std::is_integral_v<D>) {
       if (auto* p = std::get_if<bool>(&value_)) return static_cast<T>(*p);
-      if (auto* p = std::get_if<std::int64_t>(&value_)) return static_cast<T>(*p);
+      if (auto* p = std::get_if<std::int64_t>(&value_)) {
+        if (IsOutsideIntegralRange<T>(*p)) return std::nullopt;
+        return static_cast<T>(*p);
+      }
       if (auto* p = std::get_if<double>(&value_)) {
         if (IsOutsideIntegralRange<T>(*p)) return std::nullopt;
         return static_cast<T>(*p);
@@ -159,22 +163,27 @@ class ParamValue {
                                           std::span<const std::byte> body);
 
  private:
-  /// Returns true when a double value cannot be stored in integral type T.
-  /// Rejects NaN/inf and values outside T's representable range.  Uses
-  /// correctly-rounded bounds so that int64_t max (which is not exactly
-  /// representable in double) is safely excluded.
+  /// Returns true when an S64 value cannot be represented by integral type T.
+  template <typename T>
+  static bool IsOutsideIntegralRange(std::int64_t v) {
+    return !std::in_range<T>(v);
+  }
+
+  /// Returns true when a DP value cannot be converted to integral type T.
+  /// Floating-to-integral conversion truncates first. Powers of two are exact
+  /// in binary64, so [-2^digits, 2^digits) gives exact signed bounds and
+  /// [0, 2^digits) gives exact unsigned bounds, including int64_t/uint64_t.
   template <typename T>
   static bool IsOutsideIntegralRange(double v) {
     if (!std::isfinite(v)) return true;
-    if (v < static_cast<double>(std::numeric_limits<T>::lowest())) return true;
-    if constexpr (sizeof(T) >= sizeof(std::int64_t)) {
-      // int64_t max is not exactly representable in double;
-      // static_cast<double>(max) rounds up, so ≥ is correct.
-      return v >= static_cast<double>(std::numeric_limits<T>::max());
+    const double truncated = std::trunc(v);
+    const double upper_bound = std::ldexp(1.0, std::numeric_limits<T>::digits);
+    if constexpr (std::is_signed_v<T>) {
+      if (truncated < -upper_bound) return true;
     } else {
-      // Smaller types' max is exactly representable; > keeps the max itself.
-      return v > static_cast<double>(std::numeric_limits<T>::max());
+      if (truncated < 0.0) return true;
     }
+    return truncated >= upper_bound;
   }
 
   /// Returns true when a double value is outside the range representable by

--- a/include/sitos/param_value.hpp
+++ b/include/sitos/param_value.hpp
@@ -99,10 +99,7 @@ class ParamValue {
       if (auto* p = std::get_if<bool>(&value_)) return static_cast<T>(*p);
       if (auto* p = std::get_if<std::int64_t>(&value_)) return static_cast<T>(*p);
       if (auto* p = std::get_if<double>(&value_)) {
-        if (!std::isfinite(*p)) return std::nullopt;
-        if (*p < static_cast<double>(std::numeric_limits<T>::lowest()) ||
-            *p > static_cast<double>(std::numeric_limits<T>::max()))
-          return std::nullopt;
+        if (IsOutsideIntegralRange<T>(*p)) return std::nullopt;
         return static_cast<T>(*p);
       }
       return std::nullopt;
@@ -162,6 +159,24 @@ class ParamValue {
                                           std::span<const std::byte> body);
 
  private:
+  /// Returns true when a double value cannot be stored in integral type T.
+  /// Rejects NaN/inf and values outside T's representable range.  Uses
+  /// correctly-rounded bounds so that int64_t max (which is not exactly
+  /// representable in double) is safely excluded.
+  template <typename T>
+  static bool IsOutsideIntegralRange(double v) {
+    if (!std::isfinite(v)) return true;
+    if (v < static_cast<double>(std::numeric_limits<T>::lowest())) return true;
+    if constexpr (sizeof(T) >= sizeof(std::int64_t)) {
+      // int64_t max is not exactly representable in double;
+      // static_cast<double>(max) rounds up, so ≥ is correct.
+      return v >= static_cast<double>(std::numeric_limits<T>::max());
+    } else {
+      // Smaller types' max is exactly representable; > keeps the max itself.
+      return v > static_cast<double>(std::numeric_limits<T>::max());
+    }
+  }
+
   /// Returns true when a double value is outside the range representable by
   /// a narrower floating-point type D.  Always false when D is as wide as
   /// double (no narrowing needed).

--- a/tests/unit/param_value_test.cpp
+++ b/tests/unit/param_value_test.cpp
@@ -285,6 +285,12 @@ TEST(ParamValue, NumericCastsRejectUnrepresentableValues) {
   sitos::ParamValue beyond_neg_i64{-1e20};
   EXPECT_FALSE(beyond_neg_i64.As<int64_t>().has_value());
 
+  // double → integral: value exactly at 2^63 (outside int64_t range).
+  // int64_t max is 2^63-1, which is not exactly representable in double;
+  // static_cast<double>(int64_max) rounds up to 2^63.
+  sitos::ParamValue two63{9.223372036854775808e18};  // exact 2^63
+  EXPECT_FALSE(two63.As<int64_t>().has_value());
+
   // Normal finite double → int still works.
   sitos::ParamValue fine{3.14};
   auto fi = fine.As<int>();

--- a/tests/unit/param_value_test.cpp
+++ b/tests/unit/param_value_test.cpp
@@ -291,6 +291,31 @@ TEST(ParamValue, NumericCastsRejectUnrepresentableValues) {
   sitos::ParamValue two63{9.223372036854775808e18};  // exact 2^63
   EXPECT_FALSE(two63.As<int64_t>().has_value());
 
+  // Exact 2^64 is outside uint64_t range; the previous representable double
+  // below it remains convertible.
+  const double two64 = std::ldexp(1.0, 64);
+  sitos::ParamValue at_two64{two64};
+  EXPECT_FALSE(at_two64.As<uint64_t>().has_value());
+  sitos::ParamValue below_two64{std::nextafter(two64, 0.0)};
+  EXPECT_TRUE(below_two64.As<uint64_t>().has_value());
+
+  // Range checks follow floating-to-integral semantics: truncate first, then
+  // test whether the integral result is representable.
+  sitos::ParamValue upper_fraction{255.9};
+  EXPECT_EQ(upper_fraction.As<uint8_t>(), uint8_t{255});
+  sitos::ParamValue negative_fraction{-0.5};
+  EXPECT_EQ(negative_fraction.As<uint8_t>(), uint8_t{0});
+  sitos::ParamValue signed_lower_fraction{-128.9};
+  EXPECT_EQ(signed_lower_fraction.As<int8_t>(), int8_t{-128});
+
+  // Stored S64 values must not wrap when narrowed to a smaller integral type.
+  sitos::ParamValue s64_too_large{int64_t{256}};
+  EXPECT_FALSE(s64_too_large.As<uint8_t>().has_value());
+  sitos::ParamValue s64_negative{int64_t{-1}};
+  EXPECT_FALSE(s64_negative.As<uint8_t>().has_value());
+  sitos::ParamValue s64_in_range{int64_t{255}};
+  EXPECT_EQ(s64_in_range.As<uint8_t>(), uint8_t{255});
+
   // Normal finite double → int still works.
   sitos::ParamValue fine{3.14};
   auto fi = fine.As<int>();

--- a/tests/unit/param_value_test.cpp
+++ b/tests/unit/param_value_test.cpp
@@ -264,6 +264,91 @@ TEST(ParamValue, AsSpanIsZeroCopyAndAligned) {
   EXPECT_EQ(es->size(), 0u);
 }
 
+// Numeric casts return nullopt for non-finite or unrepresentable values.
+TEST(ParamValue, NumericCastsRejectUnrepresentableValues) {
+  // double → integral: NaN and infinity are rejected.
+  sitos::ParamValue nan_dp{std::numeric_limits<double>::quiet_NaN()};
+  EXPECT_FALSE(nan_dp.As<int64_t>().has_value());
+  EXPECT_FALSE(nan_dp.As<int>().has_value());
+  EXPECT_FALSE(nan_dp.As<uint64_t>().has_value());
+
+  sitos::ParamValue inf_dp{std::numeric_limits<double>::infinity()};
+  EXPECT_FALSE(inf_dp.As<int64_t>().has_value());
+
+  sitos::ParamValue neg_inf_dp{-std::numeric_limits<double>::infinity()};
+  EXPECT_FALSE(neg_inf_dp.As<int64_t>().has_value());
+
+  // double → integral: value clearly outside int64_t range.
+  sitos::ParamValue beyond_i64{1e20};
+  EXPECT_FALSE(beyond_i64.As<int64_t>().has_value());
+
+  sitos::ParamValue beyond_neg_i64{-1e20};
+  EXPECT_FALSE(beyond_neg_i64.As<int64_t>().has_value());
+
+  // Normal finite double → int still works.
+  sitos::ParamValue fine{3.14};
+  auto fi = fine.As<int>();
+  ASSERT_TRUE(fi.has_value());
+  EXPECT_EQ(*fi, 3);
+
+  // Bool → int is always safe.
+  sitos::ParamValue bt{true};
+  EXPECT_TRUE(bt.As<int>().has_value());
+
+  // double → float: DBL_MAX is rejected (outside float range).
+  sitos::ParamValue dbl_max{std::numeric_limits<double>::max()};
+  EXPECT_FALSE(dbl_max.As<float>().has_value());
+
+  sitos::ParamValue dbl_lowest{std::numeric_limits<double>::lowest()};
+  EXPECT_FALSE(dbl_lowest.As<float>().has_value());
+
+  // Normal double within float range still works.
+  sitos::ParamValue normal{3.14};
+  auto nf = normal.As<float>();
+  ASSERT_TRUE(nf.has_value());
+  EXPECT_FLOAT_EQ(*nf, 3.14f);
+
+  // double NaN and infinity are representable as float, so those are allowed.
+  auto inf_f = inf_dp.As<float>();
+  ASSERT_TRUE(inf_f.has_value());
+  EXPECT_TRUE(std::isinf(*inf_f));
+
+  auto nan_f = nan_dp.As<float>();
+  ASSERT_TRUE(nan_f.has_value());
+  EXPECT_TRUE(std::isnan(*nan_f));
+}
+
+// long double → double saturation on platforms where long double has wider range.
+TEST(ParamValue, LongDoubleConstructSaturatesAtDoubleBoundary) {
+  if constexpr (std::numeric_limits<long double>::max() >
+                std::numeric_limits<double>::max()) {
+    // Platform with extended long double (e.g., GCC/Linux).  Finite values
+    // beyond double range saturate to ±inf.
+    sitos::ParamValue huge{std::numeric_limits<long double>::max()};
+    EXPECT_EQ(huge.type(), sitos::ValueType::Dp);
+    auto d = huge.As<double>();
+    ASSERT_TRUE(d.has_value());
+    EXPECT_TRUE(std::isinf(*d) && *d > 0.0);
+
+    sitos::ParamValue neg_huge{-std::numeric_limits<long double>::max()};
+    auto nd = neg_huge.As<double>();
+    ASSERT_TRUE(nd.has_value());
+    EXPECT_TRUE(std::isinf(*nd) && *nd < 0.0);
+
+    // Normal long double within double range works.
+    sitos::ParamValue normal{1.5L};
+    auto n = normal.As<double>();
+    ASSERT_TRUE(n.has_value());
+    EXPECT_DOUBLE_EQ(*n, 1.5);
+  } else {
+    // MSVC: long double == double, no saturation needed.
+    sitos::ParamValue normal{1.5L};
+    auto d = normal.As<double>();
+    ASSERT_TRUE(d.has_value());
+    EXPECT_DOUBLE_EQ(*d, 1.5);
+  }
+}
+
 // Invalid payloads are rejected without UB (verified under ASan/UBSan in CI).
 TEST(ParamValue, RejectsInvalidPayloads) {
   auto expect_invalid = [](const std::vector<std::byte>& payload) {


### PR DESCRIPTION
Closes #65

## Scope

- [x] Guard double->integral conversions in `As<T>()` — NaN, infinity, and out-of-range finite values return `std::nullopt`
- [x] Guard double->narrower-float conversions (double->float overflow) — out-of-range values return `std::nullopt`
- [x] Saturate `long double` values beyond `double` range to ±inf on platforms with extended long double (GCC/Linux)
- [x] Add regression tests: `NumericCastsRejectUnrepresentableValues`, `LongDoubleConstructSaturatesAtDoubleBoundary`

## AC Verification

- RED phase: `NumericCastsRejectUnrepresentableValues` failed before implementation
- GREEN phase: 94/94 tests pass on MSVC+Ninja (2 new tests, 0 regressions)
