### PR TITLE
feat(logging): add injectable logging boundary (#76)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(sitos STATIC
   src/key.cpp
   src/storage_engine.cpp
   src/in_memory_engine.cpp
+  src/logging.cpp
   src/storage_node.cpp
 )
 add_library(sitos::sitos ALIAS sitos)

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -11,10 +11,10 @@ plog, quill, or another backend through a `LogSink` adapter; backend-specific ty
 and initialization never enter sitos component APIs. `LogRecord` string views are callback-scoped,
 so asynchronous adapters must copy the component and message before `Write()` returns.
 
-`LogSink::Write()` may be called concurrently and each sink owns its thread-safety policy.
-`EmitLog()` is the non-throwing exception-containment boundary, while backend lifecycle,
-configuration, filtering, formatting, and ownership remain with the application or optional
-adapter. An explicitly null sink disables emission; omitted `StorageNodeConfig` sinks use the
+`LogSink::Write()` may be called concurrently, so sink implementations must synchronize access
+to their mutable state. `EmitLog()` is the non-throwing exception-containment boundary, while
+backend lifecycle, configuration, filtering, formatting, and ownership remain with the
+application or optional adapter. An explicitly null sink disables emission; omitted `StorageNodeConfig` sinks use the
 immutable built-in stderr sink.
 
 * The compatibility units for sitos are the `sitos.v1` payload, key space, and batch/ack protocols,

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -4,6 +4,19 @@
 
 sitos **owns its wire specification and thinly isolates zenoh as a transport dependency**.
 
+### 1.1 Backend-isolated logging
+
+The core logging API has no mandatory third-party backend dependency. Applications may provide
+plog, quill, or another backend through a `LogSink` adapter; backend-specific types, macros,
+and initialization never enter sitos component APIs. `LogRecord` string views are callback-scoped,
+so asynchronous adapters must copy the component and message before `Write()` returns.
+
+`LogSink::Write()` may be called concurrently and each sink owns its thread-safety policy.
+`EmitLog()` is the non-throwing exception-containment boundary, while backend lifecycle,
+configuration, filtering, formatting, and ownership remain with the application or optional
+adapter. An explicitly null sink disables emission; omitted `StorageNodeConfig` sinks use the
+immutable built-in stderr sink.
+
 * The compatibility units for sitos are the `sitos.v1` payload, key space, and batch/ack protocols,
   not zenoh internal APIs
 * The scope affected by zenoh version upgrades is limited to `src/transport/zenoh_transport.cpp`

--- a/include/sitos/logging.hpp
+++ b/include/sitos/logging.hpp
@@ -18,8 +18,8 @@ enum class LogLevel { kDebug, kInfo, kWarning, kError };
 ///
 /// The component and message views are valid only during the synchronous
 /// LogSink::Write call. An asynchronous sink must copy both strings before
