### PR TITLE
fix(transport): check zenoh slice conversion result (#66)

### DIFF
--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -178,7 +178,7 @@ void OnGetReply(z_loaned_reply_t* reply, void* context) {
 
   const z_loaned_bytes_t* payload = z_sample_payload(sample);
   z_owned_slice_t slice;
-  z_bytes_to_slice(payload, &slice);
+  if (z_bytes_to_slice(payload, &slice) != Z_OK) return;
 
   const auto* data = reinterpret_cast<const std::byte*>(z_slice_data(z_slice_loan(&slice)));
   auto len = z_slice_len(z_slice_loan(&slice));


### PR DESCRIPTION
Closes #66

## Scope

- [x] Check `z_bytes_to_slice()` before loaning or dropping its output slice in `OnGetReply`.
- [x] Ensure an unsuccessful conversion neither loans nor drops an uninitialized slice.
- [x] Keep the successful slice lifetime and callback payload view valid through the sink invocation.
- [x] Add regression coverage for the failure path where testable.

## AC Verification

1. **A failed `z_bytes_to_slice()` cannot use or destroy an uninitialized owned slice.** — `OnGetReply` now returns immediately on `z_bytes_to_slice() != Z_OK` before any `z_slice_loan` or `z_drop` call.
2. **Existing transport round-trip and no-queryable tests remain green.** — 94/94 tests pass including `TransportTest.QueryableRoundTrip` and `TransportTest.GetWithoutQueryableDoesNotInvokeSink`.

## RED Phase

N/A — `z_bytes_to_slice` is a zenoh-c internal C API; it cannot be mocked or triggered to fail without a corrupted zenoh payload, which is not reachable through the public Transport interface. The fix is a return-value guard verified by code inspection and the existing round-trip test.

## Notes

- The `z_bytes_to_slice()` failure path is defensive: in zenoh-c 1.9.0 it only fails on internal allocation errors or corrupted `z_loaned_bytes_t`, neither of which is reachable through normal Transport operations.
- The successful path (slice lifetime, payload span validity through sink) is unchanged.