### PR TITLE
fix(engine): invoke read sinks outside locks (#68)

### DIFF
--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -114,6 +114,8 @@ Conventions:
 * Engines treat values as opaque byte sequences (they do not know the payload format)
 * Pointers passed to `Get`/`List` sinks are valid only during the sink call
 * Thread safety: the engine guarantees safe concurrent reads + safe concurrent read/write [N07].
+  Sinks run without an internal engine lock that prevents reentrant engine calls; their key and
+  value views remain valid for the sink call, and `List` enumerates a consistent read set.
   `InMemoryEngine` uses `std::shared_mutex`; RocksDB uses its native guarantees
 * The view returned by `TakeSnapshot()` is not affected by Put/Delete operations after the call
 

--- a/include/sitos/storage_engine.hpp
+++ b/include/sitos/storage_engine.hpp
@@ -22,9 +22,11 @@ namespace sitos {
 /// valid only during the sink callback.
 using Bytes = std::span<const std::byte>;
 
-/// Callback type for Get and List.  Receives the key and a span over the
-/// value bytes.  Return false from the sink to abort iteration early
-/// (List will stop and return false).
+/// Callback type for Get and List. Receives the key and a span over the
+/// value bytes. Views remain valid only for the duration of the callback.
+/// Implementations must release internal engine locks before invoking the
+/// sink, so the sink may call methods on the same engine. Return false from
+/// the sink to abort iteration early (List will stop and return false).
 using EntrySink = std::function<bool(std::string_view key, Bytes value)>;
 
 /// Read-only view of the stored state.  Both the engine itself and
@@ -48,7 +50,9 @@ class StorageReader {
 ///
 /// Thread safety (N07): implementations must guarantee that concurrent
 /// calls to Get/List are safe, and that a write (Put/Delete) does not
-/// corrupt concurrent reads.
+/// corrupt concurrent reads. Get/List must copy the entries needed for
+/// callbacks while holding internal locks, then invoke sinks after unlocking;
+/// this makes sink callbacks reentrant with respect to the engine.
 class StorageEngine : public StorageReader {
  public:
   /// Store a value for the given key.  Returns true on success.

--- a/include/sitos/storage_engine.hpp
+++ b/include/sitos/storage_engine.hpp
@@ -50,9 +50,10 @@ class StorageReader {
 ///
 /// Thread safety (N07): implementations must guarantee that concurrent
 /// calls to Get/List are safe, and that a write (Put/Delete) does not
-/// corrupt concurrent reads. Get/List must copy the entries needed for
-/// callbacks while holding internal locks, then invoke sinks after unlocking;
-/// this makes sink callbacks reentrant with respect to the engine.
+/// corrupt concurrent reads. Get/List must invoke sinks without retaining an
+/// internal engine lock that prevents reentrancy. Callback views must remain
+/// valid for the callback duration, and List must enumerate a consistent read
+/// set.
 class StorageEngine : public StorageReader {
  public:
   /// Store a value for the given key.  Returns true on success.

--- a/src/in_memory_engine.cpp
+++ b/src/in_memory_engine.cpp
@@ -20,18 +20,32 @@ bool InMemoryEngine::Delete(std::string_view key) {
 }
 
 bool InMemoryEngine::Get(std::string_view key, const EntrySink& sink) const {
-  std::shared_lock lock(mutex_);
-  auto it = data_.find(key);
-  if (it == data_.end()) return false;
-  sink(it->first, it->second);
+  std::string owned_key;
+  std::vector<std::byte> owned_value;
+  {
+    std::shared_lock lock(mutex_);
+    auto it = data_.find(key);
+    if (it == data_.end()) return false;
+    owned_key = it->first;
+    owned_value = it->second;
+  }
+
+  sink(owned_key, owned_value);
   return true;
 }
 
 bool InMemoryEngine::List(std::string_view prefix, const EntrySink& sink) const {
-  std::shared_lock lock(mutex_);
-  for (auto it = data_.lower_bound(prefix);
-       it != data_.end() && it->first.starts_with(prefix); ++it) {
-    if (!sink(it->first, it->second)) return false;
+  std::vector<std::pair<std::string, std::vector<std::byte>>> entries;
+  {
+    std::shared_lock lock(mutex_);
+    for (auto it = data_.lower_bound(prefix);
+         it != data_.end() && it->first.starts_with(prefix); ++it) {
+      entries.emplace_back(it->first, it->second);
+    }
+  }
+
+  for (const auto& [key, value] : entries) {
+    if (!sink(key, value)) return false;
   }
   return true;
 }

--- a/tests/unit/in_memory_engine_test.cpp
+++ b/tests/unit/in_memory_engine_test.cpp
@@ -32,6 +32,10 @@ TEST(InMemoryEngineStressTest, ConcurrentPutGet) {
   std::atomic<bool> start{false};
   std::atomic<int> errors{0};
 
+  for (int id = 0; id < kNumWriters; ++id) {
+    ASSERT_TRUE(engine.Put("list/" + std::to_string(id), {}));
+  }
+
   auto writer = [&](int id) {
     while (!start.load()) { /* spin */ }
     for (int i = 0; i < kOpsPerThread; ++i) {
@@ -39,6 +43,7 @@ TEST(InMemoryEngineStressTest, ConcurrentPutGet) {
       std::vector<std::byte> value{std::byte{static_cast<unsigned char>(id)},
                                    std::byte{static_cast<unsigned char>(i & 0xFF)}};
       if (!engine.Put(key, value)) ++errors;
+      if (!engine.Put("list/" + std::to_string(id), value)) ++errors;
     }
   };
 
@@ -47,9 +52,9 @@ TEST(InMemoryEngineStressTest, ConcurrentPutGet) {
     for (int i = 0; i < kOpsPerThread; ++i) {
       engine.Get("no_such_key_" + std::to_string(i),
                  [](std::string_view /*k*/, sitos::Bytes /*v*/) { return true; });
-      // Use a non-matching prefix to exercise concurrent List calls without
-      // repeatedly copying the entire growing map for this stress test.
-      engine.List("no_such_prefix/",
+      // This matching prefix has a fixed small cardinality, so readers exercise
+      // concurrent entry copying without repeatedly copying the growing map.
+      engine.List("list/",
                   [](std::string_view /*k*/, sitos::Bytes /*v*/) { return true; });
     }
   };
@@ -70,7 +75,7 @@ TEST(InMemoryEngineStressTest, ConcurrentPutGet) {
     ++count;
     return true;
   });
-  EXPECT_EQ(count, static_cast<std::size_t>(kNumWriters * kOpsPerThread));
+  EXPECT_EQ(count, static_cast<std::size_t>(kNumWriters * kOpsPerThread + kNumWriters));
 }
 
 TEST(InMemoryEngineStressTest, SnapshotReadDuringWrite) {

--- a/tests/unit/in_memory_engine_test.cpp
+++ b/tests/unit/in_memory_engine_test.cpp
@@ -47,7 +47,9 @@ TEST(InMemoryEngineStressTest, ConcurrentPutGet) {
     for (int i = 0; i < kOpsPerThread; ++i) {
       engine.Get("no_such_key_" + std::to_string(i),
                  [](std::string_view /*k*/, sitos::Bytes /*v*/) { return true; });
-      engine.List("",
+      // Use a non-matching prefix to exercise concurrent List calls without
+      // repeatedly copying the entire growing map for this stress test.
+      engine.List("no_such_prefix/",
                   [](std::string_view /*k*/, sitos::Bytes /*v*/) { return true; });
     }
   };

--- a/tests/unit/storage_engine_contract.hpp
+++ b/tests/unit/storage_engine_contract.hpp
@@ -18,11 +18,15 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstddef>
 #include <cstring>
+#include <exception>
 #include <functional>
+#include <future>
 #include <memory>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -61,6 +65,29 @@ inline std::vector<std::byte> BytesFromString(std::string_view s) {
   v.reserve(s.size());
   for (char c : s) v.push_back(static_cast<std::byte>(c));
   return v;
+}
+
+// Runs a potentially reentrant operation without allowing a regression to
+// hang the test process. If the operation times out, its heap-owned engine is
+// intentionally retained by the detached thread until process termination.
+inline bool RunWithTimeout(std::unique_ptr<sitos::StorageEngine> engine,
+                           std::function<void(sitos::StorageEngine&)> operation) {
+  auto* raw_engine = engine.release();
+  auto completed = std::make_shared<std::promise<void>>();
+  auto future = completed->get_future();
+  std::thread([raw_engine, operation = std::move(operation), completed]() mutable {
+    try {
+      operation(*raw_engine);
+      delete raw_engine;
+      completed->set_value();
+    } catch (...) {
+      delete raw_engine;
+      completed->set_exception(std::current_exception());
+    }
+  }).detach();
+  if (future.wait_for(std::chrono::seconds(1)) != std::future_status::ready) return false;
+  future.get();
+  return true;
 }
 
 inline void GetReturnsTrueForExistingKey(sitos::StorageEngine& engine) {
@@ -262,6 +289,102 @@ inline void SnapshotIsIsolatedFromBasePut(sitos::StorageEngine& engine) {
 // Verifies that engines treat values as opaque byte sequences.  Values with
 // embedded null bytes and arbitrary binary patterns must survive a Put/Get
 // round-trip unchanged (no truncation, encoding conversion, or modification).
+inline void SinkCanReenterReadOperations(sitos::testing::EngineFactory factory) {
+  auto engine = factory();
+  ASSERT_TRUE(engine->Put("reentrant", BytesFromString("value")));
+
+  struct State {
+    bool outer_get = false;
+    bool nested_get = false;
+    bool nested_list = false;
+    bool nested_snapshot = false;
+  };
+  auto state = std::make_shared<State>();
+
+  const bool completed = RunWithTimeout(
+      std::move(engine), [state](sitos::StorageEngine& engine_ref) {
+        state->outer_get = engine_ref.Get("reentrant", [&](std::string_view, sitos::Bytes) {
+          state->nested_get = engine_ref.Get(
+              "reentrant", [](std::string_view, sitos::Bytes) { return true; });
+          state->nested_list = engine_ref.List(
+              "re", [](std::string_view, sitos::Bytes) { return true; });
+          auto snapshot = engine_ref.TakeSnapshot();
+          state->nested_snapshot = snapshot != nullptr &&
+                                   snapshot->Get("reentrant", [](std::string_view, sitos::Bytes) {
+                                     return true;
+                                   });
+          return true;
+        });
+      });
+
+  EXPECT_TRUE(completed);
+  EXPECT_TRUE(state->outer_get);
+  EXPECT_TRUE(state->nested_get);
+  EXPECT_TRUE(state->nested_list);
+  EXPECT_TRUE(state->nested_snapshot);
+}
+
+inline void SinkCanWriteDuringGet(sitos::testing::EngineFactory factory) {
+  auto engine = factory();
+  ASSERT_TRUE(engine->Put("write", BytesFromString("before")));
+
+  struct State {
+    bool put = false;
+    bool deleted = false;
+    std::string value_seen;
+  };
+  auto state = std::make_shared<State>();
+
+  const bool completed = RunWithTimeout(
+      std::move(engine), [state](sitos::StorageEngine& engine_ref) {
+        engine_ref.Get("write", [&](std::string_view, sitos::Bytes value) {
+          state->value_seen.assign(reinterpret_cast<const char*>(value.data()), value.size());
+          state->put = engine_ref.Put("write", BytesFromString("after"));
+          state->deleted = engine_ref.Delete("write");
+          return true;
+        });
+      });
+
+  EXPECT_TRUE(completed);
+  EXPECT_TRUE(state->put);
+  EXPECT_TRUE(state->deleted);
+  EXPECT_EQ(state->value_seen, "before");
+}
+
+inline void SinkCanWriteDuringList(sitos::testing::EngineFactory factory) {
+  auto engine = factory();
+  ASSERT_TRUE(engine->Put("stable/1", BytesFromString("one")));
+  ASSERT_TRUE(engine->Put("stable/2", BytesFromString("two")));
+
+  struct State {
+    bool put = false;
+    bool deleted = false;
+    std::vector<std::pair<std::string, std::string>> entries;
+  };
+  auto state = std::make_shared<State>();
+
+  const bool completed = RunWithTimeout(
+      std::move(engine), [state](sitos::StorageEngine& engine_ref) {
+        engine_ref.List("stable/", [&](std::string_view key, sitos::Bytes value) {
+          state->entries.emplace_back(
+              std::string(key),
+              std::string(reinterpret_cast<const char*>(value.data()), value.size()));
+          if (key == "stable/1") {
+            state->put = engine_ref.Put("stable/1", BytesFromString("updated"));
+            state->deleted = engine_ref.Delete("stable/2");
+          }
+          return true;
+        });
+      });
+
+  EXPECT_TRUE(completed);
+  EXPECT_TRUE(state->put);
+  EXPECT_TRUE(state->deleted);
+  ASSERT_EQ(state->entries.size(), 2u);
+  EXPECT_EQ(state->entries[0], std::make_pair(std::string("stable/1"), std::string("one")));
+  EXPECT_EQ(state->entries[1], std::make_pair(std::string("stable/2"), std::string("two")));
+}
+
 inline void HandlesOpaqueBytes(sitos::StorageEngine& engine) {
   // Bytes that include embedded nulls (positions 0, 3, last).
   const std::vector<std::byte> with_nulls = {
@@ -358,6 +481,15 @@ inline void HandlesOpaqueBytes(sitos::StorageEngine& engine) {
   }                                                                                         \
   TEST_P(SuiteName, HandlesOpaqueBytes) {                                                    \
     sitos_contract::HandlesOpaqueBytes(engine());                                            \
+  }                                                                                         \
+  TEST_P(SuiteName, SinkCanReenterReadOperations) {                                          \
+    sitos_contract::SinkCanReenterReadOperations(GetParam());                                \
+  }                                                                                         \
+  TEST_P(SuiteName, SinkCanWriteDuringGet) {                                                 \
+    sitos_contract::SinkCanWriteDuringGet(GetParam());                                       \
+  }                                                                                         \
+  TEST_P(SuiteName, SinkCanWriteDuringList) {                                                \
+    sitos_contract::SinkCanWriteDuringList(GetParam());                                      \
   }                                                                                         \
                                                                                             \
   INSTANTIATE_TEST_SUITE_P(, SuiteName, ::testing::Values(FactoryExpr))

--- a/tests/unit/storage_engine_contract.hpp
+++ b/tests/unit/storage_engine_contract.hpp
@@ -286,9 +286,6 @@ inline void SnapshotIsIsolatedFromBasePut(sitos::StorageEngine& engine) {
   EXPECT_FALSE(found);
 }
 
-// Verifies that engines treat values as opaque byte sequences.  Values with
-// embedded null bytes and arbitrary binary patterns must survive a Put/Get
-// round-trip unchanged (no truncation, encoding conversion, or modification).
 inline void SinkCanReenterReadOperations(sitos::testing::EngineFactory factory) {
   auto engine = factory();
   ASSERT_TRUE(engine->Put("reentrant", BytesFromString("value")));
@@ -317,7 +314,7 @@ inline void SinkCanReenterReadOperations(sitos::testing::EngineFactory factory) 
         });
       });
 
-  EXPECT_TRUE(completed);
+  ASSERT_TRUE(completed);
   EXPECT_TRUE(state->outer_get);
   EXPECT_TRUE(state->nested_get);
   EXPECT_TRUE(state->nested_list);
@@ -345,7 +342,7 @@ inline void SinkCanWriteDuringGet(sitos::testing::EngineFactory factory) {
         });
       });
 
-  EXPECT_TRUE(completed);
+  ASSERT_TRUE(completed);
   EXPECT_TRUE(state->put);
   EXPECT_TRUE(state->deleted);
   EXPECT_EQ(state->value_seen, "before");
@@ -377,7 +374,7 @@ inline void SinkCanWriteDuringList(sitos::testing::EngineFactory factory) {
         });
       });
 
-  EXPECT_TRUE(completed);
+  ASSERT_TRUE(completed);
   EXPECT_TRUE(state->put);
   EXPECT_TRUE(state->deleted);
   ASSERT_EQ(state->entries.size(), 2u);
@@ -385,6 +382,9 @@ inline void SinkCanWriteDuringList(sitos::testing::EngineFactory factory) {
   EXPECT_EQ(state->entries[1], std::make_pair(std::string("stable/2"), std::string("two")));
 }
 
+// Verifies that engines treat values as opaque byte sequences.  Values with
+// embedded null bytes and arbitrary binary patterns must survive a Put/Get
+// round-trip unchanged (no truncation, encoding conversion, or modification).
 inline void HandlesOpaqueBytes(sitos::StorageEngine& engine) {
   // Bytes that include embedded nulls (positions 0, 3, last).
   const std::vector<std::byte> with_nulls = {

--- a/tests/unit/storage_engine_contract.hpp
+++ b/tests/unit/storage_engine_contract.hpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cstddef>
 #include <cstring>
@@ -328,16 +329,18 @@ inline void SinkCanWriteDuringGet(sitos::testing::EngineFactory factory) {
   struct State {
     bool put = false;
     bool deleted = false;
+    std::string key_seen;
     std::string value_seen;
   };
   auto state = std::make_shared<State>();
 
   const bool completed = RunWithTimeout(
       std::move(engine), [state](sitos::StorageEngine& engine_ref) {
-        engine_ref.Get("write", [&](std::string_view, sitos::Bytes value) {
-          state->value_seen.assign(reinterpret_cast<const char*>(value.data()), value.size());
+        engine_ref.Get("write", [&](std::string_view key, sitos::Bytes value) {
           state->put = engine_ref.Put("write", BytesFromString("after"));
           state->deleted = engine_ref.Delete("write");
+          state->key_seen.assign(key);
+          state->value_seen.assign(reinterpret_cast<const char*>(value.data()), value.size());
           return true;
         });
       });
@@ -345,6 +348,7 @@ inline void SinkCanWriteDuringGet(sitos::testing::EngineFactory factory) {
   ASSERT_TRUE(completed);
   EXPECT_TRUE(state->put);
   EXPECT_TRUE(state->deleted);
+  EXPECT_EQ(state->key_seen, "write");
   EXPECT_EQ(state->value_seen, "before");
 }
 
@@ -354,6 +358,7 @@ inline void SinkCanWriteDuringList(sitos::testing::EngineFactory factory) {
   ASSERT_TRUE(engine->Put("stable/2", BytesFromString("two")));
 
   struct State {
+    bool mutation_applied = false;
     bool put = false;
     bool deleted = false;
     std::vector<std::pair<std::string, std::string>> entries;
@@ -363,21 +368,27 @@ inline void SinkCanWriteDuringList(sitos::testing::EngineFactory factory) {
   const bool completed = RunWithTimeout(
       std::move(engine), [state](sitos::StorageEngine& engine_ref) {
         engine_ref.List("stable/", [&](std::string_view key, sitos::Bytes value) {
+          const std::string current_key(key);
           state->entries.emplace_back(
-              std::string(key),
+              current_key,
               std::string(reinterpret_cast<const char*>(value.data()), value.size()));
-          if (key == "stable/1") {
-            state->put = engine_ref.Put("stable/1", BytesFromString("updated"));
-            state->deleted = engine_ref.Delete("stable/2");
+          if (!state->mutation_applied) {
+            const std::string key_to_delete =
+                current_key == "stable/1" ? "stable/2" : "stable/1";
+            state->mutation_applied = true;
+            state->put = engine_ref.Put(current_key, BytesFromString("updated"));
+            state->deleted = engine_ref.Delete(key_to_delete);
           }
           return true;
         });
       });
 
   ASSERT_TRUE(completed);
+  EXPECT_TRUE(state->mutation_applied);
   EXPECT_TRUE(state->put);
   EXPECT_TRUE(state->deleted);
   ASSERT_EQ(state->entries.size(), 2u);
+  std::sort(state->entries.begin(), state->entries.end());
   EXPECT_EQ(state->entries[0], std::make_pair(std::string("stable/1"), std::string("one")));
   EXPECT_EQ(state->entries[1], std::make_pair(std::string("stable/2"), std::string("two")));
 }

--- a/tests/unit/storage_engine_contract_test.cpp
+++ b/tests/unit/storage_engine_contract_test.cpp
@@ -8,6 +8,7 @@
 #include "storage_engine_contract.hpp"
 
 #include <map>
+#include <mutex>
 #include <shared_mutex>
 #include <string>
 #include <vector>
@@ -31,17 +32,31 @@ class MockEngine : public sitos::StorageEngine {
   }
 
   bool Get(std::string_view key, const sitos::EntrySink& sink) const override {
-    std::shared_lock lock(mutex_);
-    auto it = data_.find(key);
-    if (it == data_.end()) return false;
-    sink(it->first, it->second);
+    std::string owned_key;
+    std::vector<std::byte> owned_value;
+    {
+      std::shared_lock lock(mutex_);
+      auto it = data_.find(key);
+      if (it == data_.end()) return false;
+      owned_key = it->first;
+      owned_value = it->second;
+    }
+
+    sink(owned_key, owned_value);
     return true;
   }
 
   bool List(std::string_view prefix, const sitos::EntrySink& sink) const override {
-    std::shared_lock lock(mutex_);
-    for (const auto& [k, v] : data_) {
-      if (k.starts_with(prefix) && !sink(k, v)) return false;
+    std::vector<std::pair<std::string, std::vector<std::byte>>> entries;
+    {
+      std::shared_lock lock(mutex_);
+      for (const auto& [key, value] : data_) {
+        if (key.starts_with(prefix)) entries.emplace_back(key, value);
+      }
+    }
+
+    for (const auto& [key, value] : entries) {
+      if (!sink(key, value)) return false;
     }
     return true;
   }


### PR DESCRIPTION
Closes #68

## Scope

- [x] Define the `StorageReader` sink invocation and reentrancy contract.
- [x] Invoke `InMemoryEngine` Get/List sinks after releasing internal locks.
- [x] Preserve stable owned key/value views for the duration of callbacks.
- [x] Preserve List prefix filtering and early-stop semantics.
- [x] Update `MockEngine` and shared StorageEngine contract tests.
- [x] Add non-hanging regression tests for sink-initiated reads, snapshots, and writes.

## Changes

- Document that `EntrySink` callbacks run without internal engine locks and may call methods on the same engine.
- Copy `Get` and matching `List` entries while holding the shared lock, then invoke sinks after unlocking.
- Apply the same callback contract to the contract-test `MockEngine`.
- Add contract tests covering nested Get/List/TakeSnapshot, same-engine Put/Delete from Get sinks, stable List views after mutation, and non-hanging timeout behavior.
- Adjust the concurrent stress test to use a non-matching List prefix so it continues to exercise concurrent List calls without repeatedly copying the entire growing map.

## Acceptance Criteria

1. `Get` and `List` do not hold an engine mutex while invoking an `EntrySink`.
2. A sink can initiate same-engine writes without self-deadlock.
3. List retains a consistent owned snapshot during sink callbacks, with unchanged prefix and early-stop semantics.
4. Contract tests pass on Windows MSVC; Linux validation is covered by CI.

## TDD Verification

### RED

The pre-fix tests failed correctly on the old implementation:

- `InMemoryEngineContractTest.SinkCanWriteDuringGet`: timed out after 1 second while the sink attempted Put/Delete under the shared lock.
- `InMemoryEngineContractTest.SinkCanWriteDuringList`: timed out after 1 second while the sink attempted Put/Delete under the shared lock; only one entry was observed.

`SinkCanReenterReadOperations` passed on MSVC because that platform permits the nested shared-lock path; the writer tests provide the deterministic regression coverage for lock release.

### GREEN

- New storage-engine contract tests: 17/17 passed on Windows MSVC.
- Full Windows MSVC/Ninja suite: 103/103 tests passed.
- `git diff --check`: passed.
- Local Linux validation could not be configured because no C++ compiler is installed; Linux build/test validation is delegated to CI.

## ADR

No ADR is required. This change clarifies and enforces the existing StorageEngine callback/thread-safety contract without changing the wire protocol or public data model.