-/// Write returns. Write may be called concurrently; each sink owns its
-/// thread-safety policy.
+/// Write returns. Write may be called concurrently; sink implementations
+/// must synchronize access to their mutable state.
 struct LogRecord {
   LogLevel level;
   std::string_view component;

--- a/include/sitos/logging.hpp
+++ b/include/sitos/logging.hpp
@@ -1,0 +1,53 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Backend-neutral diagnostics boundary for sitos.
+
+#ifndef SITOS_LOGGING_HPP
+#define SITOS_LOGGING_HPP
+
+#include <memory>
+#include <string_view>
+
+namespace sitos {
+
+/// Severity assigned to a diagnostic record.
+enum class LogLevel { kDebug, kInfo, kWarning, kError };
+
+/// A non-owning diagnostic record.
+///
+/// The component and message views are valid only during the synchronous
+/// LogSink::Write call. An asynchronous sink must copy both strings before
+/// Write returns. Write may be called concurrently; each sink owns its
+/// thread-safety policy.
+struct LogRecord {
+  LogLevel level;
+  std::string_view component;
+  std::string_view message;
+};
+
+/// Application-provided destination for diagnostic records.
+///
+/// This method intentionally is not noexcept: adapters may use third-party
+/// backends that throw. EmitLog is the non-throwing boundary for sitos code.
+class LogSink {
+ public:
+  virtual ~LogSink() = default;
+
+  /// Consumes a record synchronously, or copies it for asynchronous delivery.
+  virtual void Write(const LogRecord& record) = 0;
+};
+
+/// Returns the immutable built-in stderr sink used by omitted configurations.
+/// Applications may provide their own sink without configuring global state.
+std::shared_ptr<LogSink> DefaultLogSink();
+
+/// Delivers a diagnostic if sink is non-null and contains every sink exception.
+/// Logging failure never changes component results, storage state, or callback
+/// control flow. A null sink is an explicit no-op.
+void EmitLog(const std::shared_ptr<LogSink>& sink, LogLevel level,
+             std::string_view component, std::string_view message) noexcept;
+
+}  // namespace sitos
+
+#endif  // SITOS_LOGGING_HPP

--- a/include/sitos/storage_node.hpp
+++ b/include/sitos/storage_node.hpp
@@ -13,6 +13,7 @@
 #include <string_view>
 #include <system_error>
 
+#include "sitos/logging.hpp"
 #include "sitos/storage_engine.hpp"
 #include "sitos/transport.hpp"
 
@@ -35,6 +36,8 @@ std::optional<StorageQuery> ParseStorageQuery(std::string_view prefix,
 
 struct StorageNodeConfig {
   std::string prefix = "sitos";
+  /// Diagnostic destination; nullptr explicitly disables logging.
+  std::shared_ptr<LogSink> log_sink = DefaultLogSink();
 };
 
 /// Serves base-scope Get/List queries through a Transport queryable.
@@ -65,11 +68,15 @@ class StorageNode {
 
  private:
   struct State {
-    State(std::shared_ptr<StorageEngine> storage, std::string key_prefix)
-        : engine(std::move(storage)), prefix(std::move(key_prefix)) {}
+    State(std::shared_ptr<StorageEngine> storage, std::string key_prefix,
+          std::shared_ptr<LogSink> diagnostics)
+        : engine(std::move(storage)),
+          prefix(std::move(key_prefix)),
+          log_sink(std::move(diagnostics)) {}
 
     std::shared_ptr<StorageEngine> engine;
     std::string prefix;
+    std::shared_ptr<LogSink> log_sink;
     std::atomic<bool> active{true};
   };
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -14,14 +14,15 @@ namespace sitos {
 namespace {
 
 std::string_view LevelName(LogLevel level) {
+  using enum LogLevel;
   switch (level) {
-    case LogLevel::kDebug:
+    case kDebug:
       return "debug";
-    case LogLevel::kInfo:
+    case kInfo:
       return "info";
-    case LogLevel::kWarning:
+    case kWarning:
       return "warning";
-    case LogLevel::kError:
+    case kError:
       return "error";
   }
   return "unknown";
@@ -53,6 +54,7 @@ void EmitLog(const std::shared_ptr<LogSink>& sink, LogLevel level, std::string_v
     sink->Write(LogRecord{level, component, message});
   } catch (...) {
     // Diagnostics must never escape into component or transport callback code.
+    return;
   }
 }
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -1,0 +1,59 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Built-in stderr diagnostics sink.
+
+#include "sitos/logging.hpp"
+
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <string_view>
+
+namespace sitos {
+namespace {
+
+std::string_view LevelName(LogLevel level) {
+  switch (level) {
+    case LogLevel::kDebug:
+      return "debug";
+    case LogLevel::kInfo:
+      return "info";
+    case LogLevel::kWarning:
+      return "warning";
+    case LogLevel::kError:
+      return "error";
+  }
+  return "unknown";
+}
+
+class StderrLogSink final : public LogSink {
+ public:
+  void Write(const LogRecord& record) override {
+    std::lock_guard lock(mutex_);
+    std::cerr << "[sitos][" << LevelName(record.level) << "][" << record.component << "] "
+              << record.message << '\n';
+  }
+
+ private:
+  std::mutex mutex_;
+};
+
+}  // namespace
+
+std::shared_ptr<LogSink> DefaultLogSink() {
+  static const std::shared_ptr<LogSink> sink = std::make_shared<StderrLogSink>();
+  return sink;
+}
+
+void EmitLog(const std::shared_ptr<LogSink>& sink, LogLevel level, std::string_view component,
+             std::string_view message) noexcept {
+  try {
+    if (sink == nullptr) return;
+    sink->Write(LogRecord{level, component, message});
+  } catch (...) {
+    // Diagnostics must never escape into component or transport callback code.
+  }
+}
+
+}  // namespace sitos

--- a/src/storage_node.cpp
+++ b/src/storage_node.cpp
@@ -82,7 +82,8 @@ Result<void> StorageNode::Start(std::shared_ptr<StorageEngine> engine, Transport
     return Result<void>::Err(InvalidArgument());
   }
 
-  auto state = std::make_shared<State>(std::move(engine), std::move(config.prefix));
+  auto state = std::make_shared<State>(std::move(engine), std::move(config.prefix),
+                                       std::move(config.log_sink));
   const std::string queryable_key = state->prefix + "/**";
   queryable_ = transport.DeclareQueryable(
       queryable_key, [state](TransportQuery& query) { OnQuery(state, query); });

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,13 @@ target_link_libraries(sitos_in_memory_engine_test
 sitos_enable_warnings(sitos_in_memory_engine_test)
 gtest_discover_tests(sitos_in_memory_engine_test)
 
+add_executable(sitos_logging_test
+  unit/logging_test.cpp)
+target_link_libraries(sitos_logging_test
+  PRIVATE GTest::gtest_main sitos::sitos)
+sitos_enable_warnings(sitos_logging_test)
+gtest_discover_tests(sitos_logging_test)
+
 add_executable(sitos_storage_node_test
   unit/storage_node_test.cpp)
 target_link_libraries(sitos_storage_node_test

--- a/tests/unit/logging_test.cpp
+++ b/tests/unit/logging_test.cpp
@@ -1,0 +1,97 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/logging.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace sitos {
+namespace {
+
+struct CapturedRecord {
+  LogLevel level;
+  std::string component;
+  std::string message;
+};
+
+class CaptureSink final : public LogSink {
+ public:
+  void Write(const LogRecord& record) override {
+    std::lock_guard lock(mutex_);
+    record_ = CapturedRecord{record.level, std::string(record.component),
+                            std::string(record.message)};
+    ++write_count_;
+  }
+
+  CapturedRecord Record() const {
+    std::lock_guard lock(mutex_);
+    return *record_;
+  }
+
+  int WriteCount() const {
+    std::lock_guard lock(mutex_);
+    return write_count_;
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  std::optional<CapturedRecord> record_;
+  int write_count_ = 0;
+};
+
+class ThrowingSink final : public LogSink {
+ public:
+  void Write(const LogRecord&) override { throw std::runtime_error("sink failure"); }
+};
+
+TEST(LoggingTest, EmitLogDeliversRecord) {
+  auto sink = std::make_shared<CaptureSink>();
+
+  EmitLog(sink, LogLevel::kWarning, "node", "diagnostic message");
+
+  EXPECT_EQ(sink->WriteCount(), 1);
+  const CapturedRecord record = sink->Record();
+  EXPECT_EQ(record.level, LogLevel::kWarning);
+  EXPECT_EQ(record.component, "node");
+  EXPECT_EQ(record.message, "diagnostic message");
+}
+
+TEST(LoggingTest, EmitLogIgnoresNullSink) {
+  EXPECT_NO_THROW(EmitLog(nullptr, LogLevel::kInfo, "node", "ignored"));
+}
+
+TEST(LoggingTest, EmitLogContainsSinkExceptions) {
+  static_assert(noexcept(EmitLog(std::shared_ptr<LogSink>{}, LogLevel::kError, "node", "error")));
+
+  auto sink = std::make_shared<ThrowingSink>();
+  EXPECT_NO_THROW(EmitLog(sink, LogLevel::kError, "node", "error"));
+}
+
+TEST(LoggingTest, RecordViewsAreCallbackScoped) {
+  auto sink = std::make_shared<CaptureSink>();
+  {
+    std::string component = "temporary-component";
+    std::string message = "temporary-message";
+    EmitLog(sink, LogLevel::kDebug, component, message);
+  }
+
+  const CapturedRecord record = sink->Record();
+  EXPECT_EQ(record.component, "temporary-component");
+  EXPECT_EQ(record.message, "temporary-message");
+}
+
+TEST(LoggingTest, DefaultSinkIsCallable) {
+  auto sink = DefaultLogSink();
+  ASSERT_NE(sink, nullptr);
+  EXPECT_NO_THROW(sink->Write({LogLevel::kInfo, "test", "smoke"}));
+}
+
+}  // namespace
+}  // namespace sitos

--- a/tests/unit/logging_test.cpp
+++ b/tests/unit/logging_test.cpp
@@ -56,7 +56,7 @@ TEST(LoggingTest, EmitLogDeliversRecord) {
 
   EmitLog(sink, LogLevel::kWarning, "node", "diagnostic message");
 
-  EXPECT_EQ(sink->WriteCount(), 1);
+  ASSERT_EQ(sink->WriteCount(), 1);
   const CapturedRecord record = sink->Record();
   EXPECT_EQ(record.level, LogLevel::kWarning);
   EXPECT_EQ(record.component, "node");

--- a/tests/unit/storage_node_test.cpp
+++ b/tests/unit/storage_node_test.cpp
@@ -140,6 +140,10 @@ TEST(StorageNodeQueryTest, RetainsInjectedLogSinkWhileStarted) {
   EXPECT_FALSE(weak_sink.expired());
 
   node.Stop();
+  EXPECT_FALSE(weak_sink.expired());
+
+  // The test transport models undeclaration by releasing its callback.
+  transport.query_callback = {};
   EXPECT_TRUE(weak_sink.expired());
 }
 

--- a/tests/unit/storage_node_test.cpp
+++ b/tests/unit/storage_node_test.cpp
@@ -9,6 +9,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "sitos/in_memory_engine.hpp"
@@ -119,11 +120,15 @@ TEST(StorageNodeQueryTest, UsesDefaultPrefix) {
 }
 
 TEST(StorageNodeQueryTest, UsesDefaultLogSink) {
+  StorageNodeConfig config;
+  ASSERT_NE(config.log_sink, nullptr);
+  EXPECT_EQ(config.log_sink, DefaultLogSink());
+
   auto engine = std::make_shared<InMemoryEngine>();
   FakeTransport transport;
   StorageNode node(transport);
 
-  ASSERT_TRUE(node.Start(engine, {}).IsOk());
+  ASSERT_TRUE(node.Start(engine, std::move(config)).IsOk());
   EXPECT_TRUE(node.IsStarted());
   node.Stop();
 }

--- a/tests/unit/storage_node_test.cpp
+++ b/tests/unit/storage_node_test.cpp
@@ -12,9 +12,15 @@
 #include <vector>
 
 #include "sitos/in_memory_engine.hpp"
+#include "sitos/logging.hpp"
 
 namespace sitos {
 namespace {
+
+class LifetimeSink final : public LogSink {
+ public:
+  void Write(const LogRecord&) override {}
+};
 
 class FakeTransport final : public Transport {
  public:
@@ -110,6 +116,41 @@ TEST(StorageNodeQueryTest, UsesDefaultPrefix) {
 
   ASSERT_TRUE(node.Start(engine, {}).IsOk());
   EXPECT_EQ(transport.declared_keyexpr, "sitos/**");
+}
+
+TEST(StorageNodeQueryTest, UsesDefaultLogSink) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  StorageNode node(transport);
+
+  ASSERT_TRUE(node.Start(engine, {}).IsOk());
+  EXPECT_TRUE(node.IsStarted());
+  node.Stop();
+}
+
+TEST(StorageNodeQueryTest, RetainsInjectedLogSinkWhileStarted) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  StorageNode node(transport);
+  auto sink = std::make_shared<LifetimeSink>();
+  const std::weak_ptr<LifetimeSink> weak_sink = sink;
+
+  ASSERT_TRUE(node.Start(engine, {.prefix = "sitos", .log_sink = sink}).IsOk());
+  sink.reset();
+  EXPECT_FALSE(weak_sink.expired());
+
+  node.Stop();
+  EXPECT_TRUE(weak_sink.expired());
+}
+
+TEST(StorageNodeQueryTest, StartsWithLoggingDisabled) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  StorageNode node(transport);
+
+  ASSERT_TRUE(node.Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  EXPECT_TRUE(node.IsStarted());
+  node.Stop();
 }
 
 TEST(StorageNodeQueryTest, RejectsInvalidStartArguments) {


### PR DESCRIPTION
Closes #76

## Summary

- Add a dependency-free, backend-neutral public logging API in `include/sitos/logging.hpp`.
- Add an immutable built-in thread-safe stderr sink and `noexcept` exception-containing emission helper.
- Inject and retain `StorageNodeConfig::log_sink` in `StorageNode::State`, preserving prefix-first aggregate/designated initialization compatibility.
- Add no Issue #10 warning call sites, subscriber work, wire changes, Transport API changes, macros, global configuration, or third-party dependencies.

## Acceptance criteria

- [x] A component can receive an injected `LogSink` through `StorageNodeConfig` without depending on a concrete logging backend.
- [x] An omitted sink uses the built-in stderr sink without global mutable logger configuration.
- [x] A capture sink deterministically receives level, component, and message.
- [x] A throwing sink cannot propagate an exception through `EmitLog`, which is statically asserted `noexcept`.
- [x] The public API documents callback-scoped record views and concurrent-call requirements.
- [x] Zenoh-disabled and zenoh-enabled Windows MSVC builds/tests pass locally.
- [x] plog/quill adapters can consume the public API without changes to sitos logging or StorageNode callback code; asynchronous adapters must copy record views.

## TDD RED evidence

The focused tests were added before production declarations/implementation. The first build failed genuinely with:

```text
C:\Users\tetet\gw\sitos.tmp\tests\unit\logging_test.cpp(4,10): error C1083: include file cannot be opened: 'sitos/logging.hpp': No such file or directory
```

## Verification

- `ctest --test-dir build/issue76-off-vs -C Debug --output-on-failure` — 116/116 passed.
- `ctest --test-dir build/issue76-on-vs -C Debug --output-on-failure` — 138/138 passed, including Zenoh smoke and transport tests.
- `git diff --check` — passed.
- Secret scan of all changed files — no issues found.
- Sonar list/verify was attempted for the feature branch and changed files, but the configured CLI failed with `unknown option '--org'`; no Sonar result was available.
- Linux builds were not run in this Windows environment; CI should provide the Linux GCC/Clang coverage.

## ADR and scope review

No ADR is required: this adds an injectable diagnostics boundary without a dependency, wire/protocol change, or public Transport API change. Backend lifecycle and configuration remain application/adapter-owned.