### PR TITLE
fix(transport): contain callback exceptions at C ABI boundary (#67)

### DIFF
--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -194,7 +194,16 @@ void OnGetReply(z_loaned_reply_t* reply, void* context) {
   Encoding enc;
   enc.id = "sitos.v1";
 
-  if (!c->sink(key_str, std::span<const std::byte>(data, len), enc)) {
+  try {
+    if (c->sink) {
+      if (!c->sink(key_str, std::span<const std::byte>(data, len), enc)) {
+        c->stop.store(true, std::memory_order_relaxed);
+      }
+    }
+  } catch (...) {
+    // Contain user sink exceptions at the C ABI boundary (#67). Stop further
+    // replies for this Get so the closure drains without re-entering a
+    // throwing sink.
     c->stop.store(true, std::memory_order_relaxed);
   }
   z_drop(z_move(slice));
@@ -405,6 +414,10 @@ class ZenohTransport : public Transport {
   Queryable DeclareQueryable(std::string_view keyexpr_str,
                              const std::function<void(TransportQuery&)>& callback) override {
     Queryable q;
+    // An empty callback is a programming error; return an empty handle with
+    // defined, safe behavior rather than registering a closure that would
+    // throw std::bad_function_call on every query (#67).
+    if (!callback) return q;
     q.impl_ = std::make_unique<Queryable::Impl>();
     if (!session_valid_) {
       q.impl_.reset();
@@ -443,7 +456,11 @@ class ZenohTransport : public Transport {
           tq.keyexpr = std::string(z_string_data(z_view_string_loan(&qks)),
                                    z_string_len(z_view_string_loan(&qks)));
 
-          state->callback(tq);
+          try {
+            if (state->callback) state->callback(tq);
+          } catch (...) {
+            // Contain user callback exceptions at the C ABI boundary (#67).
+          }
           std::lock_guard<std::mutex> lock(state->mutex);
           callback_state->active = false;
         },

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -171,42 +171,39 @@ struct GetReplyCtx {
 
 void OnGetReply(z_loaned_reply_t* reply, void* context) {
   auto* c = static_cast<GetReplyCtx*>(context);
-  if (c->stop.load(std::memory_order_relaxed)) return;
-
-  const z_loaned_sample_t* sample = z_reply_ok(reply);
-  if (!sample) return;
-
-  const z_loaned_bytes_t* payload = z_sample_payload(sample);
-  z_owned_slice_t slice;
-  if (z_bytes_to_slice(payload, &slice) != Z_OK) return;
-
-  const auto* data = reinterpret_cast<const std::byte*>(z_slice_data(z_slice_loan(&slice)));
-  auto len = z_slice_len(z_slice_loan(&slice));
-
-  z_view_string_t ks;
-  z_keyexpr_as_view_string(z_sample_keyexpr(sample), &ks);
-  std::string key_str(z_string_data(z_view_string_loan(&ks)),
-                      z_string_len(z_view_string_loan(&ks)));
-
-  // TODO(#3): Extract encoding from z_sample_encoding(sample).
-  // zenoh-c 1.9.0 does not expose encoding-to-string conversion;
-  // "sitos.v1" is the only encoding used in v0.1.
-  Encoding enc;
-  enc.id = "sitos.v1";
-
   try {
-    if (c->sink) {
-      if (!c->sink(key_str, std::span<const std::byte>(data, len), enc)) {
-        c->stop.store(true, std::memory_order_relaxed);
-      }
+    if (c->stop.load(std::memory_order_relaxed)) return;
+
+    const z_loaned_sample_t* sample = z_reply_ok(reply);
+    if (!sample) return;
+
+    const z_loaned_bytes_t* payload = z_sample_payload(sample);
+    ZenohOwned<z_owned_slice_t> slice;
+    if (z_bytes_to_slice(payload, slice.get()) != Z_OK) return;
+    slice.mark_valid();
+
+    const auto* data = reinterpret_cast<const std::byte*>(z_slice_data(slice.loan()));
+    auto len = z_slice_len(slice.loan());
+
+    z_view_string_t ks;
+    z_keyexpr_as_view_string(z_sample_keyexpr(sample), &ks);
+    std::string key_str(z_string_data(z_view_string_loan(&ks)),
+                        z_string_len(z_view_string_loan(&ks)));
+
+    // TODO(#3): Extract encoding from z_sample_encoding(sample).
+    // zenoh-c 1.9.0 does not expose encoding-to-string conversion;
+    // "sitos.v1" is the only encoding used in v0.1.
+    Encoding enc;
+    enc.id = "sitos.v1";
+
+    if (c->sink && !c->sink(key_str, std::span<const std::byte>(data, len), enc)) {
+      c->stop.store(true, std::memory_order_relaxed);
     }
   } catch (...) {
-    // Contain user sink exceptions at the C ABI boundary (#67). Stop further
-    // replies for this Get so the closure drains without re-entering a
-    // throwing sink.
+    // Contain all C++ exceptions at the zenoh-c callback boundary (#67).
+    // The RAII slice owner drops a successfully-created slice while unwinding.
     c->stop.store(true, std::memory_order_relaxed);
   }
-  z_drop(z_move(slice));
 }
 
 }  // namespace
@@ -227,7 +224,7 @@ struct QueryableState {
 struct QueryCallbackState {
   const z_loaned_query_t* query = nullptr;
   std::shared_ptr<QueryableState> queryable;
-  bool active = true;
+  std::atomic<bool> active{true};
 };
 
 }  // namespace
@@ -261,7 +258,7 @@ Result<void> TransportQuery::Reply(std::string_view key, std::span<const std::by
   // Hold the lock through z_query_reply() so Queryable::~Queryable() cannot
   // drop the underlying queryable while zenoh uses the loaned query.
   std::lock_guard<std::mutex> lock(queryable->mutex);
-  if (!callback_state->active || !queryable->alive || !callback_state->query) {
+  if (!callback_state->active.load() || !queryable->alive || !callback_state->query) {
     return Result<void>::Err(MakeError(TransportErrc::kErrNoQuery));
   }
 
@@ -327,6 +324,41 @@ bool OpenZenohSession(z_owned_session_t* session) {
 }  // namespace
 
 class ZenohTransport : public Transport {
+ private:
+  static void OnQueryable(z_loaned_query_t* query, void* context) {
+    std::shared_ptr<QueryCallbackState> callback_state;
+    try {
+      auto state = *static_cast<std::shared_ptr<QueryableState>*>(context);
+      callback_state = std::make_shared<QueryCallbackState>();
+      callback_state->query = query;
+      callback_state->queryable = state;
+
+      {
+        std::lock_guard<std::mutex> lock(state->mutex);
+        if (!state->alive) {
+          callback_state->active.store(false);
+          return;
+        }
+      }
+
+      TransportQuery tq;
+      tq.impl_ = std::make_unique<TransportQuery::Impl>();
+      tq.impl_->callback_state = callback_state;
+
+      z_view_string_t qks;
+      z_keyexpr_as_view_string(z_query_keyexpr(query), &qks);
+      tq.keyexpr = std::string(z_string_data(z_view_string_loan(&qks)),
+                               z_string_len(z_view_string_loan(&qks)));
+
+      if (state->callback) state->callback(tq);
+    } catch (...) {
+      // Contain all C++ exceptions at the zenoh-c callback boundary (#67).
+      if (callback_state) callback_state->active.store(false);
+      return;
+    }
+    callback_state->active.store(false);
+  }
+
  public:
   ZenohTransport() : session_valid_(OpenZenohSession(&session_)) {}
 
@@ -435,35 +467,7 @@ class ZenohTransport : public Transport {
     auto* context = new std::shared_ptr<QueryableState>(q.impl_->state);
     z_owned_closure_query_t closure;
     z_closure_query(
-        &closure,
-        +[](z_loaned_query_t* query, void* context) {
-          auto state = *static_cast<std::shared_ptr<QueryableState>*>(context);
-          auto callback_state = std::make_shared<QueryCallbackState>();
-          callback_state->query = query;
-          callback_state->queryable = state;
-
-          {
-            std::lock_guard<std::mutex> lock(state->mutex);
-            if (!state->alive) return;
-          }
-
-          TransportQuery tq;
-          tq.impl_ = std::make_unique<TransportQuery::Impl>();
-          tq.impl_->callback_state = callback_state;
-
-          z_view_string_t qks;
-          z_keyexpr_as_view_string(z_query_keyexpr(query), &qks);
-          tq.keyexpr = std::string(z_string_data(z_view_string_loan(&qks)),
-                                   z_string_len(z_view_string_loan(&qks)));
-
-          try {
-            if (state->callback) state->callback(tq);
-          } catch (...) {
-            // Contain user callback exceptions at the C ABI boundary (#67).
-          }
-          std::lock_guard<std::mutex> lock(state->mutex);
-          callback_state->active = false;
-        },
+        &closure, OnQueryable,
         +[](void* context) { delete static_cast<std::shared_ptr<QueryableState>*>(context); },
         context);
 

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -11,6 +11,7 @@
 #include <condition_variable>
 #include <cstddef>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -110,6 +111,89 @@ TEST_F(TransportTest, QueryableRoundTrip) {
   }
 
   EXPECT_EQ(received_payload, kExpectedPayload);
+}
+
+// A throwing user callback must not let a C++ exception cross the C ABI
+// boundary of the zenoh-c queryable closure. The process must survive and
+// the session must remain usable afterward.
+TEST_F(TransportTest, QueryableCallbackExceptionIsContained) {
+  const std::string kQueryKey = "sitos/test/query/throws";
+  sitos::Encoding enc;
+  enc.id = std::string(sitos::Encoding::kSitosV1);
+
+  auto q = transport_->DeclareQueryable(
+      kQueryKey,
+      [&](sitos::TransportQuery& /*tq*/) { throw std::runtime_error("boom"); });
+
+  // The queryable will be invoked but throws before replying. Get must return
+  // without crashing, and no reply should reach the sink.
+  bool sink_called = false;
+  auto result = transport_->Get(
+      kQueryKey,
+      [&](std::string_view, std::span<const std::byte>, const sitos::Encoding&) {
+        sink_called = true;
+        return true;
+      },
+      std::chrono::milliseconds(1000));
+
+  EXPECT_TRUE(result.IsOk());
+  EXPECT_FALSE(sink_called)
+      << "The queryable threw before replying, so no reply is expected";
+
+  // Prove the session is still healthy by round-tripping a working queryable.
+  const std::string kOkKey = "sitos/test/query/ok_after_throw";
+  const std::vector<std::byte> kPayload = {std::byte{0x01}};
+  auto q2 = transport_->DeclareQueryable(
+      kOkKey, [&](sitos::TransportQuery& tq) { tq.Reply(kOkKey, kPayload, enc); });
+
+  std::mutex mtx;
+  std::condition_variable cv;
+  bool done = false;
+  transport_->Get(
+      kOkKey,
+      [&](std::string_view, std::span<const std::byte> payload, const sitos::Encoding&) {
+        {
+          std::lock_guard<std::mutex> lock(mtx);
+          std::vector<std::byte> copy(payload.begin(), payload.end());
+          if (copy == kPayload) done = true;
+        }
+        cv.notify_one();
+        return false;
+      },
+      std::chrono::milliseconds(2000));
+  std::unique_lock<std::mutex> lock(mtx);
+  EXPECT_TRUE(cv.wait_for(lock, std::chrono::seconds(3), [&] { return done; }))
+      << "Session should remain usable after a contained callback exception";
+}
+
+// A throwing Get result sink must not let a C++ exception cross the C ABI
+// boundary of the zenoh-c reply closure.
+TEST_F(TransportTest, GetSinkExceptionIsContained) {
+  const std::string kQueryKey = "sitos/test/sink/throws";
+  sitos::Encoding enc;
+  enc.id = std::string(sitos::Encoding::kSitosV1);
+  const std::vector<std::byte> kPayload = {std::byte{0x42}};
+
+  auto q = transport_->DeclareQueryable(
+      kQueryKey, [&](sitos::TransportQuery& tq) { tq.Reply(kQueryKey, kPayload, enc); });
+
+  auto result = transport_->Get(
+      kQueryKey,
+      [&](std::string_view, std::span<const std::byte>, const sitos::Encoding&)
+          -> bool {
+        throw std::runtime_error("sink boom");
+      },
+      std::chrono::milliseconds(2000));
+
+  EXPECT_TRUE(result.IsOk());
+  // Reaching this assertion means the exception did not crash the process.
+}
+
+// An empty queryable callback must have defined, safe behavior: no crash on
+// declaration or destruction, and the session remains usable.
+TEST_F(TransportTest, EmptyQueryableCallbackIsSafe) {
+  auto q = transport_->DeclareQueryable("sitos/test/empty_cb", {});
+  // Destruction of the (empty) handle must not crash; it goes out of scope.
 }
 
 }  // namespace

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -189,6 +189,9 @@ TEST_F(TransportTest, GetSinkExceptionIsContained) {
   sitos::Encoding enc;
   enc.id = std::string(sitos::Encoding::kSitosV1);
   const std::vector<std::byte> kPayload = {std::byte{0x42}};
+  std::mutex sink_mutex;
+  std::condition_variable sink_cv;
+  bool sink_entered = false;
 
   auto q = transport_->DeclareQueryable(
       kQueryKey, [&](sitos::TransportQuery& tq) { tq.Reply(kQueryKey, kPayload, enc); });
@@ -197,12 +200,44 @@ TEST_F(TransportTest, GetSinkExceptionIsContained) {
       kQueryKey,
       [&](std::string_view, std::span<const std::byte>, const sitos::Encoding&)
           -> bool {
+        {
+          std::lock_guard<std::mutex> lock(sink_mutex);
+          sink_entered = true;
+        }
+        sink_cv.notify_one();
         throw std::runtime_error("sink boom");
       },
       std::chrono::milliseconds(2000));
 
   EXPECT_TRUE(result.IsOk());
-  // Reaching this assertion means the exception did not crash the process.
+  {
+    std::unique_lock<std::mutex> lock(sink_mutex);
+    EXPECT_TRUE(sink_cv.wait_for(lock, std::chrono::seconds(3),
+                                 [&] { return sink_entered; }))
+        << "The throwing sink must be invoked";
+  }
+
+  // Prove the session remains usable after the sink exception is contained.
+  std::mutex reply_mutex;
+  std::condition_variable reply_cv;
+  bool reply_received = false;
+  auto healthy_get = transport_->Get(
+      kQueryKey,
+      [&](std::string_view, std::span<const std::byte> payload, const sitos::Encoding&) {
+        {
+          std::lock_guard<std::mutex> lock(reply_mutex);
+          reply_received = std::vector<std::byte>(payload.begin(), payload.end()) == kPayload;
+        }
+        reply_cv.notify_one();
+        return false;
+      },
+      std::chrono::milliseconds(2000));
+
+  EXPECT_TRUE(healthy_get.IsOk());
+  std::unique_lock<std::mutex> lock(reply_mutex);
+  EXPECT_TRUE(reply_cv.wait_for(lock, std::chrono::seconds(3),
+                                [&] { return reply_received; }))
+      << "Session should remain usable after a contained sink exception";
 }
 
 // An empty queryable callback must have defined, safe behavior: no crash on

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <cstddef>
@@ -120,49 +121,64 @@ TEST_F(TransportTest, QueryableCallbackExceptionIsContained) {
   const std::string kQueryKey = "sitos/test/query/throws";
   sitos::Encoding enc;
   enc.id = std::string(sitos::Encoding::kSitosV1);
+  std::mutex callback_mutex;
+  std::condition_variable callback_cv;
+  bool callback_entered = false;
+  std::atomic<bool> sink_called{false};
 
-  auto q = transport_->DeclareQueryable(
-      kQueryKey,
-      [&](sitos::TransportQuery& /*tq*/) { throw std::runtime_error("boom"); });
+  auto q = transport_->DeclareQueryable(kQueryKey, [&](sitos::TransportQuery& /*tq*/) {
+    {
+      std::lock_guard<std::mutex> lock(callback_mutex);
+      callback_entered = true;
+    }
+    callback_cv.notify_one();
+    throw std::runtime_error("boom");
+  });
 
-  // The queryable will be invoked but throws before replying. Get must return
-  // without crashing, and no reply should reach the sink.
-  bool sink_called = false;
+  // The queryable will be invoked but throws before replying. Wait until it
+  // starts before checking that no reply reached the sink.
   auto result = transport_->Get(
       kQueryKey,
       [&](std::string_view, std::span<const std::byte>, const sitos::Encoding&) {
-        sink_called = true;
+        sink_called.store(true);
         return true;
       },
       std::chrono::milliseconds(1000));
 
   EXPECT_TRUE(result.IsOk());
-  EXPECT_FALSE(sink_called)
+  {
+    std::unique_lock<std::mutex> lock(callback_mutex);
+    EXPECT_TRUE(callback_cv.wait_for(lock, std::chrono::seconds(3),
+                                     [&] { return callback_entered; }));
+  }
+  EXPECT_FALSE(sink_called.load())
       << "The queryable threw before replying, so no reply is expected";
 
   // Prove the session is still healthy by round-tripping a working queryable.
   const std::string kOkKey = "sitos/test/query/ok_after_throw";
   const std::vector<std::byte> kPayload = {std::byte{0x01}};
+  std::mutex reply_mutex;
+  std::condition_variable reply_cv;
+  bool reply_received = false;
   auto q2 = transport_->DeclareQueryable(
       kOkKey, [&](sitos::TransportQuery& tq) { tq.Reply(kOkKey, kPayload, enc); });
 
-  std::mutex mtx;
-  std::condition_variable cv;
-  bool done = false;
-  transport_->Get(
+  auto healthy_get = transport_->Get(
       kOkKey,
       [&](std::string_view, std::span<const std::byte> payload, const sitos::Encoding&) {
         {
-          std::lock_guard<std::mutex> lock(mtx);
+          std::lock_guard<std::mutex> lock(reply_mutex);
           std::vector<std::byte> copy(payload.begin(), payload.end());
-          if (copy == kPayload) done = true;
+          if (copy == kPayload) reply_received = true;
         }
-        cv.notify_one();
+        reply_cv.notify_one();
         return false;
       },
       std::chrono::milliseconds(2000));
-  std::unique_lock<std::mutex> lock(mtx);
-  EXPECT_TRUE(cv.wait_for(lock, std::chrono::seconds(3), [&] { return done; }))
+  EXPECT_TRUE(healthy_get.IsOk());
+  std::unique_lock<std::mutex> lock(reply_mutex);
+  EXPECT_TRUE(reply_cv.wait_for(lock, std::chrono::seconds(3),
+                                [&] { return reply_received; }))
       << "Session should remain usable after a contained callback exception";
 }
 


### PR DESCRIPTION
Closes #67

## Scope

- [x] Define safe handling for empty and throwing user callbacks in Get and Queryable callback thunks.
- [x] Catch exceptions at the outermost C callback boundary and terminate the affected callback operation safely.
- [x] Preserve owned-resource cleanup on normal and exceptional paths.
- [x] Add regression coverage for callback error containment where testable.

## Changes

### `src/transport/zenoh_transport.cpp`

- **OnGetReply** (Get reply closure): wrap the complete C callback thunk in `try/catch(...)`. On throw, stop further replies for this Get (`c->stop = true`) so the closure drains without re-entering a throwing sink. A `ZenohOwned<z_owned_slice_t>` RAII owner releases a successfully created slice on both normal and exceptional paths.
- **Queryable closure thunk**: extract `OnQueryable` as a named callback and wrap the complete thunk in `try/catch(...)`. Atomic `callback_state->active` deactivation runs on normal, exceptional, and inactive-queryable paths.
- **DeclareQueryable**: reject empty callbacks at declaration time (return empty handle) instead of registering a closure that would throw `std::bad_function_call` on every query.

### `tests/integration/transport_test.cpp`

- `QueryableCallbackExceptionIsContained`: a throwing queryable callback does not crash the process; the session remains usable (round-trips a second working queryable afterward).
- `GetSinkExceptionIsContained`: confirms the throwing Get result sink is invoked, contains its exception, and verifies the session remains usable afterward.
- `EmptyQueryableCallbackIsSafe`: an empty callback yields a safe empty handle.

## AC Verification

1. **No zenoh-c callback lets a C++ exception cross the C ABI boundary.** — Both `OnGetReply` and `OnQueryable` wrap their complete callback thunks in `try/catch(...)`.
2. **An empty callback has defined, safe behavior.** — `DeclareQueryable` returns an empty handle for an empty callback; the thunk also guards `if (state->callback)`.
3. **Existing transport round-trip and no-queryable tests remain green.** — 97/97 tests pass including `QueryableRoundTrip`, `GetWithoutQueryableDoesNotInvokeSink`, `PutAndDeleteReturnOk`.

## RED Phase

Confirmed before the fix (current `main`):
- `QueryableCallbackExceptionIsContained`: **Timeout** — the thrown exception escaped the zenoh-c closure, disrupting the internal runtime thread so the session stopped responding.
- `GetSinkExceptionIsContained`: **Failed** — `C++ exception with description "sink boom" thrown in the test body` (escaped the C ABI boundary into the test runner).
- `EmptyQueryableCallbackIsSafe`: passed (declaration did not crash even before the guard).

After the fix all three pass and the full suite is green (97/97).

## Notes

- The contained exception is swallowed silently because zenoh-c callbacks have no error/abort channel. Stopping further replies for the affected Get is the safest recoverable behavior.
- `std::bad_function_call` from an empty callback is now impossible because empty callbacks are rejected at `DeclareQueryable` time; the `if (state->callback)` guard in the thunk is a defensive second layer.
