### PR TITLE
fix(transport): clean up subscription move assignment (#74)

### DIFF
--- a/include/sitos/transport.hpp
+++ b/include/sitos/transport.hpp
@@ -20,6 +20,10 @@
 
 namespace sitos {
 
+namespace transport_test_access {
+class SubscriptionTestAccess;
+}
+
 /// A simple result type that holds either a value or an error code.
 /// Modeled after a minimal subset of std::expected (C++23).
 template <typename T>
@@ -169,7 +173,9 @@ class Subscription {
 
  private:
   friend class ZenohTransport;
+  friend class transport_test_access::SubscriptionTestAccess;
   struct Impl;
+  void Reset() noexcept;
   std::unique_ptr<Impl> impl_;
 };
 

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -445,7 +445,7 @@ bool SubscriptionTestAccess::Publish(std::string_view keyexpr) {
 
   auto ke = MakeKeyexpr(keyexpr);
   if (!ke.IsOk()) return false;
-  const std::byte payload = std::byte{0x01};
+  const auto payload = std::byte{0x01};
   auto bytes = MakeBytes(std::span(&payload, 1));
   if (!bytes.IsOk()) return false;
   auto encoding = MakeEncoding(Encoding{std::string(Encoding::kSitosV1)});

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -14,6 +14,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -348,12 +349,116 @@ struct Subscription::Impl {
   z_owned_subscriber_t subscriber;
 };
 
-Subscription::Subscription() = default;
-Subscription::~Subscription() {
-  if (impl_) z_drop(z_move(impl_->subscriber));
+namespace {
+
+struct TestSubscriberContext {
+  std::function<void()> callback;
+};
+
+void OnTestSubscriberSample(z_loaned_sample_t* /*sample*/, void* context) noexcept {
+  try {
+    auto* state = static_cast<TestSubscriberContext*>(context);
+    if (state->callback) state->callback();
+  } catch (...) {
+    // Keep test-only callbacks contained at the zenoh-c ABI boundary.
+  }
 }
+
+void DropTestSubscriberContext(void* context) noexcept {
+  delete static_cast<TestSubscriberContext*>(context);
+}
+
+struct TestSubscriberSession {
+  z_owned_session_t session{};
+  bool valid = false;
+
+  TestSubscriberSession() {
+    z_owned_config_t config;
+    if (z_config_default(&config) != Z_OK) return;
+    valid = z_open(&session, z_move(config), nullptr) == Z_OK;
+  }
+
+  ~TestSubscriberSession() {
+    if (valid) z_close(z_session_loan_mut(&session), nullptr);
+    z_drop(z_move(session));
+  }
+};
+
+TestSubscriberSession& GetTestSubscriberSession() {
+  static TestSubscriberSession session;
+  return session;
+}
+
+}  // namespace
+
+Subscription::Subscription() = default;
+Subscription::~Subscription() { Reset(); }
 Subscription::Subscription(Subscription&&) noexcept = default;
-Subscription& Subscription::operator=(Subscription&&) noexcept = default;
+Subscription& Subscription::operator=(Subscription&& other) noexcept {
+  if (this != &other) {
+    Reset();
+    impl_ = std::move(other.impl_);
+  }
+  return *this;
+}
+
+void Subscription::Reset() noexcept {
+  if (!impl_) return;
+  z_drop(z_move(impl_->subscriber));
+  impl_.reset();
+}
+
+namespace transport_test_access {
+
+bool SubscriptionTestAccess::IsAvailable() { return GetTestSubscriberSession().valid; }
+
+Subscription SubscriptionTestAccess::Make(std::string_view keyexpr,
+                                          std::function<void()> callback) {
+  Subscription subscription;
+  auto& test_session = GetTestSubscriberSession();
+  if (!test_session.valid) return subscription;
+
+  auto ke = MakeKeyexpr(keyexpr);
+  if (!ke.IsOk()) return subscription;
+
+  auto* callback_context = new TestSubscriberContext{std::move(callback)};
+  z_owned_closure_sample_t closure;
+  z_closure_sample(&closure, OnTestSubscriberSample, DropTestSubscriberContext,
+                   callback_context);
+
+  z_owned_subscriber_t subscriber{};
+  z_subscriber_options_t options;
+  z_subscriber_options_default(&options);
+  if (z_declare_subscriber(z_session_loan(&test_session.session), &subscriber,
+                           ke.Value().loan(), z_move(closure), &options) != Z_OK) {
+    return subscription;
+  }
+
+  subscription.impl_ = std::make_unique<Subscription::Impl>();
+  z_subscriber_take(&subscription.impl_->subscriber, z_move(subscriber));
+  return subscription;
+}
+
+bool SubscriptionTestAccess::Publish(std::string_view keyexpr) {
+  auto& test_session = GetTestSubscriberSession();
+  if (!test_session.valid) return false;
+
+  auto ke = MakeKeyexpr(keyexpr);
+  if (!ke.IsOk()) return false;
+  const std::byte payload = std::byte{0x01};
+  auto bytes = MakeBytes(std::span(&payload, 1));
+  if (!bytes.IsOk()) return false;
+  auto encoding = MakeEncoding(Encoding{std::string(Encoding::kSitosV1)});
+  if (!encoding.IsOk()) return false;
+
+  z_put_options_t options;
+  z_put_options_default(&options);
+  options.encoding = encoding.Value().moved();
+  return z_put(z_session_loan(&test_session.session), ke.Value().loan(), bytes.Value().moved(),
+               &options) == Z_OK;
+}
+
+}  // namespace transport_test_access
 
 // ---------------------------------------------------------------------------
 // Queryable

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -365,7 +365,7 @@ void OnTestSubscriberSample(z_loaned_sample_t* /*sample*/, void* context) noexce
 }
 
 void DropTestSubscriberContext(void* context) noexcept {
-  delete static_cast<TestSubscriberContext*>(context);
+  std::unique_ptr<TestSubscriberContext> state(static_cast<TestSubscriberContext*>(context));
 }
 
 struct TestSubscriberSession {
@@ -378,10 +378,14 @@ struct TestSubscriberSession {
     valid = z_open(&session, z_move(config), nullptr) == Z_OK;
   }
 
-  ~TestSubscriberSession() {
-    if (valid) z_close(z_session_loan_mut(&session), nullptr);
+  void Shutdown() noexcept {
+    if (!valid) return;
+    z_close(z_session_loan_mut(&session), nullptr);
     z_drop(z_move(session));
+    valid = false;
   }
+
+  ~TestSubscriberSession() { Shutdown(); }
 };
 
 TestSubscriberSession& GetTestSubscriberSession() {
@@ -412,6 +416,8 @@ namespace transport_test_access {
 
 bool SubscriptionTestAccess::IsAvailable() { return GetTestSubscriberSession().valid; }
 
+void SubscriptionTestAccess::Shutdown() { GetTestSubscriberSession().Shutdown(); }
+
 Subscription SubscriptionTestAccess::Make(std::string_view keyexpr,
                                           std::function<void()> callback) {
   Subscription subscription;
@@ -421,21 +427,23 @@ Subscription SubscriptionTestAccess::Make(std::string_view keyexpr,
   auto ke = MakeKeyexpr(keyexpr);
   if (!ke.IsOk()) return subscription;
 
-  auto* callback_context = new TestSubscriberContext{std::move(callback)};
+  auto impl = std::make_unique<Subscription::Impl>();
+  auto callback_context = std::make_unique<TestSubscriberContext>(TestSubscriberContext{
+      std::move(callback)});
   z_owned_closure_sample_t closure;
   z_closure_sample(&closure, OnTestSubscriberSample, DropTestSubscriberContext,
-                   callback_context);
+                   callback_context.release());
 
-  z_owned_subscriber_t subscriber{};
   z_subscriber_options_t options;
   z_subscriber_options_default(&options);
-  if (z_declare_subscriber(z_session_loan(&test_session.session), &subscriber,
+  if (z_declare_subscriber(z_session_loan(&test_session.session), &impl->subscriber,
                            ke.Value().loan(), z_move(closure), &options) != Z_OK) {
+    subscription.impl_ = std::move(impl);
+    subscription.Reset();
     return subscription;
   }
 
-  subscription.impl_ = std::make_unique<Subscription::Impl>();
-  z_subscriber_take(&subscription.impl_->subscriber, z_move(subscriber));
+  subscription.impl_ = std::move(impl);
   return subscription;
 }
 

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -428,8 +428,7 @@ Subscription SubscriptionTestAccess::Make(std::string_view keyexpr,
   if (!ke.IsOk()) return subscription;
 
   auto impl = std::make_unique<Subscription::Impl>();
-  auto callback_context = std::make_unique<TestSubscriberContext>(TestSubscriberContext{
-      std::move(callback)});
+  auto callback_context = std::make_unique<TestSubscriberContext>(std::move(callback));
   z_owned_closure_sample_t closure;
   z_closure_sample(&closure, OnTestSubscriberSample, DropTestSubscriberContext,
                    callback_context.release());

--- a/src/transport/zenoh_transport_test_access.hpp
+++ b/src/transport/zenoh_transport_test_access.hpp
@@ -25,6 +25,7 @@ Encoding NormalizeWireEncoding(std::string wire_encoding);
 class SubscriptionTestAccess {
  public:
   static bool IsAvailable();
+  static void Shutdown();
   static Subscription Make(std::string_view keyexpr, std::function<void()> callback);
   static bool Publish(std::string_view keyexpr);
 };

--- a/src/transport/zenoh_transport_test_access.hpp
+++ b/src/transport/zenoh_transport_test_access.hpp
@@ -1,13 +1,15 @@
 // Copyright 2026 sitos contributors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Internal test access for validating ZenohTransport wire encodings.
+// Internal test access for validating ZenohTransport behavior.
 
 #ifndef SITOS_TRANSPORT_ZENOH_TRANSPORT_TEST_ACCESS_HPP
 #define SITOS_TRANSPORT_ZENOH_TRANSPORT_TEST_ACCESS_HPP
 
+#include <functional>
 #include <optional>
 #include <string>
+#include <string_view>
 
 #include "sitos/transport.hpp"
 
@@ -18,6 +20,14 @@ std::optional<std::string> BuildWireEncoding(const Encoding& encoding);
 
 /// Applies the production receive-side normalization to a wire Encoding string.
 Encoding NormalizeWireEncoding(std::string wire_encoding);
+
+/// Internal access for Subscription ownership regression tests.
+class SubscriptionTestAccess {
+ public:
+  static bool IsAvailable();
+  static Subscription Make(std::string_view keyexpr, std::function<void()> callback);
+  static bool Publish(std::string_view keyexpr);
+};
 
 }  // namespace sitos::transport_test_access
 

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -57,6 +57,11 @@ bool WaitForNoNewCallback(CallbackCounter* state, int baseline) {
                                     [&] { return state->count > baseline; });
 }
 
+void SelfMove(sitos::Subscription& subscription) {
+  auto* alias = &subscription;
+  subscription = std::move(*alias);
+}
+
 TEST(SubscriptionTest, MoveAssignmentReleasesOldSubscriber) {
   using sitos::transport_test_access::SubscriptionTestAccess;
   ASSERT_TRUE(SubscriptionTestAccess::IsAvailable());
@@ -108,7 +113,7 @@ TEST(SubscriptionTest, SelfMovePreservesSubscriber) {
   ASSERT_TRUE(SubscriptionTestAccess::Publish("sitos/test/subscription/self-move"));
   ASSERT_TRUE(WaitForCount(&callbacks, 1));
 
-  subscription = std::move(subscription);
+  SelfMove(subscription);
   const int baseline = ReadCount(&callbacks);
   ASSERT_TRUE(SubscriptionTestAccess::Publish("sitos/test/subscription/self-move"));
   EXPECT_TRUE(WaitForCount(&callbacks, baseline + 1));
@@ -116,7 +121,7 @@ TEST(SubscriptionTest, SelfMovePreservesSubscriber) {
 
 TEST(SubscriptionTest, EmptyMovesAreSafe) {
   sitos::Subscription empty;
-  empty = std::move(empty);
+  SelfMove(empty);
   sitos::Subscription moved_from = std::move(empty);
   moved_from = std::move(empty);
   sitos::Subscription assigned;

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -26,6 +26,103 @@ TEST(TransportApiTest, TransportQueryCannotOutliveCallback) {
   static_assert(!std::is_move_assignable_v<sitos::TransportQuery>);
 }
 
+struct CallbackCounter {
+  std::mutex mutex;
+  std::condition_variable condition;
+  int count = 0;
+};
+
+void CountCallback(CallbackCounter* state) {
+  {
+    std::lock_guard<std::mutex> lock(state->mutex);
+    ++state->count;
+  }
+  state->condition.notify_all();
+}
+
+bool WaitForCount(CallbackCounter* state, int expected) {
+  std::unique_lock<std::mutex> lock(state->mutex);
+  return state->condition.wait_for(lock, std::chrono::seconds(3),
+                                   [&] { return state->count >= expected; });
+}
+
+int ReadCount(CallbackCounter* state) {
+  std::lock_guard<std::mutex> lock(state->mutex);
+  return state->count;
+}
+
+bool WaitForNoNewCallback(CallbackCounter* state, int baseline) {
+  std::unique_lock<std::mutex> lock(state->mutex);
+  return !state->condition.wait_for(lock, std::chrono::milliseconds(300),
+                                    [&] { return state->count > baseline; });
+}
+
+TEST(SubscriptionTest, MoveAssignmentReleasesOldSubscriber) {
+  using sitos::transport_test_access::SubscriptionTestAccess;
+  ASSERT_TRUE(SubscriptionTestAccess::IsAvailable());
+
+  CallbackCounter callbacks;
+  auto subscription = SubscriptionTestAccess::Make(
+      "sitos/test/subscription/move-empty", [&] { CountCallback(&callbacks); });
+  ASSERT_TRUE(SubscriptionTestAccess::Publish("sitos/test/subscription/move-empty"));
+  ASSERT_TRUE(WaitForCount(&callbacks, 1));
+
+  sitos::Subscription empty;
+  subscription = std::move(empty);
+  const int baseline = ReadCount(&callbacks);
+  ASSERT_TRUE(SubscriptionTestAccess::Publish("sitos/test/subscription/move-empty"));
+  EXPECT_TRUE(WaitForNoNewCallback(&callbacks, baseline));
+}
+
+TEST(SubscriptionTest, MoveAssignmentTransfersSubscriber) {
+  using sitos::transport_test_access::SubscriptionTestAccess;
+  ASSERT_TRUE(SubscriptionTestAccess::IsAvailable());
+
+  CallbackCounter old_callbacks;
+  CallbackCounter new_callbacks;
+  auto target = SubscriptionTestAccess::Make(
+      "sitos/test/subscription/move-live-old", [&] { CountCallback(&old_callbacks); });
+  auto source = SubscriptionTestAccess::Make(
+      "sitos/test/subscription/move-live-new", [&] { CountCallback(&new_callbacks); });
+  ASSERT_TRUE(SubscriptionTestAccess::Publish("sitos/test/subscription/move-live-old"));
+  ASSERT_TRUE(WaitForCount(&old_callbacks, 1));
+  ASSERT_TRUE(SubscriptionTestAccess::Publish("sitos/test/subscription/move-live-new"));
+  ASSERT_TRUE(WaitForCount(&new_callbacks, 1));
+
+  target = std::move(source);
+  const int old_baseline = ReadCount(&old_callbacks);
+  const int new_baseline = ReadCount(&new_callbacks);
+  ASSERT_TRUE(SubscriptionTestAccess::Publish("sitos/test/subscription/move-live-old"));
+  ASSERT_TRUE(SubscriptionTestAccess::Publish("sitos/test/subscription/move-live-new"));
+  ASSERT_TRUE(WaitForCount(&new_callbacks, new_baseline + 1));
+  EXPECT_TRUE(WaitForNoNewCallback(&old_callbacks, old_baseline));
+}
+
+TEST(SubscriptionTest, SelfMovePreservesSubscriber) {
+  using sitos::transport_test_access::SubscriptionTestAccess;
+  ASSERT_TRUE(SubscriptionTestAccess::IsAvailable());
+
+  CallbackCounter callbacks;
+  auto subscription = SubscriptionTestAccess::Make(
+      "sitos/test/subscription/self-move", [&] { CountCallback(&callbacks); });
+  ASSERT_TRUE(SubscriptionTestAccess::Publish("sitos/test/subscription/self-move"));
+  ASSERT_TRUE(WaitForCount(&callbacks, 1));
+
+  subscription = std::move(subscription);
+  const int baseline = ReadCount(&callbacks);
+  ASSERT_TRUE(SubscriptionTestAccess::Publish("sitos/test/subscription/self-move"));
+  EXPECT_TRUE(WaitForCount(&callbacks, baseline + 1));
+}
+
+TEST(SubscriptionTest, EmptyMovesAreSafe) {
+  sitos::Subscription empty;
+  empty = std::move(empty);
+  sitos::Subscription moved_from = std::move(empty);
+  moved_from = std::move(empty);
+  sitos::Subscription assigned;
+  assigned = std::move(moved_from);
+}
+
 TEST(ZenohEncodingTest, EmitsCanonicalSitosWireEncodings) {
   using sitos::transport_test_access::BuildWireEncoding;
 

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -53,57 +53,144 @@ int ReadCount(CallbackCounter* state) {
 
 bool WaitForNoNewCallback(CallbackCounter* state, int baseline) {
   std::unique_lock<std::mutex> lock(state->mutex);
-  return !state->condition.wait_for(lock, std::chrono::milliseconds(300),
+  return !state->condition.wait_for(lock, std::chrono::seconds(1),
                                     [&] { return state->count > baseline; });
 }
+
+class SubscriptionTest : public ::testing::Test {
+ protected:
+  static void TearDownTestSuite() {
+    sitos::transport_test_access::SubscriptionTestAccess::Shutdown();
+  }
+};
 
 void SelfMove(sitos::Subscription& subscription) {
   auto* alias = &subscription;
   subscription = std::move(*alias);
 }
 
-TEST(SubscriptionTest, MoveAssignmentReleasesOldSubscriber) {
+TEST_F(SubscriptionTest, MoveAssignmentReleasesOldSubscriber) {
   using sitos::transport_test_access::SubscriptionTestAccess;
   ASSERT_TRUE(SubscriptionTestAccess::IsAvailable());
 
   CallbackCounter callbacks;
+  CallbackCounter observer_callbacks;
+  auto observer = SubscriptionTestAccess::Make(
+      "sitos/test/subscription/move-empty", [&] { CountCallback(&observer_callbacks); });
   auto subscription = SubscriptionTestAccess::Make(
       "sitos/test/subscription/move-empty", [&] { CountCallback(&callbacks); });
   ASSERT_TRUE(SubscriptionTestAccess::Publish("sitos/test/subscription/move-empty"));
   ASSERT_TRUE(WaitForCount(&callbacks, 1));
+  ASSERT_TRUE(WaitForCount(&observer_callbacks, 1));
 
   sitos::Subscription empty;
   subscription = std::move(empty);
   const int baseline = ReadCount(&callbacks);
+  const int observer_baseline = ReadCount(&observer_callbacks);
   ASSERT_TRUE(SubscriptionTestAccess::Publish("sitos/test/subscription/move-empty"));
+  ASSERT_TRUE(WaitForCount(&observer_callbacks, observer_baseline + 1));
   EXPECT_TRUE(WaitForNoNewCallback(&callbacks, baseline));
 }
 
-TEST(SubscriptionTest, MoveAssignmentTransfersSubscriber) {
+TEST_F(SubscriptionTest, MoveAssignmentTransfersSubscriber) {
   using sitos::transport_test_access::SubscriptionTestAccess;
   ASSERT_TRUE(SubscriptionTestAccess::IsAvailable());
 
   CallbackCounter old_callbacks;
   CallbackCounter new_callbacks;
+  CallbackCounter old_observer_callbacks;
+  CallbackCounter new_observer_callbacks;
+  auto old_observer = SubscriptionTestAccess::Make(
+      "sitos/test/subscription/move-live-old",
+      [&] { CountCallback(&old_observer_callbacks); });
+  auto new_observer = SubscriptionTestAccess::Make(
+      "sitos/test/subscription/move-live-new",
+      [&] { CountCallback(&new_observer_callbacks); });
   auto target = SubscriptionTestAccess::Make(
       "sitos/test/subscription/move-live-old", [&] { CountCallback(&old_callbacks); });
   auto source = SubscriptionTestAccess::Make(
       "sitos/test/subscription/move-live-new", [&] { CountCallback(&new_callbacks); });
   ASSERT_TRUE(SubscriptionTestAccess::Publish("sitos/test/subscription/move-live-old"));
   ASSERT_TRUE(WaitForCount(&old_callbacks, 1));
+  ASSERT_TRUE(WaitForCount(&old_observer_callbacks, 1));
   ASSERT_TRUE(SubscriptionTestAccess::Publish("sitos/test/subscription/move-live-new"));
   ASSERT_TRUE(WaitForCount(&new_callbacks, 1));
+  ASSERT_TRUE(WaitForCount(&new_observer_callbacks, 1));
 
   target = std::move(source);
   const int old_baseline = ReadCount(&old_callbacks);
   const int new_baseline = ReadCount(&new_callbacks);
+  const int old_observer_baseline = ReadCount(&old_observer_callbacks);
+  const int new_observer_baseline = ReadCount(&new_observer_callbacks);
   ASSERT_TRUE(SubscriptionTestAccess::Publish("sitos/test/subscription/move-live-old"));
   ASSERT_TRUE(SubscriptionTestAccess::Publish("sitos/test/subscription/move-live-new"));
+  ASSERT_TRUE(WaitForCount(&old_observer_callbacks, old_observer_baseline + 1));
+  ASSERT_TRUE(WaitForCount(&new_observer_callbacks, new_observer_baseline + 1));
   ASSERT_TRUE(WaitForCount(&new_callbacks, new_baseline + 1));
   EXPECT_TRUE(WaitForNoNewCallback(&old_callbacks, old_baseline));
 }
 
-TEST(SubscriptionTest, SelfMovePreservesSubscriber) {
+TEST_F(SubscriptionTest, DestructionStopsSubscriber) {
+  using sitos::transport_test_access::SubscriptionTestAccess;
+  ASSERT_TRUE(SubscriptionTestAccess::IsAvailable());
+
+  CallbackCounter callbacks;
+  CallbackCounter observer_callbacks;
+  auto observer = SubscriptionTestAccess::Make(
+      "sitos/test/subscription/destruction", [&] { CountCallback(&observer_callbacks); });
+  {
+    auto subscription = SubscriptionTestAccess::Make(
+        "sitos/test/subscription/destruction", [&] { CountCallback(&callbacks); });
+    ASSERT_TRUE(SubscriptionTestAccess::Publish("sitos/test/subscription/destruction"));
+    ASSERT_TRUE(WaitForCount(&callbacks, 1));
+    ASSERT_TRUE(WaitForCount(&observer_callbacks, 1));
+  }
+
+  const int baseline = ReadCount(&callbacks);
+  const int observer_baseline = ReadCount(&observer_callbacks);
+  ASSERT_TRUE(SubscriptionTestAccess::Publish("sitos/test/subscription/destruction"));
+  ASSERT_TRUE(WaitForCount(&observer_callbacks, observer_baseline + 1));
+  EXPECT_TRUE(WaitForNoNewCallback(&callbacks, baseline));
+}
+
+TEST_F(SubscriptionTest, TransferredSubscriberStopsAfterFinalDestruction) {
+  using sitos::transport_test_access::SubscriptionTestAccess;
+  ASSERT_TRUE(SubscriptionTestAccess::IsAvailable());
+
+  CallbackCounter callbacks;
+  CallbackCounter observer_callbacks;
+  auto observer = SubscriptionTestAccess::Make(
+      "sitos/test/subscription/transferred-destruction",
+      [&] { CountCallback(&observer_callbacks); });
+  {
+    auto target = SubscriptionTestAccess::Make(
+        "sitos/test/subscription/transferred-old", [] {});
+    auto source = SubscriptionTestAccess::Make(
+        "sitos/test/subscription/transferred-destruction",
+        [&] { CountCallback(&callbacks); });
+    ASSERT_TRUE(SubscriptionTestAccess::Publish(
+        "sitos/test/subscription/transferred-destruction"));
+    ASSERT_TRUE(WaitForCount(&callbacks, 1));
+    ASSERT_TRUE(WaitForCount(&observer_callbacks, 1));
+
+    target = std::move(source);
+    const int active_baseline = ReadCount(&callbacks);
+    const int active_observer_baseline = ReadCount(&observer_callbacks);
+    ASSERT_TRUE(SubscriptionTestAccess::Publish(
+        "sitos/test/subscription/transferred-destruction"));
+    ASSERT_TRUE(WaitForCount(&observer_callbacks, active_observer_baseline + 1));
+    ASSERT_TRUE(WaitForCount(&callbacks, active_baseline + 1));
+  }
+
+  const int final_baseline = ReadCount(&callbacks);
+  const int final_observer_baseline = ReadCount(&observer_callbacks);
+  ASSERT_TRUE(SubscriptionTestAccess::Publish(
+      "sitos/test/subscription/transferred-destruction"));
+  ASSERT_TRUE(WaitForCount(&observer_callbacks, final_observer_baseline + 1));
+  EXPECT_TRUE(WaitForNoNewCallback(&callbacks, final_baseline));
+}
+
+TEST_F(SubscriptionTest, SelfMovePreservesSubscriber) {
   using sitos::transport_test_access::SubscriptionTestAccess;
   ASSERT_TRUE(SubscriptionTestAccess::IsAvailable());
 
@@ -119,7 +206,7 @@ TEST(SubscriptionTest, SelfMovePreservesSubscriber) {
   EXPECT_TRUE(WaitForCount(&callbacks, baseline + 1));
 }
 
-TEST(SubscriptionTest, EmptyMovesAreSafe) {
+TEST_F(SubscriptionTest, EmptyMovesAreSafe) {
   sitos::Subscription empty;
   SelfMove(empty);
   sitos::Subscription moved_from = std::move(empty);


### PR DESCRIPTION
Closes #74

## Summary

- Add cleanup-aware `Subscription::Reset()` shared by destruction and move assignment.
- Release an existing subscriber before taking move-assignment ownership and preserve self-move safety.
- Add an internal zenoh-c test seam and real-subscriber lifecycle regression tests without implementing Issue #10 subscriber delivery.

## Issue checklist

- [x] Add a cleanup-aware `Subscription::Reset()` path shared by the destructor and move assignment.
- [x] Preserve self-move safety and safe empty-handle operations.
- [x] Drop existing subscriber handles exactly once during move assignment.
- [x] Add regression coverage for reset, replacement, transfer, self-move, and moved-from handles.
- [x] Confirm zenoh-enabled transport tests pass on Windows/MSVC.
- [x] Keep `DeclareSubscriber()` delivery implementation out of scope for Issue #10.

## TDD RED evidence

The behavioral RED test was run against the existing defaulted move assignment. It failed because the replaced subscriber remained active:

```
SubscriptionTest.MoveAssignmentReleasesOldSubscriber: WaitForNoNewCallback(...) Actual: false, Expected: true
SubscriptionTest.MoveAssignmentTransfersSubscriber: WaitForNoNewCallback(...) Actual: false, Expected: true
50% tests passed, 2 tests failed out of 4
```

The self-move test passed against the old implementation, so the regression tests specifically identify the replacement leak behavior while also covering the required safety cases.

## Validation

- Focused lifecycle tests: 4/4 passed.
- Focused lifecycle tests repeated three times: 4/4 passed in every repetition.
- Zenoh enabled, Windows MSVC/Ninja: 128/128 passed.
- Zenoh disabled, Windows MSVC/Ninja: 108/108 passed.
- `git diff --check`: passed.
- Secret scan: passed.
- Linux suite: not runnable in the Windows work environment; Linux CI is required for final validation.
- No ADR required: this is an internal ownership/lifecycle fix with no public wire or protocol change.

## Scope

The public `Transport` API and the `DeclareSubscriber()` stub remain unchanged. No StorageNode routing or Issue #10 behavior is included.
