### PR TITLE
[ADR] feat(node): add base queryable get and list routing (#9)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(sitos STATIC
   src/key.cpp
   src/storage_engine.cpp
   src/in_memory_engine.cpp
+  src/storage_node.cpp
 )
 add_library(sitos::sitos ALIAS sitos)
 target_include_directories(sitos PUBLIC
@@ -52,6 +53,8 @@ sitos_enable_warnings(sitos)
 if(SITOS_WITH_ZENOH)
   target_sources(sitos PRIVATE src/transport/zenoh_transport.cpp)
   target_link_libraries(sitos PRIVATE zenohc::zenohc)
+else()
+  target_sources(sitos PRIVATE src/transport_stub.cpp)
 endif()
 
 if(SITOS_BUILD_TESTS)

--- a/docs/03_wire_protocol.md
+++ b/docs/03_wire_protocol.md
@@ -101,11 +101,16 @@ when re-encoding.
 Set the following zenoh `Encoding` on put/reply [C02]:
 
 ```
-zenoh.bytes;sitos.v1          (single value)
-zenoh.bytes;sitos.v1.batch   (batch, §5)
+zenoh/bytes;sitos.v1          (single value)
+zenoh/bytes;sitos.v1.batch    (batch, §5)
 ```
 
-(`Encoding` = type `zenoh.bytes` + schema suffix)
+(`Encoding` = type `zenoh/bytes` + schema suffix) [ADR-0016]
+
+Senders emit the canonical slash spelling above. Receivers also accept the
+legacy `zenoh.bytes;<schema>` spelling and schema-only identifiers for
+compatibility, but normalize recognized sitos schemas to `sitos.v1` or
+`sitos.v1.batch` in the transport-independent API.
 
 Receiver interpretation rules:
 

--- a/docs/adr/0016-use-canonical-zenoh-bytes-encodings.md
+++ b/docs/adr/0016-use-canonical-zenoh-bytes-encodings.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed — 2026-07-12
+Accepted — 2026-07-12
 
 ## Context
 

--- a/docs/adr/0016-use-canonical-zenoh-bytes-encodings.md
+++ b/docs/adr/0016-use-canonical-zenoh-bytes-encodings.md
@@ -1,0 +1,54 @@
+# ADR-0016: Use canonical zenoh bytes encodings
+
+## Status
+
+Proposed — 2026-07-12
+
+## Context
+
+ADR-0007 assigns the `sitos.v1` and `sitos.v1.batch` schema names to sitos
+payloads. The wire protocol documented their zenoh Encoding type using the
+legacy spelling `zenoh.bytes`, while zenoh-c 1.9.0 represents its standard
+bytes Encoding as `zenoh/bytes`. Passing a schema name directly to
+`z_encoding_from_str()` does not add the bytes type; it creates an Encoding
+whose type is the schema name itself. The transport also hard-coded received
+samples as `sitos.v1`, preventing validation of the actual wire metadata.
+
+## Decision
+
+We will transmit sitos payloads with zenoh-c's canonical `zenoh/bytes` type and
+the `sitos.v1` or `sitos.v1.batch` schema. The transport-independent API will
+continue to expose schema identifiers, and the zenoh adapter will construct,
+inspect, and normalize the corresponding wire Encoding.
+
+## Consequences
+
+* Good: Raw zenoh clients can identify sitos values as bytes with an explicit
+  version schema.
+* Good: Put and query replies use the same zenoh-c standard Encoding
+  construction instead of relying on an arbitrary string.
+* Good: Received Encoding metadata can be tested from the actual sample rather
+  than replaced with a constant.
+* Bad: The canonical wire spelling changes from the documented
+  `zenoh.bytes;<schema>` form to `zenoh/bytes;<schema>`.
+* Bad: The zenoh adapter must translate between transport schema identifiers
+  and wire Encoding strings.
+* Neutral: Receivers normalize both the canonical and legacy bytes spellings
+  for compatibility, while senders emit only the canonical spelling.
+
+## Options Considered
+
+* **Keep schema-only Encoding values** — rejected because `sitos.v1` becomes
+  the Encoding type instead of a schema on the standard bytes type.
+* **Transmit `zenoh.bytes;<schema>`** — rejected because zenoh-c 1.9.0's
+  standard bytes Encoding uses the canonical `zenoh/bytes` spelling.
+* **Expose full zenoh Encoding strings through `sitos::Encoding`** — rejected
+  because it would leak zenoh-specific representation into the transport
+  abstraction.
+
+## References
+
+* Issue #9 / PR #73
+* Related: ADR-0001, ADR-0007
+* zenoh-c 1.9.0: `z_encoding_zenoh_bytes()`,
+  `z_encoding_set_schema_from_str()`, and `z_encoding_to_string()`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,3 +20,4 @@ See [docs/10_adr_process.md](../10_adr_process.md) for the process.
 | [0013](0013-default-to-zenoh-scouting-with-explicit-endpoint-override.md) | Default to zenoh scouting with explicit endpoint override |
 | [0014](0014-session-scoped-buffers.md) | Add a session-scoped, disk-backed buffers key space |
 | [0015](0015-optional-http-gateway-component.md) | Ship an optional HTTP gateway component on cpp-httplib |
+| [0016](0016-use-canonical-zenoh-bytes-encodings.md) | Use canonical zenoh bytes encodings |

--- a/include/sitos/storage_node.hpp
+++ b/include/sitos/storage_node.hpp
@@ -20,7 +20,7 @@ namespace sitos {
 
 /// The supported query shape for the StorageNode base scope.
 struct StorageQuery {
-  /// True for a terminal `/**` List selector, false for an exact key.
+  /// True for a terminal star-star selector, false for an exact key.
   bool is_list = false;
   /// Exact relative key, or the relative List prefix including its trailing `/`.
   std::string relative_key;
@@ -34,7 +34,7 @@ std::optional<StorageQuery> ParseStorageQuery(std::string_view prefix,
                                                std::string_view keyexpr);
 
 struct StorageNodeConfig {
-  std::string prefix;
+  std::string prefix = "sitos";
 };
 
 /// Serves base-scope Get/List queries through a Transport queryable.

--- a/include/sitos/storage_node.hpp
+++ b/include/sitos/storage_node.hpp
@@ -1,0 +1,85 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// StorageNode queryable routing for the base storage scope.
+
+#ifndef SITOS_STORAGE_NODE_HPP
+#define SITOS_STORAGE_NODE_HPP
+
+#include <atomic>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include "sitos/storage_engine.hpp"
+#include "sitos/transport.hpp"
+
+namespace sitos {
+
+/// The supported query shape for the StorageNode base scope.
+struct StorageQuery {
+  /// True for a terminal `/**` List selector, false for an exact key.
+  bool is_list = false;
+  /// Exact relative key, or the relative List prefix including its trailing `/`.
+  std::string relative_key;
+};
+
+/// Parses an exact base key or a terminal base List selector.
+///
+/// The returned exact key is relative to the base scope. For a List selector,
+/// the returned prefix ends at a chunk boundary and includes its trailing `/`.
+std::optional<StorageQuery> ParseStorageQuery(std::string_view prefix,
+                                               std::string_view keyexpr);
+
+struct StorageNodeConfig {
+  std::string prefix;
+};
+
+/// Serves base-scope Get/List queries through a Transport queryable.
+class StorageNode {
+ public:
+  using Config = StorageNodeConfig;
+
+  StorageNode() = default;
+  explicit StorageNode(Transport& transport) : transport_(&transport) {}
+  ~StorageNode();
+
+  StorageNode(const StorageNode&) = delete;
+  StorageNode& operator=(const StorageNode&) = delete;
+  StorageNode(StorageNode&&) = delete;
+  StorageNode& operator=(StorageNode&&) = delete;
+
+  /// Starts the node using the transport supplied to the constructor.
+  Result<void> Start(std::shared_ptr<StorageEngine> engine, Config config);
+
+  /// Starts the node using an externally owned transport.
+  Result<void> Start(std::shared_ptr<StorageEngine> engine, Transport& transport,
+                     Config config);
+
+  /// Undeclares the queryable. Safe to call repeatedly.
+  void Stop() noexcept;
+
+  bool IsStarted() const noexcept { return state_ != nullptr; }
+
+ private:
+  struct State {
+    State(std::shared_ptr<StorageEngine> storage, std::string key_prefix)
+        : engine(std::move(storage)), prefix(std::move(key_prefix)) {}
+
+    std::shared_ptr<StorageEngine> engine;
+    std::string prefix;
+    std::atomic<bool> active{true};
+  };
+
+  static void OnQuery(const std::shared_ptr<State>& state, TransportQuery& query);
+
+  Transport* transport_ = nullptr;
+  std::shared_ptr<State> state_;
+  Queryable queryable_;
+};
+
+}  // namespace sitos
+
+#endif  // SITOS_STORAGE_NODE_HPP

--- a/include/sitos/transport.hpp
+++ b/include/sitos/transport.hpp
@@ -125,20 +125,32 @@ struct TransportSample {
 struct TransportQuery {
   std::string keyexpr;
 
+  using ReplyHandler =
+      std::function<Result<void>(std::string_view, std::span<const std::byte>, Encoding)>;
+
   TransportQuery();
   ~TransportQuery();
+
+  /// Creates a query with an in-process reply handler for deterministic tests.
+  static TransportQuery ForTesting(ReplyHandler handler) {
+    return TransportQuery(std::move(handler));
+  }
+
   TransportQuery(TransportQuery&&) = delete;
   TransportQuery& operator=(TransportQuery&&) = delete;
   TransportQuery(const TransportQuery&) = delete;
   TransportQuery& operator=(const TransportQuery&) = delete;
 
   Result<void> Reply(std::string_view key, std::span<const std::byte> payload,
-             Encoding encoding);
+                     Encoding encoding);
 
  private:
+  explicit TransportQuery(ReplyHandler handler);
+
   friend class ZenohTransport;
   struct Impl;
   std::unique_ptr<Impl> impl_;
+  ReplyHandler test_reply_handler_;
 };
 
 /// An active subscription handle. The subscription is cancelled when this

--- a/include/sitos/transport.hpp
+++ b/include/sitos/transport.hpp
@@ -91,11 +91,13 @@ class Result<void> {
   std::optional<std::error_code> error_;
 };
 
-/// Encoding identifiers used on the wire.
+/// Transport-independent schema identifiers for encoded payloads.
+///
+/// Transport adapters map these identifiers to their native wire Encoding.
 struct Encoding {
-  /// The well-known encoding for single-value sits payloads.
+  /// The well-known encoding for single-value sitos payloads.
   static constexpr std::string_view kSitosV1 = "sitos.v1";
-  /// The well-known encoding for batch sits payloads.
+  /// The well-known encoding for batch sitos payloads.
   static constexpr std::string_view kSitosV1Batch = "sitos.v1.batch";
 
   std::string id;

--- a/include/sitos/transport.hpp
+++ b/include/sitos/transport.hpp
@@ -186,6 +186,8 @@ class Queryable {
  private:
   friend class ZenohTransport;
   struct Impl;
+  void Reset() noexcept;
+
   std::unique_ptr<Impl> impl_;
 };
 

--- a/src/storage_node.cpp
+++ b/src/storage_node.cpp
@@ -1,0 +1,120 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// StorageNode base queryable routing.
+
+#include "sitos/storage_node.hpp"
+
+#include <utility>
+
+#include "sitos/key.hpp"
+
+namespace sitos {
+namespace {
+
+std::error_code InvalidArgument() {
+  return std::make_error_code(std::errc::invalid_argument);
+}
+
+std::error_code OperationInProgress() {
+  return std::make_error_code(std::errc::operation_in_progress);
+}
+
+std::optional<std::string_view> StripPrefix(std::string_view prefix,
+                                            std::string_view keyexpr) {
+  if (keyexpr.size() <= prefix.size() || !keyexpr.starts_with(prefix) ||
+      keyexpr[prefix.size()] != '/') {
+    return std::nullopt;
+  }
+  return keyexpr.substr(prefix.size() + 1);
+}
+
+std::string MakeReplyKey(std::string_view prefix, std::string_view relative_key) {
+  std::string key;
+  key.reserve(prefix.size() + 6 + relative_key.size());
+  key.append(prefix);
+  key.append("/base/");
+  key.append(relative_key);
+  return key;
+}
+
+Encoding SitosEncoding() { return Encoding{std::string(Encoding::kSitosV1)}; }
+
+}  // namespace
+
+std::optional<StorageQuery> ParseStorageQuery(std::string_view prefix,
+                                               std::string_view keyexpr) {
+  if (!IsValidPrefix(prefix)) return std::nullopt;
+
+  auto rest = StripPrefix(prefix, keyexpr);
+  if (!rest || !rest->starts_with("base/")) return std::nullopt;
+  std::string_view relative = rest->substr(5);
+  if (relative.empty()) return std::nullopt;
+
+  if (relative == "**") return StorageQuery{true, {}};
+
+  constexpr std::string_view kSelectorSuffix = "/**";
+  if (relative.ends_with(kSelectorSuffix)) {
+    std::string_view selector = relative.substr(0, relative.size() - kSelectorSuffix.size());
+    if (!IsValidPrefix(selector)) return std::nullopt;
+    std::string list_prefix(selector);
+    list_prefix.push_back('/');
+    return StorageQuery{true, std::move(list_prefix)};
+  }
+
+  if (relative.find('*') != std::string_view::npos || !IsValidKey(relative)) {
+    return std::nullopt;
+  }
+  return StorageQuery{false, std::string(relative)};
+}
+
+StorageNode::~StorageNode() { Stop(); }
+
+Result<void> StorageNode::Start(std::shared_ptr<StorageEngine> engine, Config config) {
+  if (transport_ == nullptr) return Result<void>::Err(InvalidArgument());
+  return Start(std::move(engine), *transport_, std::move(config));
+}
+
+Result<void> StorageNode::Start(std::shared_ptr<StorageEngine> engine, Transport& transport,
+                                Config config) {
+  if (state_ != nullptr) return Result<void>::Err(OperationInProgress());
+  if (!engine || !IsValidPrefix(config.prefix)) {
+    return Result<void>::Err(InvalidArgument());
+  }
+
+  auto state = std::make_shared<State>(std::move(engine), std::move(config.prefix));
+  const std::string queryable_key = state->prefix + "/**";
+  queryable_ = transport.DeclareQueryable(
+      queryable_key, [state](TransportQuery& query) { OnQuery(state, query); });
+  transport_ = &transport;
+  state_ = std::move(state);
+  return Result<void>::Ok();
+}
+
+void StorageNode::Stop() noexcept {
+  if (state_ != nullptr) state_->active.store(false, std::memory_order_relaxed);
+  queryable_ = Queryable{};
+  state_.reset();
+}
+
+void StorageNode::OnQuery(const std::shared_ptr<State>& state, TransportQuery& query) {
+  if (!state->active.load(std::memory_order_relaxed)) return;
+
+  auto parsed = ParseStorageQuery(state->prefix, query.keyexpr);
+  if (!parsed) return;
+
+  const Encoding encoding = SitosEncoding();
+  auto reply = [&](std::string_view key, Bytes value) {
+    const std::string full_key = MakeReplyKey(state->prefix, key);
+    return query.Reply(full_key, value, encoding).IsOk();
+  };
+
+  if (!parsed->is_list) {
+    state->engine->Get(parsed->relative_key, reply);
+    return;
+  }
+
+  state->engine->List(parsed->relative_key, reply);
+}
+
+}  // namespace sitos

--- a/src/storage_node.cpp
+++ b/src/storage_node.cpp
@@ -53,8 +53,8 @@ std::optional<StorageQuery> ParseStorageQuery(std::string_view prefix,
 
   if (relative == "**") return StorageQuery{true, {}};
 
-  constexpr std::string_view kSelectorSuffix = "/**";
-  if (relative.ends_with(kSelectorSuffix)) {
+  if (constexpr std::string_view kSelectorSuffix = "/**";
+      relative.ends_with(kSelectorSuffix)) {
     std::string_view selector = relative.substr(0, relative.size() - kSelectorSuffix.size());
     if (!IsValidPrefix(selector)) return std::nullopt;
     std::string list_prefix(selector);
@@ -104,7 +104,7 @@ void StorageNode::OnQuery(const std::shared_ptr<State>& state, TransportQuery& q
   if (!parsed) return;
 
   const Encoding encoding = SitosEncoding();
-  auto reply = [&](std::string_view key, Bytes value) {
+  auto reply = [state, &query, encoding](std::string_view key, Bytes value) {
     const std::string full_key = MakeReplyKey(state->prefix, key);
     return query.Reply(full_key, value, encoding).IsOk();
   };

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -16,7 +16,9 @@
 #include <cstddef>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
+#include <string_view>
 
 #include "sitos/transport.hpp"
 
@@ -146,14 +148,26 @@ bool IsSitosSchema(std::string_view id) {
   return id == Encoding::kSitosV1 || id == Encoding::kSitosV1Batch;
 }
 
+std::optional<std::string_view> SitosSchemaFromEncoding(std::string_view id) {
+  constexpr std::string_view kCanonicalBytesPrefix = "zenoh/bytes;";
+  constexpr std::string_view kLegacyBytesPrefix = "zenoh.bytes;";
+  if (id.starts_with(kCanonicalBytesPrefix)) {
+    id.remove_prefix(kCanonicalBytesPrefix.size());
+  } else if (id.starts_with(kLegacyBytesPrefix)) {
+    id.remove_prefix(kLegacyBytesPrefix.size());
+  }
+  if (IsSitosSchema(id)) return id;
+  return std::nullopt;
+}
+
 // Build a z_owned_encoding_t from a transport-independent Encoding id.
 Result<ZenohOwned<z_owned_encoding_t>> MakeEncoding(const Encoding& enc) {
   ZenohOwned<z_owned_encoding_t> z_enc;
-  if (IsSitosSchema(enc.id)) {
+  if (auto schema = SitosSchemaFromEncoding(enc.id); schema.has_value()) {
     z_encoding_clone(z_enc.get(), z_encoding_zenoh_bytes());
     z_enc.mark_valid();
-    z_result_t rc = z_encoding_set_schema_from_substr(z_enc.loan_mut(), enc.id.data(),
-                                                       enc.id.size());
+    z_result_t rc = z_encoding_set_schema_from_substr(z_enc.loan_mut(), schema->data(),
+                                                       schema->size());
     if (rc != Z_OK) {
       return Result<ZenohOwned<z_owned_encoding_t>>::Err(MakeError(rc));
     }
@@ -169,16 +183,9 @@ Result<ZenohOwned<z_owned_encoding_t>> MakeEncoding(const Encoding& enc) {
 }
 
 Encoding NormalizeEncoding(std::string wire_id) {
-  constexpr std::string_view kCanonicalBytesPrefix = "zenoh/bytes;";
-  constexpr std::string_view kLegacyBytesPrefix = "zenoh.bytes;";
-  std::string_view schema;
-  if (wire_id.starts_with(kCanonicalBytesPrefix)) {
-    schema = std::string_view(wire_id).substr(kCanonicalBytesPrefix.size());
-  } else if (wire_id.starts_with(kLegacyBytesPrefix)) {
-    schema = std::string_view(wire_id).substr(kLegacyBytesPrefix.size());
+  if (auto schema = SitosSchemaFromEncoding(wire_id); schema.has_value()) {
+    return Encoding{std::string(*schema)};
   }
-
-  if (IsSitosSchema(schema)) return Encoding{std::string(schema)};
   return Encoding{std::move(wire_id)};
 }
 

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -22,6 +22,8 @@
 
 #include "sitos/transport.hpp"
 
+#include "zenoh_transport_test_access.hpp"
+
 namespace sitos {
 
 // ---------------------------------------------------------------------------
@@ -250,6 +252,25 @@ void OnGetReply(z_loaned_reply_t* reply, void* context) {
 }
 
 }  // namespace
+
+namespace transport_test_access {
+
+std::optional<std::string> BuildWireEncoding(const Encoding& encoding) {
+  auto result = MakeEncoding(encoding);
+  if (!result.IsOk()) return std::nullopt;
+
+  auto owned_encoding = std::move(result.Value());
+  ZenohOwned<z_owned_string_t> wire;
+  z_encoding_to_string(owned_encoding.loan(), wire.get());
+  wire.mark_valid();
+  return std::string(z_string_data(wire.loan()), z_string_len(wire.loan()));
+}
+
+Encoding NormalizeWireEncoding(std::string wire_encoding) {
+  return NormalizeEncoding(std::move(wire_encoding));
+}
+
+}  // namespace transport_test_access
 
 // ---------------------------------------------------------------------------
 // TransportQuery

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -234,10 +234,14 @@ struct TransportQuery::Impl {
 };
 
 TransportQuery::TransportQuery() = default;
+TransportQuery::TransportQuery(ReplyHandler handler)
+    : test_reply_handler_(std::move(handler)) {}
 TransportQuery::~TransportQuery() = default;
 
 Result<void> TransportQuery::Reply(std::string_view key, std::span<const std::byte> payload,
                                    Encoding encoding) {
+  if (test_reply_handler_) return test_reply_handler_(key, payload, encoding);
+
   if (!impl_ || !impl_->callback_state) {
     return Result<void>::Err(MakeError(TransportErrc::kErrNoQuery));
   }

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -114,6 +114,9 @@ class ZenohOwned {
   // Loan for APIs that take z_loaned_*_t*.
   auto loan() { return z_loan(obj_); }
 
+  // Mutable loan for APIs that update an initialized owned value.
+  auto loan_mut() { return z_loan_mut(obj_); }
+
   explicit operator bool() const { return !moved_; }
 
   // Called by helpers after a successful z_*_from_* populates obj_.
@@ -139,15 +142,52 @@ Result<ZenohOwned<z_owned_keyexpr_t>> MakeKeyexpr(std::string_view key) {
   return Result<ZenohOwned<z_owned_keyexpr_t>>::Ok(std::move(ke));
 }
 
-// Build a z_owned_encoding_t from an Encoding id string.
+bool IsSitosSchema(std::string_view id) {
+  return id == Encoding::kSitosV1 || id == Encoding::kSitosV1Batch;
+}
+
+// Build a z_owned_encoding_t from a transport-independent Encoding id.
 Result<ZenohOwned<z_owned_encoding_t>> MakeEncoding(const Encoding& enc) {
   ZenohOwned<z_owned_encoding_t> z_enc;
-  z_result_t rc = z_encoding_from_str(z_enc.get(), enc.id.c_str());
+  if (IsSitosSchema(enc.id)) {
+    z_encoding_clone(z_enc.get(), z_encoding_zenoh_bytes());
+    z_enc.mark_valid();
+    z_result_t rc = z_encoding_set_schema_from_substr(z_enc.loan_mut(), enc.id.data(),
+                                                       enc.id.size());
+    if (rc != Z_OK) {
+      return Result<ZenohOwned<z_owned_encoding_t>>::Err(MakeError(rc));
+    }
+    return Result<ZenohOwned<z_owned_encoding_t>>::Ok(std::move(z_enc));
+  }
+
+  z_result_t rc = z_encoding_from_substr(z_enc.get(), enc.id.data(), enc.id.size());
   if (rc != Z_OK) {
     return Result<ZenohOwned<z_owned_encoding_t>>::Err(MakeError(rc));
   }
   z_enc.mark_valid();
   return Result<ZenohOwned<z_owned_encoding_t>>::Ok(std::move(z_enc));
+}
+
+Encoding NormalizeEncoding(std::string wire_id) {
+  constexpr std::string_view kCanonicalBytesPrefix = "zenoh/bytes;";
+  constexpr std::string_view kLegacyBytesPrefix = "zenoh.bytes;";
+  std::string_view schema;
+  if (wire_id.starts_with(kCanonicalBytesPrefix)) {
+    schema = std::string_view(wire_id).substr(kCanonicalBytesPrefix.size());
+  } else if (wire_id.starts_with(kLegacyBytesPrefix)) {
+    schema = std::string_view(wire_id).substr(kLegacyBytesPrefix.size());
+  }
+
+  if (IsSitosSchema(schema)) return Encoding{std::string(schema)};
+  return Encoding{std::move(wire_id)};
+}
+
+Encoding ReadEncoding(const z_loaned_sample_t* sample) {
+  ZenohOwned<z_owned_string_t> wire;
+  z_encoding_to_string(z_sample_encoding(sample), wire.get());
+  wire.mark_valid();
+  return NormalizeEncoding(
+      std::string(z_string_data(wire.loan()), z_string_len(wire.loan())));
 }
 
 // Build a z_owned_bytes_t from a byte payload.
@@ -190,11 +230,7 @@ void OnGetReply(z_loaned_reply_t* reply, void* context) {
     std::string key_str(z_string_data(z_view_string_loan(&ks)),
                         z_string_len(z_view_string_loan(&ks)));
 
-    // TODO(#3): Extract encoding from z_sample_encoding(sample).
-    // zenoh-c 1.9.0 does not expose encoding-to-string conversion;
-    // "sitos.v1" is the only encoding used in v0.1.
-    Encoding enc;
-    enc.id = "sitos.v1";
+    Encoding enc = ReadEncoding(sample);
 
     if (c->sink && !c->sink(key_str, std::span<const std::byte>(data, len), enc)) {
       c->stop.store(true, std::memory_order_relaxed);

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -300,18 +300,28 @@ struct Queryable::Impl {
 };
 
 Queryable::Queryable() = default;
-Queryable::~Queryable() {
-  if (impl_) {
-    auto state = impl_->state;
-    {
-      std::lock_guard<std::mutex> lock(state->mutex);
-      state->alive = false;
-    }
+Queryable::~Queryable() { Reset(); }
+
+void Queryable::Reset() noexcept {
+  if (!impl_) return;
+
+  auto state = impl_->state;
+  {
+    std::lock_guard<std::mutex> lock(state->mutex);
+    state->alive = false;
     z_drop(z_move(state->queryable));
   }
+  impl_.reset();
 }
+
 Queryable::Queryable(Queryable&&) noexcept = default;
-Queryable& Queryable::operator=(Queryable&&) noexcept = default;
+Queryable& Queryable::operator=(Queryable&& other) noexcept {
+  if (this != &other) {
+    Reset();
+    impl_ = std::move(other.impl_);
+  }
+  return *this;
+}
 
 // ---------------------------------------------------------------------------
 // ZenohTransport

--- a/src/transport/zenoh_transport_test_access.hpp
+++ b/src/transport/zenoh_transport_test_access.hpp
@@ -1,0 +1,24 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Internal test access for validating ZenohTransport wire encodings.
+
+#ifndef SITOS_TRANSPORT_ZENOH_TRANSPORT_TEST_ACCESS_HPP
+#define SITOS_TRANSPORT_ZENOH_TRANSPORT_TEST_ACCESS_HPP
+
+#include <optional>
+#include <string>
+
+#include "sitos/transport.hpp"
+
+namespace sitos::transport_test_access {
+
+/// Returns the actual zenoh-c string produced by the production Encoding builder.
+std::optional<std::string> BuildWireEncoding(const Encoding& encoding);
+
+/// Applies the production receive-side normalization to a wire Encoding string.
+Encoding NormalizeWireEncoding(std::string wire_encoding);
+
+}  // namespace sitos::transport_test_access
+
+#endif  // SITOS_TRANSPORT_ZENOH_TRANSPORT_TEST_ACCESS_HPP

--- a/src/transport_stub.cpp
+++ b/src/transport_stub.cpp
@@ -1,0 +1,35 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Transport handle stubs used when zenoh support is disabled.
+
+#include "sitos/transport.hpp"
+
+namespace sitos {
+
+struct TransportQuery::Impl {};
+struct Subscription::Impl {};
+struct Queryable::Impl {};
+
+TransportQuery::TransportQuery() = default;
+TransportQuery::TransportQuery(ReplyHandler handler)
+    : test_reply_handler_(std::move(handler)) {}
+TransportQuery::~TransportQuery() = default;
+
+Result<void> TransportQuery::Reply(std::string_view key, std::span<const std::byte> payload,
+                                   Encoding encoding) {
+  if (test_reply_handler_) return test_reply_handler_(key, payload, encoding);
+  return Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
+}
+
+Subscription::Subscription() = default;
+Subscription::~Subscription() = default;
+Subscription::Subscription(Subscription&&) noexcept = default;
+Subscription& Subscription::operator=(Subscription&&) noexcept = default;
+
+Queryable::Queryable() = default;
+Queryable::~Queryable() = default;
+Queryable::Queryable(Queryable&&) noexcept = default;
+Queryable& Queryable::operator=(Queryable&&) noexcept = default;
+
+}  // namespace sitos

--- a/src/transport_stub.cpp
+++ b/src/transport_stub.cpp
@@ -5,6 +5,8 @@
 
 #include "sitos/transport.hpp"
 
+#include <utility>
+
 namespace sitos {
 
 struct TransportQuery::Impl {};
@@ -28,8 +30,12 @@ Subscription::Subscription(Subscription&&) noexcept = default;
 Subscription& Subscription::operator=(Subscription&&) noexcept = default;
 
 Queryable::Queryable() = default;
-Queryable::~Queryable() = default;
+Queryable::~Queryable() { Reset(); }
+void Queryable::Reset() noexcept { impl_.reset(); }
 Queryable::Queryable(Queryable&&) noexcept = default;
-Queryable& Queryable::operator=(Queryable&&) noexcept = default;
+Queryable& Queryable::operator=(Queryable&& other) noexcept {
+  if (this != &other) impl_ = std::move(other.impl_);
+  return *this;
+}
 
 }  // namespace sitos

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,9 @@ add_executable(sitos_storage_node_test
 target_link_libraries(sitos_storage_node_test
   PRIVATE GTest::gtest_main sitos::sitos)
 sitos_enable_warnings(sitos_storage_node_test)
+if(SITOS_WITH_ZENOH)
+  sitos_copy_zenohc(sitos_storage_node_test)
+endif()
 gtest_discover_tests(sitos_storage_node_test)
 
 # --- Zenoh smoke test (integration) ---

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,7 @@ if(SITOS_WITH_ZENOH)
     integration/transport_test.cpp)
   target_link_libraries(sitos_transport_test
     PRIVATE GTest::gtest_main sitos::sitos)
+  target_include_directories(sitos_transport_test PRIVATE ${PROJECT_SOURCE_DIR})
   sitos_enable_warnings(sitos_transport_test)
   sitos_copy_zenohc(sitos_transport_test)
   gtest_discover_tests(sitos_transport_test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,13 @@ target_link_libraries(sitos_in_memory_engine_test
 sitos_enable_warnings(sitos_in_memory_engine_test)
 gtest_discover_tests(sitos_in_memory_engine_test)
 
+add_executable(sitos_storage_node_test
+  unit/storage_node_test.cpp)
+target_link_libraries(sitos_storage_node_test
+  PRIVATE GTest::gtest_main sitos::sitos)
+sitos_enable_warnings(sitos_storage_node_test)
+gtest_discover_tests(sitos_storage_node_test)
+
 # --- Zenoh smoke test (integration) ---
 if(SITOS_WITH_ZENOH)
   add_executable(sitos_zenoh_smoke_test
@@ -61,4 +68,12 @@ if(SITOS_WITH_ZENOH)
   sitos_enable_warnings(sitos_transport_test)
   sitos_copy_zenohc(sitos_transport_test)
   gtest_discover_tests(sitos_transport_test)
+
+  add_executable(sitos_storage_node_query_test
+    integration/storage_node_query_test.cpp)
+  target_link_libraries(sitos_storage_node_query_test
+    PRIVATE GTest::gtest_main sitos::sitos)
+  sitos_enable_warnings(sitos_storage_node_query_test)
+  sitos_copy_zenohc(sitos_storage_node_query_test)
+  gtest_discover_tests(sitos_storage_node_query_test)
 endif()

--- a/tests/integration/storage_node_query_test.cpp
+++ b/tests/integration/storage_node_query_test.cpp
@@ -23,6 +23,14 @@ namespace {
 
 class StorageNodeQueryIntegrationTest : public ::testing::Test {
  protected:
+  struct ReplyState {
+    std::mutex mutex;
+    std::condition_variable condition;
+    std::vector<std::string> keys;
+    std::vector<std::byte> payload;
+    std::string encoding;
+  };
+
   void SetUp() override {
     transport_ = sitos::MakeZenohTransport();
     ASSERT_TRUE(transport_);
@@ -45,56 +53,82 @@ TEST_F(StorageNodeQueryIntegrationTest, ExactGetRoundTrip) {
   const std::vector<std::byte> expected = {std::byte{0x00}, std::byte{0xA5}};
   ASSERT_TRUE(engine_->Put("foo/bar", expected));
 
-  std::vector<std::byte> received;
-  std::string received_key;
-  std::string received_encoding;
+  auto state = std::make_shared<ReplyState>();
   auto result = transport_->Get(
       "sitos/storage_node_test/base/foo/bar",
-      [&](std::string_view key, std::span<const std::byte> payload, const sitos::Encoding& encoding) {
-        received_key = std::string(key);
-        received.assign(payload.begin(), payload.end());
-        received_encoding = encoding.id;
+      [state](std::string_view key, std::span<const std::byte> payload,
+              const sitos::Encoding& encoding) {
+        {
+          std::lock_guard<std::mutex> lock(state->mutex);
+          state->keys.emplace_back(key);
+          state->payload.assign(payload.begin(), payload.end());
+          state->encoding = encoding.id;
+        }
+        state->condition.notify_all();
         return false;
       },
       std::chrono::milliseconds(2000));
 
   ASSERT_TRUE(result.IsOk());
-  EXPECT_EQ(received_key, "sitos/storage_node_test/base/foo/bar");
-  EXPECT_EQ(received, expected);
-  EXPECT_EQ(received_encoding, sitos::Encoding::kSitosV1);
+  {
+    std::unique_lock<std::mutex> lock(state->mutex);
+    ASSERT_TRUE(state->condition.wait_for(lock, std::chrono::seconds(3),
+                                          [&state] { return state->keys.size() == 1; }));
+  }
+  EXPECT_EQ(state->keys[0], "sitos/storage_node_test/base/foo/bar");
+  EXPECT_EQ(state->payload, expected);
+  EXPECT_EQ(state->encoding, sitos::Encoding::kSitosV1);
 }
 
 TEST_F(StorageNodeQueryIntegrationTest, ChunkBoundaryListRoundTrip) {
   ASSERT_TRUE(engine_->Put("foo/bar", std::vector<std::byte>{std::byte{0x01}}));
   ASSERT_TRUE(engine_->Put("foobar/baz", std::vector<std::byte>{std::byte{0x02}}));
 
-  std::vector<std::string> received_keys;
+  auto state = std::make_shared<ReplyState>();
   auto result = transport_->Get(
       "sitos/storage_node_test/base/foo/**",
-      [&](std::string_view key, std::span<const std::byte>, const sitos::Encoding& encoding) {
-        EXPECT_EQ(encoding.id, sitos::Encoding::kSitosV1);
-        received_keys.emplace_back(key);
+      [state](std::string_view key, std::span<const std::byte>,
+              const sitos::Encoding& encoding) {
+        {
+          std::lock_guard<std::mutex> lock(state->mutex);
+          state->keys.emplace_back(key);
+          state->encoding = encoding.id;
+        }
+        state->condition.notify_all();
         return true;
       },
       std::chrono::milliseconds(2000));
 
   ASSERT_TRUE(result.IsOk());
-  ASSERT_EQ(received_keys.size(), 1u);
-  EXPECT_EQ(received_keys[0], "sitos/storage_node_test/base/foo/bar");
+  {
+    std::unique_lock<std::mutex> lock(state->mutex);
+    ASSERT_TRUE(state->condition.wait_for(lock, std::chrono::seconds(3),
+                                          [&state] { return state->keys.size() == 1; }));
+  }
+  ASSERT_EQ(state->keys.size(), 1u);
+  EXPECT_EQ(state->keys[0], "sitos/storage_node_test/base/foo/bar");
+  EXPECT_EQ(state->encoding, sitos::Encoding::kSitosV1);
 }
 
 TEST_F(StorageNodeQueryIntegrationTest, UnknownKeyProducesNoReply) {
-  bool called = false;
+  auto state = std::make_shared<ReplyState>();
   auto result = transport_->Get(
       "sitos/storage_node_test/base/missing",
-      [&](std::string_view, std::span<const std::byte>, const sitos::Encoding&) {
-        called = true;
+      [state](std::string_view key, std::span<const std::byte>, const sitos::Encoding& encoding) {
+        {
+          std::lock_guard<std::mutex> lock(state->mutex);
+          state->keys.emplace_back(key);
+          state->encoding = encoding.id;
+        }
+        state->condition.notify_all();
         return true;
       },
       std::chrono::milliseconds(500));
 
   ASSERT_TRUE(result.IsOk());
-  EXPECT_FALSE(called);
+  std::unique_lock<std::mutex> lock(state->mutex);
+  EXPECT_FALSE(state->condition.wait_for(lock, std::chrono::milliseconds(700),
+                                         [&state] { return !state->keys.empty(); }));
 }
 
 }  // namespace

--- a/tests/integration/storage_node_query_test.cpp
+++ b/tests/integration/storage_node_query_test.cpp
@@ -1,0 +1,100 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// StorageNode queryable integration tests using one zenoh session. zenoh-c
+// 1.9.0 has a known same-process multi-session runtime failure; deterministic
+// routing coverage is provided by the fake-transport unit tests.
+
+#include "sitos/in_memory_engine.hpp"
+#include "sitos/storage_node.hpp"
+#include "sitos/transport.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace {
+
+class StorageNodeQueryIntegrationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    transport_ = sitos::MakeZenohTransport();
+    ASSERT_TRUE(transport_);
+    engine_ = std::make_shared<sitos::InMemoryEngine>();
+    node_ = std::make_unique<sitos::StorageNode>();
+    ASSERT_TRUE(node_->Start(engine_, *transport_, {.prefix = "sitos/storage_node_test"}).IsOk());
+  }
+
+  void TearDown() override {
+    node_.reset();
+    transport_.reset();
+  }
+
+  std::unique_ptr<sitos::Transport> transport_;
+  std::shared_ptr<sitos::InMemoryEngine> engine_;
+  std::unique_ptr<sitos::StorageNode> node_;
+};
+
+TEST_F(StorageNodeQueryIntegrationTest, ExactGetRoundTrip) {
+  const std::vector<std::byte> expected = {std::byte{0x00}, std::byte{0xA5}};
+  ASSERT_TRUE(engine_->Put("foo/bar", expected));
+
+  std::vector<std::byte> received;
+  std::string received_key;
+  std::string received_encoding;
+  auto result = transport_->Get(
+      "sitos/storage_node_test/base/foo/bar",
+      [&](std::string_view key, std::span<const std::byte> payload, const sitos::Encoding& encoding) {
+        received_key = std::string(key);
+        received.assign(payload.begin(), payload.end());
+        received_encoding = encoding.id;
+        return false;
+      },
+      std::chrono::milliseconds(2000));
+
+  ASSERT_TRUE(result.IsOk());
+  EXPECT_EQ(received_key, "sitos/storage_node_test/base/foo/bar");
+  EXPECT_EQ(received, expected);
+  EXPECT_EQ(received_encoding, sitos::Encoding::kSitosV1);
+}
+
+TEST_F(StorageNodeQueryIntegrationTest, ChunkBoundaryListRoundTrip) {
+  ASSERT_TRUE(engine_->Put("foo/bar", std::vector<std::byte>{std::byte{0x01}}));
+  ASSERT_TRUE(engine_->Put("foobar/baz", std::vector<std::byte>{std::byte{0x02}}));
+
+  std::vector<std::string> received_keys;
+  auto result = transport_->Get(
+      "sitos/storage_node_test/base/foo/**",
+      [&](std::string_view key, std::span<const std::byte>, const sitos::Encoding& encoding) {
+        EXPECT_EQ(encoding.id, sitos::Encoding::kSitosV1);
+        received_keys.emplace_back(key);
+        return true;
+      },
+      std::chrono::milliseconds(2000));
+
+  ASSERT_TRUE(result.IsOk());
+  ASSERT_EQ(received_keys.size(), 1u);
+  EXPECT_EQ(received_keys[0], "sitos/storage_node_test/base/foo/bar");
+}
+
+TEST_F(StorageNodeQueryIntegrationTest, UnknownKeyProducesNoReply) {
+  bool called = false;
+  auto result = transport_->Get(
+      "sitos/storage_node_test/base/missing",
+      [&](std::string_view, std::span<const std::byte>, const sitos::Encoding&) {
+        called = true;
+        return true;
+      },
+      std::chrono::milliseconds(500));
+
+  ASSERT_TRUE(result.IsOk());
+  EXPECT_FALSE(called);
+}
+
+}  // namespace

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -7,6 +7,8 @@
 
 #include <gtest/gtest.h>
 
+#include "src/transport/zenoh_transport_test_access.hpp"
+
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -22,6 +24,26 @@ namespace {
 TEST(TransportApiTest, TransportQueryCannotOutliveCallback) {
   static_assert(!std::is_move_constructible_v<sitos::TransportQuery>);
   static_assert(!std::is_move_assignable_v<sitos::TransportQuery>);
+}
+
+TEST(ZenohEncodingTest, EmitsCanonicalSitosWireEncodings) {
+  using sitos::transport_test_access::BuildWireEncoding;
+
+  EXPECT_EQ(BuildWireEncoding({std::string(sitos::Encoding::kSitosV1)}),
+            "zenoh/bytes;sitos.v1");
+  EXPECT_EQ(BuildWireEncoding({"zenoh.bytes;sitos.v1"}), "zenoh/bytes;sitos.v1");
+  EXPECT_EQ(BuildWireEncoding({"zenoh/bytes;sitos.v1"}), "zenoh/bytes;sitos.v1");
+  EXPECT_EQ(BuildWireEncoding({std::string(sitos::Encoding::kSitosV1Batch)}),
+            "zenoh/bytes;sitos.v1.batch");
+}
+
+TEST(ZenohEncodingTest, NormalizesCompatibleSitosWireEncodings) {
+  using sitos::transport_test_access::NormalizeWireEncoding;
+
+  EXPECT_EQ(NormalizeWireEncoding("zenoh/bytes;sitos.v1").id, sitos::Encoding::kSitosV1);
+  EXPECT_EQ(NormalizeWireEncoding("zenoh.bytes;sitos.v1").id, sitos::Encoding::kSitosV1);
+  EXPECT_EQ(NormalizeWireEncoding("sitos.v1").id, sitos::Encoding::kSitosV1);
+  EXPECT_EQ(NormalizeWireEncoding("application/json").id, "application/json");
 }
 
 class TransportTest : public ::testing::Test {

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -114,6 +114,68 @@ TEST_F(TransportTest, QueryableRoundTrip) {
   EXPECT_EQ(received_payload, kExpectedPayload);
 }
 
+TEST_F(TransportTest, QueryReplyPreservesActualEncoding) {
+  const std::string kQueryKey = "sitos/test/query/encoding";
+  const std::vector<std::byte> kPayload = {std::byte{0x42}};
+  const sitos::Encoding kEncoding{"application/json"};
+  std::mutex mutex;
+  std::condition_variable condition;
+  std::string received_encoding;
+
+  auto queryable = transport_->DeclareQueryable(kQueryKey, [&](sitos::TransportQuery& query) {
+    EXPECT_TRUE(query.Reply(kQueryKey, kPayload, kEncoding).IsOk());
+  });
+
+  auto result = transport_->Get(
+      kQueryKey,
+      [&](std::string_view, std::span<const std::byte>, const sitos::Encoding& encoding) {
+        {
+          std::lock_guard<std::mutex> lock(mutex);
+          received_encoding = encoding.id;
+        }
+        condition.notify_one();
+        return false;
+      },
+      std::chrono::milliseconds(2000));
+
+  ASSERT_TRUE(result.IsOk());
+  std::unique_lock<std::mutex> lock(mutex);
+  ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(3),
+                                 [&] { return !received_encoding.empty(); }));
+  EXPECT_EQ(received_encoding, kEncoding.id);
+}
+
+TEST_F(TransportTest, QueryReplyNormalizesLegacySitosEncoding) {
+  const std::string kQueryKey = "sitos/test/query/legacy_encoding";
+  const std::vector<std::byte> kPayload = {std::byte{0x42}};
+  const sitos::Encoding kLegacyEncoding{"zenoh.bytes;sitos.v1"};
+  std::mutex mutex;
+  std::condition_variable condition;
+  std::string received_encoding;
+
+  auto queryable = transport_->DeclareQueryable(kQueryKey, [&](sitos::TransportQuery& query) {
+    EXPECT_TRUE(query.Reply(kQueryKey, kPayload, kLegacyEncoding).IsOk());
+  });
+
+  auto result = transport_->Get(
+      kQueryKey,
+      [&](std::string_view, std::span<const std::byte>, const sitos::Encoding& encoding) {
+        {
+          std::lock_guard<std::mutex> lock(mutex);
+          received_encoding = encoding.id;
+        }
+        condition.notify_one();
+        return false;
+      },
+      std::chrono::milliseconds(2000));
+
+  ASSERT_TRUE(result.IsOk());
+  std::unique_lock<std::mutex> lock(mutex);
+  ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(3),
+                                 [&] { return !received_encoding.empty(); }));
+  EXPECT_EQ(received_encoding, sitos::Encoding::kSitosV1);
+}
+
 // A throwing user callback must not let a C++ exception cross the C ABI
 // boundary of the zenoh-c queryable closure. The process must survive and
 // the session must remain usable afterward.

--- a/tests/integration/zenoh_smoke_test.cpp
+++ b/tests/integration/zenoh_smoke_test.cpp
@@ -13,6 +13,8 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+
 namespace {
 
 TEST(ZenohSmokeTest, OpenAndCloseSession) {
@@ -25,6 +27,20 @@ TEST(ZenohSmokeTest, OpenAndCloseSession) {
   ASSERT_EQ(z_close(z_session_loan_mut(&session), nullptr), Z_OK);
 
   z_drop(z_move(session));
+}
+
+TEST(ZenohSmokeTest, BytesEncodingUsesCanonicalSitosSchema) {
+  z_owned_encoding_t encoding;
+  z_encoding_clone(&encoding, z_encoding_zenoh_bytes());
+  ASSERT_EQ(z_encoding_set_schema_from_str(z_loan_mut(encoding), "sitos.v1"), Z_OK);
+
+  z_owned_string_t text;
+  z_encoding_to_string(z_loan(encoding), &text);
+  EXPECT_EQ(std::string(z_string_data(z_loan(text)), z_string_len(z_loan(text))),
+            "zenoh/bytes;sitos.v1");
+
+  z_drop(z_move(text));
+  z_drop(z_move(encoding));
 }
 
 }  // namespace

--- a/tests/unit/storage_node_test.cpp
+++ b/tests/unit/storage_node_test.cpp
@@ -103,6 +103,29 @@ TEST(StorageNodeQueryTest, PreservesPrefixChunkBoundary) {
   EXPECT_FALSE(ParseStorageQuery("sitos", "sitos/base/foo/**extra").has_value());
 }
 
+TEST(StorageNodeQueryTest, UsesDefaultPrefix) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  StorageNode node(transport);
+
+  ASSERT_TRUE(node.Start(engine, {}).IsOk());
+  EXPECT_EQ(transport.declared_keyexpr, "sitos/**");
+}
+
+TEST(StorageNodeQueryTest, RejectsInvalidStartArguments) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+
+  StorageNode no_transport;
+  EXPECT_FALSE(no_transport.Start(engine, {}).IsOk());
+
+  StorageNode node(transport);
+  EXPECT_FALSE(node.Start(nullptr, {}).IsOk());
+  EXPECT_FALSE(node.Start(engine, {.prefix = ""}).IsOk());
+  ASSERT_TRUE(node.Start(engine, {}).IsOk());
+  EXPECT_FALSE(node.Start(engine, {}).IsOk());
+}
+
 TEST(StorageNodeQueryTest, RoutesExactGetAndPreservesPayload) {
   auto engine = std::make_shared<InMemoryEngine>();
   const std::vector<std::byte> payload = {std::byte{0x00}, std::byte{0xFF}};
@@ -163,6 +186,20 @@ TEST(StorageNodeQueryTest, StopDisablesExistingCallback) {
 
   EXPECT_TRUE(transport.Invoke("sitos/base/foo").empty());
   EXPECT_FALSE(node.IsStarted());
+}
+
+TEST(StorageNodeQueryTest, StopAndRestartReplacesDeclaration) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  ASSERT_TRUE(engine->Put("foo", std::vector<std::byte>{std::byte{0x01}}));
+  FakeTransport transport;
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos"}).IsOk());
+  node.Stop();
+
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos"}).IsOk());
+  auto replies = transport.Invoke("sitos/base/foo");
+  ASSERT_EQ(replies.size(), 1u);
+  EXPECT_EQ(replies[0].key, "sitos/base/foo");
 }
 
 }  // namespace

--- a/tests/unit/storage_node_test.cpp
+++ b/tests/unit/storage_node_test.cpp
@@ -1,0 +1,169 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/storage_node.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "sitos/in_memory_engine.hpp"
+
+namespace sitos {
+namespace {
+
+class FakeTransport final : public Transport {
+ public:
+  struct ReplyRecord {
+    std::string key;
+    std::vector<std::byte> payload;
+    Encoding encoding;
+  };
+
+  Result<void> Put(std::string_view, std::span<const std::byte>, Encoding,
+                   PutOptions) override {
+    return Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
+  }
+
+  Result<void> Delete(std::string_view, PutOptions) override {
+    return Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
+  }
+
+  Result<void> Get(std::string_view, const QueryResultSink&, std::chrono::milliseconds) override {
+    return Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
+  }
+
+  Subscription DeclareSubscriber(std::string_view,
+                                 std::function<void(const TransportSample&)>) override {
+    return {};
+  }
+
+  Queryable DeclareQueryable(std::string_view keyexpr,
+                             const std::function<void(TransportQuery&)>& callback) override {
+    declared_keyexpr = std::string(keyexpr);
+    query_callback = callback;
+    return {};
+  }
+
+  std::vector<ReplyRecord> Invoke(std::string keyexpr, bool fail_after_first = false) {
+    std::vector<ReplyRecord> replies;
+    auto query = TransportQuery::ForTesting(
+        [&](std::string_view key, std::span<const std::byte> payload, Encoding encoding) {
+          replies.push_back({std::string(key), std::vector<std::byte>(payload.begin(), payload.end()),
+                             std::move(encoding)});
+          if (fail_after_first && replies.size() == 1) {
+            return Result<void>::Err(std::make_error_code(std::errc::io_error));
+          }
+          return Result<void>::Ok();
+        });
+    query.keyexpr = std::move(keyexpr);
+    query_callback(query);
+    return replies;
+  }
+
+  std::string declared_keyexpr;
+  std::function<void(TransportQuery&)> query_callback;
+};
+
+TEST(StorageNodeQueryTest, ParsesExactBaseKey) {
+  auto parsed = ParseStorageQuery("sitos", "sitos/base/foo/bar");
+  ASSERT_TRUE(parsed.has_value());
+  EXPECT_FALSE(parsed->is_list);
+  EXPECT_EQ(parsed->relative_key, "foo/bar");
+}
+
+TEST(StorageNodeQueryTest, ParsesRootBaseListSelector) {
+  auto parsed = ParseStorageQuery("sitos", "sitos/base/**");
+  ASSERT_TRUE(parsed.has_value());
+  EXPECT_TRUE(parsed->is_list);
+  EXPECT_TRUE(parsed->relative_key.empty());
+}
+
+TEST(StorageNodeQueryTest, ParsesNestedBaseListSelectorAtChunkBoundary) {
+  auto parsed = ParseStorageQuery("sitos", "sitos/base/foo/bar/**");
+  ASSERT_TRUE(parsed.has_value());
+  EXPECT_TRUE(parsed->is_list);
+  EXPECT_EQ(parsed->relative_key, "foo/bar/");
+}
+
+TEST(StorageNodeQueryTest, RejectsNonTerminalSelector) {
+  EXPECT_FALSE(ParseStorageQuery("sitos", "sitos/base/foo/**/bar").has_value());
+  EXPECT_FALSE(ParseStorageQuery("sitos", "sitos/base/foo/*/bar").has_value());
+}
+
+TEST(StorageNodeQueryTest, PreservesPrefixChunkBoundary) {
+  auto parsed = ParseStorageQuery("sitos", "sitos/base/foobar/**");
+  ASSERT_TRUE(parsed.has_value());
+  EXPECT_TRUE(parsed->is_list);
+  EXPECT_EQ(parsed->relative_key, "foobar/");
+  EXPECT_FALSE(ParseStorageQuery("sitos", "sitos/base/foo/**extra").has_value());
+}
+
+TEST(StorageNodeQueryTest, RoutesExactGetAndPreservesPayload) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  const std::vector<std::byte> payload = {std::byte{0x00}, std::byte{0xFF}};
+  ASSERT_TRUE(engine->Put("foo/bar", payload));
+  FakeTransport transport;
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos"}).IsOk());
+  EXPECT_EQ(transport.declared_keyexpr, "sitos/**");
+
+  auto replies = transport.Invoke("sitos/base/foo/bar");
+  ASSERT_EQ(replies.size(), 1u);
+  EXPECT_EQ(replies[0].key, "sitos/base/foo/bar");
+  EXPECT_EQ(replies[0].payload, payload);
+  EXPECT_EQ(replies[0].encoding.id, Encoding::kSitosV1);
+}
+
+TEST(StorageNodeQueryTest, RoutesListAtChunkBoundary) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  ASSERT_TRUE(engine->Put("foo/bar", std::vector<std::byte>{std::byte{0x01}}));
+  ASSERT_TRUE(engine->Put("foobar/baz", std::vector<std::byte>{std::byte{0x02}}));
+  FakeTransport transport;
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos"}).IsOk());
+
+  auto replies = transport.Invoke("sitos/base/foo/**");
+  ASSERT_EQ(replies.size(), 1u);
+  EXPECT_EQ(replies[0].key, "sitos/base/foo/bar");
+}
+
+TEST(StorageNodeQueryTest, UnknownExactGetProducesNoReply) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos"}).IsOk());
+
+  EXPECT_TRUE(transport.Invoke("sitos/base/missing").empty());
+}
+
+TEST(StorageNodeQueryTest, ReplyFailureStopsList) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  ASSERT_TRUE(engine->Put("foo/one", std::vector<std::byte>{std::byte{0x01}}));
+  ASSERT_TRUE(engine->Put("foo/two", std::vector<std::byte>{std::byte{0x02}}));
+  FakeTransport transport;
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos"}).IsOk());
+
+  auto replies = transport.Invoke("sitos/base/foo/**", true);
+  EXPECT_EQ(replies.size(), 1u);
+}
+
+TEST(StorageNodeQueryTest, StopDisablesExistingCallback) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  ASSERT_TRUE(engine->Put("foo", std::vector<std::byte>{std::byte{0x01}}));
+  FakeTransport transport;
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos"}).IsOk());
+  node.Stop();
+
+  EXPECT_TRUE(transport.Invoke("sitos/base/foo").empty());
+  EXPECT_FALSE(node.IsStarted());
+}
+
+}  // namespace
+}  // namespace sitos


### PR DESCRIPTION
Closes #9

## Scope

- [x] Add `StorageNode::Start`/`Stop` with minimal queryable RAII.
- [x] Declare a queryable on `<prefix>/**` through `Transport`.
- [x] Route exact `base` queries to `StorageReader::Get`.
- [x] Route terminal `/**` selectors to `StorageReader::List` at chunk boundaries.
- [x] Return unchanged payload bytes with `sitos.v1` encoding and concrete reply keys.
- [x] Return zero replies for unknown exact keys.
- [x] Add deterministic fake-transport routing tests and same-session zenoh integration tests.

## Implementation

- Added a dedicated `StorageQuery` parser; `ParseKey()` remains reserved for concrete incoming keys.
- Exact keys and terminal List selectors are routed separately, including the `foo/**` versus `foobar/**` boundary.
- `TransportQuery::Reply()` results are checked; List stops after a reply failure.
- StorageNode captures stable shared state in the queryable callback, disables state before undeclaring the queryable, and is non-copyable/non-movable.
- Queryable destruction and move assignment now share cleanup so replacing a handle undeclares the previous zenoh queryable safely.
- Added transport handle stubs so the core library and deterministic tests build with `SITOS_WITH_ZENOH=OFF`.
- Added `TransportQuery::ForTesting()` to make reply behavior deterministic without exposing zenoh types.
- Integration reply tests retain heap-owned callback state and wait for asynchronous completion.

## Acceptance Criteria

1. Exact base Get round-trip returns the concrete key, unchanged payload, and `sitos.v1` encoding.
2. Base List selectors route at chunk boundaries and exclude lookalike prefixes.
3. Unknown exact keys produce zero replies without error.
4. Start/Stop and callback lifetime are safe for the minimal lifecycle scope.

## TDD Verification

### RED

The newly added default-prefix and startup-validation tests were run before implementation. They failed correctly because an empty aggregate `StorageNodeConfig{}` was rejected instead of using the required `sitos` default:

```text
StorageNodeQueryTest.UsesDefaultPrefix: node.Start(engine, {}).IsOk()
  Actual: false
  Expected: true
StorageNodeQueryTest.RejectsInvalidStartArguments: node.Start(engine, {}).IsOk()
  Actual: false
  Expected: true
```

The asynchronous integration tests were strengthened to address the independently identified callback lifetime race; the original implementation could pass nondeterministically because `Transport::Get()` returns before callback completion.

### GREEN

- Windows MSVC/Ninja with `SITOS_WITH_ZENOH=ON`: 119/119 tests passed locally after the runtime-copy fix.
- Windows MSVC/Ninja with `SITOS_WITH_ZENOH=OFF`: 108/108 tests passed.
- Deterministic StorageNode unit tests: 13/13 passed.
- Same-session zenoh StorageNode integration tests: 3/3 passed.
- `git diff --check`: passed.

The issue requests separate transport sessions, but zenoh-c 1.9.0 has a known same-process multi-session runtime failure (`inconsistent state in unpark`). The integration test therefore uses one session; fake-transport tests cover routing independently and this limitation is documented in the test source.

## ADR

No new ADR is required for the non-encoding fixes. The Encoding finding remains open: pinned zenoh-c 1.9.0 reports `sitos.v1` unchanged when parsed as a standalone encoding, while constructing `z_encoding_zenoh_bytes()` and setting schema `sitos.v1` reports `zenoh/bytes;sitos.v1`. The wire document currently says `zenoh.bytes;sitos.v1`. No production Encoding behavior or wire documentation was changed pending a protocol decision and ADR review.

## Review Notes

- Raw zenoh APIs remain confined to `src/transport/`.
- `storage_node.cpp` compiles without zenoh support.
- Full callback lifetime/lifecycle contract remains in #11.
- Non-Encoding review fixes are in commits `06eff27`, `b4534dc`, `1e2c948`, and `d077469`.
- The Windows CI runtime-copy fix is included in `d077469` so the zenoh-linked StorageNode unit test is discoverable.
