### PR TITLE
feat(storage): add StorageNode subscriber PUT/DELETE (#10)

### DIFF
--- a/include/sitos/storage_node.hpp
+++ b/include/sitos/storage_node.hpp
@@ -40,7 +40,7 @@ struct StorageNodeConfig {
   std::shared_ptr<LogSink> log_sink = DefaultLogSink();
 };
 
-/// Serves base-scope Get/List queries through a Transport queryable.
+/// Serves base-scope Get/List queries and base writes through Transport declarations.
 class StorageNode {
  public:
   using Config = StorageNodeConfig;
@@ -61,7 +61,7 @@ class StorageNode {
   Result<void> Start(std::shared_ptr<StorageEngine> engine, Transport& transport,
                      Config config);
 
-  /// Undeclares the queryable. Safe to call repeatedly.
+  /// Undeclares the queryable and subscriber. Safe to call repeatedly.
   void Stop() noexcept;
 
   bool IsStarted() const noexcept { return state_ != nullptr; }
@@ -76,15 +76,17 @@ class StorageNode {
 
     std::shared_ptr<StorageEngine> engine;
     std::string prefix;
-    std::shared_ptr<LogSink> log_sink;
+    const std::shared_ptr<LogSink> log_sink;
     std::atomic<bool> active{true};
   };
 
   static void OnQuery(const std::shared_ptr<State>& state, TransportQuery& query);
+  static void OnSample(const std::shared_ptr<State>& state, const TransportSample& sample);
 
   Transport* transport_ = nullptr;
   std::shared_ptr<State> state_;
   Queryable queryable_;
+  Subscription subscriber_;
 };
 
 }  // namespace sitos

--- a/include/sitos/storage_node.hpp
+++ b/include/sitos/storage_node.hpp
@@ -1,7 +1,7 @@
 // Copyright 2026 sitos contributors
 // SPDX-License-Identifier: Apache-2.0
 //
-// StorageNode queryable routing for the base storage scope.
+// StorageNode query and subscriber routing for the base storage scope.
 
 #ifndef SITOS_STORAGE_NODE_HPP
 #define SITOS_STORAGE_NODE_HPP

--- a/src/storage_node.cpp
+++ b/src/storage_node.cpp
@@ -6,8 +6,10 @@
 #include "sitos/storage_node.hpp"
 
 #include <utility>
+#include <vector>
 
 #include "sitos/key.hpp"
+#include "sitos/param_value.hpp"
 
 namespace sitos {
 namespace {
@@ -39,6 +41,14 @@ std::string MakeReplyKey(std::string_view prefix, std::string_view relative_key)
 }
 
 Encoding SitosEncoding() { return Encoding{std::string(Encoding::kSitosV1)}; }
+
+constexpr std::string_view kNodeComponent = "node";
+constexpr std::string_view kUnsupportedSubscriberKey = "unsupported subscriber key";
+constexpr std::string_view kUnknownSubscriberEncoding =
+    "unknown subscriber encoding; wrapped as bytes";
+constexpr std::string_view kSubscriberPutFailed = "subscriber PUT failed";
+constexpr std::string_view kSubscriberDeleteFailed = "subscriber DELETE failed";
+constexpr std::string_view kSubscriberCallbackFailed = "subscriber callback exception";
 
 }  // namespace
 
@@ -87,6 +97,8 @@ Result<void> StorageNode::Start(std::shared_ptr<StorageEngine> engine, Transport
   const std::string queryable_key = state->prefix + "/**";
   queryable_ = transport.DeclareQueryable(
       queryable_key, [state](TransportQuery& query) { OnQuery(state, query); });
+  subscriber_ = transport.DeclareSubscriber(
+      queryable_key, [state](const TransportSample& sample) { OnSample(state, sample); });
   transport_ = &transport;
   state_ = std::move(state);
   return Result<void>::Ok();
@@ -94,8 +106,41 @@ Result<void> StorageNode::Start(std::shared_ptr<StorageEngine> engine, Transport
 
 void StorageNode::Stop() noexcept {
   if (state_ != nullptr) state_->active.store(false, std::memory_order_relaxed);
+  subscriber_ = Subscription{};
   queryable_ = Queryable{};
   state_.reset();
+}
+
+void StorageNode::OnSample(const std::shared_ptr<State>& state, const TransportSample& sample) {
+  try {
+    if (!state->active.load(std::memory_order_relaxed)) return;
+
+    const auto parsed = ParseKey(state->prefix, sample.key);
+    if (!parsed || parsed->kind != KeyKind::Base || parsed->is_batch) {
+      EmitLog(state->log_sink, LogLevel::kWarning, kNodeComponent, kUnsupportedSubscriberKey);
+      return;
+    }
+
+    if (sample.kind == TransportSample::Kind::Delete) {
+      if (!state->engine->Delete(parsed->relative_key)) {
+        EmitLog(state->log_sink, LogLevel::kError, kNodeComponent, kSubscriberDeleteFailed);
+      }
+      return;
+    }
+
+    Bytes value = sample.payload;
+    std::vector<std::byte> wrapped;
+    if (sample.encoding.id != Encoding::kSitosV1) {
+      EmitLog(state->log_sink, LogLevel::kWarning, kNodeComponent, kUnknownSubscriberEncoding);
+      wrapped = ParamValue(std::vector<std::byte>(sample.payload.begin(), sample.payload.end())).Encode();
+      value = wrapped;
+    }
+    if (!state->engine->Put(parsed->relative_key, value)) {
+      EmitLog(state->log_sink, LogLevel::kError, kNodeComponent, kSubscriberPutFailed);
+    }
+  } catch (...) {
+    EmitLog(state->log_sink, LogLevel::kError, kNodeComponent, kSubscriberCallbackFailed);
+  }
 }
 
 void StorageNode::OnQuery(const std::shared_ptr<State>& state, TransportQuery& query) {

--- a/src/storage_node.cpp
+++ b/src/storage_node.cpp
@@ -1,7 +1,7 @@
 // Copyright 2026 sitos contributors
 // SPDX-License-Identifier: Apache-2.0
 //
-// StorageNode base queryable routing.
+// StorageNode query and subscriber routing for the base storage scope.
 
 #include "sitos/storage_node.hpp"
 
@@ -132,7 +132,8 @@ void StorageNode::OnSample(const std::shared_ptr<State>& state, const TransportS
     std::vector<std::byte> wrapped;
     if (sample.encoding.id != Encoding::kSitosV1) {
       EmitLog(state->log_sink, LogLevel::kWarning, kNodeComponent, kUnknownSubscriberEncoding);
-      wrapped = ParamValue(std::vector<std::byte>(sample.payload.begin(), sample.payload.end())).Encode();
+      auto bytes = std::vector<std::byte>(sample.payload.begin(), sample.payload.end());
+      wrapped = ParamValue(std::move(bytes)).Encode();
       value = wrapped;
     }
     if (!state->engine->Put(parsed->relative_key, value)) {

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -345,8 +345,65 @@ Result<void> TransportQuery::Reply(std::string_view key, std::span<const std::by
 // Subscription
 // ---------------------------------------------------------------------------
 
+namespace {
+
+struct SubscriberState {
+  explicit SubscriberState(std::function<void(const TransportSample&)> handler)
+      : callback(std::move(handler)) {}
+
+  std::function<void(const TransportSample&)> callback;
+  std::atomic<bool> active{true};
+};
+
+void OnSubscriberSample(z_loaned_sample_t* sample, void* context) noexcept {
+  try {
+    auto state = *static_cast<std::shared_ptr<SubscriberState>*>(context);
+    if (!state || !state->active.load(std::memory_order_acquire)) return;
+
+    const auto kind = z_sample_kind(sample);
+    if (kind != Z_SAMPLE_KIND_PUT && kind != Z_SAMPLE_KIND_DELETE) return;
+
+    z_view_string_t key_view;
+    z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_view);
+    std::string key(z_string_data(z_view_string_loan(&key_view)),
+                    z_string_len(z_view_string_loan(&key_view)));
+
+    if (kind == Z_SAMPLE_KIND_PUT) {
+      const z_loaned_bytes_t* payload = z_sample_payload(sample);
+      ZenohOwned<z_owned_slice_t> slice;
+      if (z_bytes_to_slice(payload, slice.get()) != Z_OK) return;
+      slice.mark_valid();
+      const auto* data = reinterpret_cast<const std::byte*>(z_slice_data(slice.loan()));
+      const auto length = z_slice_len(slice.loan());
+      TransportSample transport_sample{
+          std::move(key), std::span<const std::byte>(data, length), ReadEncoding(sample),
+          std::nullopt, TransportSample::Kind::Put};
+      if (state->active.load(std::memory_order_acquire) && state->callback) {
+        state->callback(transport_sample);
+      }
+      return;
+    }
+
+    // DELETE payloads and encodings are deliberately not inspected.
+    TransportSample transport_sample{std::move(key), {}, {}, std::nullopt,
+                                     TransportSample::Kind::Delete};
+    if (state->active.load(std::memory_order_acquire) && state->callback) {
+      state->callback(transport_sample);
+    }
+  } catch (...) {
+    // Contain all C++ exceptions at the zenoh-c callback boundary.
+  }
+}
+
+void DropSubscriberContext(void* context) noexcept {
+  delete static_cast<std::shared_ptr<SubscriberState>*>(context);
+}
+
+}  // namespace
+
 struct Subscription::Impl {
-  z_owned_subscriber_t subscriber;
+  z_owned_subscriber_t subscriber{};
+  std::shared_ptr<SubscriberState> callback_state;
 };
 
 namespace {
@@ -408,6 +465,9 @@ Subscription& Subscription::operator=(Subscription&& other) noexcept {
 
 void Subscription::Reset() noexcept {
   if (!impl_) return;
+  if (impl_->callback_state) {
+    impl_->callback_state->active.store(false, std::memory_order_release);
+  }
   z_drop(z_move(impl_->subscriber));
   impl_.reset();
 }
@@ -625,12 +685,31 @@ class ZenohTransport : public Transport {
   }
 
   Subscription DeclareSubscriber(
-      std::string_view /*keyexpr*/,
-      std::function<void(const TransportSample&)> /*callback*/) override {
-    // TODO(#3): implement subscriber — currently a stub that silently discards
-    // both keyexpr and callback. The caller receives an empty Subscription
-    // (impl_ == nullptr) that never delivers samples.
-    return {};
+      std::string_view keyexpr_str,
+      std::function<void(const TransportSample&)> callback) override {
+    Subscription subscription;
+    if (!session_valid_ || !callback) return subscription;
+
+    auto ke = MakeKeyexpr(keyexpr_str);
+    if (!ke.IsOk()) return subscription;
+
+    subscription.impl_ = std::make_unique<Subscription::Impl>();
+    subscription.impl_->callback_state =
+        std::make_shared<SubscriberState>(std::move(callback));
+    auto* context = new std::shared_ptr<SubscriberState>(subscription.impl_->callback_state);
+
+    z_owned_closure_sample_t closure;
+    z_closure_sample(&closure, OnSubscriberSample, DropSubscriberContext, context);
+
+    z_subscriber_options_t options;
+    z_subscriber_options_default(&options);
+    const z_result_t decl_rc = z_declare_subscriber(
+        z_session_loan(&session_), &subscription.impl_->subscriber, ke.Value().loan(),
+        z_move(closure), &options);
+    if (decl_rc != Z_OK) {
+      subscription.Reset();
+    }
+    return subscription;
   }
 
   Queryable DeclareQueryable(std::string_view keyexpr_str,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,4 +87,12 @@ if(SITOS_WITH_ZENOH)
   sitos_enable_warnings(sitos_storage_node_query_test)
   sitos_copy_zenohc(sitos_storage_node_query_test)
   gtest_discover_tests(sitos_storage_node_query_test)
+
+  add_executable(sitos_storage_node_subscriber_test
+    integration/storage_node_subscriber_test.cpp)
+  target_link_libraries(sitos_storage_node_subscriber_test
+    PRIVATE GTest::gtest_main sitos::sitos)
+  sitos_enable_warnings(sitos_storage_node_subscriber_test)
+  sitos_copy_zenohc(sitos_storage_node_subscriber_test)
+  gtest_discover_tests(sitos_storage_node_subscriber_test)
 endif()

--- a/tests/integration/storage_node_subscriber_test.cpp
+++ b/tests/integration/storage_node_subscriber_test.cpp
@@ -51,11 +51,20 @@ struct ReplyState {
   int count = 0;
 };
 
+struct CapturedLogRecord {
+  sitos::LogLevel level;
+  std::string component;
+  std::string message;
+};
+
 class CaptureSink final : public sitos::LogSink {
  public:
   void Write(const sitos::LogRecord& record) override {
     std::lock_guard lock(mutex);
-    records.push_back(record);
+    records.push_back(
+        {.level = record.level,
+         .component = std::string(record.component),
+         .message = std::string(record.message)});
   }
 
   bool HasWarning(std::string_view message) const {
@@ -71,7 +80,7 @@ class CaptureSink final : public sitos::LogSink {
 
  private:
   mutable std::mutex mutex;
-  std::vector<sitos::LogRecord> records;
+  std::vector<CapturedLogRecord> records;
 };
 
 class StorageNodeSubscriberIntegrationTest : public ::testing::Test {
@@ -149,6 +158,41 @@ TEST_F(StorageNodeSubscriberIntegrationTest, PutGetAndDeleteRoundTrip) {
   std::unique_lock lock(after_delete->mutex);
   EXPECT_FALSE(after_delete->condition.wait_for(lock, 700ms,
                                                 [&] { return after_delete->count != 0; }));
+}
+
+TEST_F(StorageNodeSubscriberIntegrationTest, UnknownEncodingIsStoredAsPayloadV1Bytes) {
+  const std::vector<std::byte> raw = {std::byte{0x10}, std::byte{0x00}, std::byte{0xFF}};
+  const std::vector<std::byte> expected = {std::byte{0x04}, std::byte{0x10},
+                                           std::byte{0x00}, std::byte{0xFF}};
+  ASSERT_TRUE(transport_
+                  ->Put("sitos/subscriber_test/base/opaque", raw,
+                        sitos::Encoding{"application/octet-stream"}, {})
+                  .IsOk());
+  ASSERT_TRUE(WaitFor([&] { return HasValue(engine_, "opaque", expected); }));
+  EXPECT_TRUE(sink_->HasWarning("unknown subscriber encoding; wrapped as bytes"));
+
+  auto reply = std::make_shared<ReplyState>();
+  ASSERT_TRUE(transport_
+                  ->Get("sitos/subscriber_test/base/opaque",
+                        [reply](std::string_view key, std::span<const std::byte> payload,
+                                sitos::Encoding encoding) {
+                          std::lock_guard lock(reply->mutex);
+                          reply->key = std::string(key);
+                          reply->payload.assign(payload.begin(), payload.end());
+                          reply->encoding = std::move(encoding.id);
+                          ++reply->count;
+                          reply->condition.notify_all();
+                          return false;
+                        },
+                        2000ms)
+                  .IsOk());
+  {
+    std::unique_lock lock(reply->mutex);
+    ASSERT_TRUE(reply->condition.wait_for(lock, 3s, [&] { return reply->count == 1; }));
+  }
+  EXPECT_EQ(reply->key, "sitos/subscriber_test/base/opaque");
+  EXPECT_EQ(reply->payload, expected);
+  EXPECT_EQ(reply->encoding, sitos::Encoding::kSitosV1);
 }
 
 TEST_F(StorageNodeSubscriberIntegrationTest, SnapPutIsIgnoredAfterSamePublisherBarrier) {

--- a/tests/integration/storage_node_subscriber_test.cpp
+++ b/tests/integration/storage_node_subscriber_test.cpp
@@ -1,0 +1,176 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/in_memory_engine.hpp"
+#include "sitos/logging.hpp"
+#include "sitos/storage_node.hpp"
+#include "sitos/transport.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using namespace std::chrono_literals;
+
+bool WaitFor(std::function<bool()> predicate) {
+  const auto deadline = std::chrono::steady_clock::now() + 3s;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (predicate()) return true;
+    std::this_thread::sleep_for(10ms);
+  }
+  return predicate();
+}
+
+bool HasValue(const std::shared_ptr<sitos::InMemoryEngine>& engine, std::string_view key,
+              std::span<const std::byte> expected) {
+  bool found = false;
+  engine->Get(key, [&](std::string_view, sitos::Bytes value) {
+    found = std::vector<std::byte>(value.begin(), value.end()) ==
+            std::vector<std::byte>(expected.begin(), expected.end());
+    return true;
+  });
+  return found;
+}
+
+struct ReplyState {
+  std::mutex mutex;
+  std::condition_variable condition;
+  std::vector<std::byte> payload;
+  std::string key;
+  std::string encoding;
+  int count = 0;
+};
+
+class CaptureSink final : public sitos::LogSink {
+ public:
+  void Write(const sitos::LogRecord& record) override {
+    std::lock_guard lock(mutex);
+    records.push_back(record);
+  }
+
+  bool HasWarning(std::string_view message) const {
+    std::lock_guard lock(mutex);
+    for (const auto& record : records) {
+      if (record.level == sitos::LogLevel::kWarning && record.component == "node" &&
+          record.message == message) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+ private:
+  mutable std::mutex mutex;
+  std::vector<sitos::LogRecord> records;
+};
+
+class StorageNodeSubscriberIntegrationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    transport_ = sitos::MakeZenohTransport();
+    ASSERT_TRUE(transport_);
+    engine_ = std::make_shared<sitos::InMemoryEngine>();
+    sink_ = std::make_shared<CaptureSink>();
+    node_ = std::make_unique<sitos::StorageNode>();
+    ASSERT_TRUE(node_->Start(engine_, *transport_,
+                             {.prefix = "sitos/subscriber_test", .log_sink = sink_})
+                    .IsOk());
+  }
+
+  void TearDown() override {
+    node_.reset();
+    transport_.reset();
+  }
+
+  std::unique_ptr<sitos::Transport> transport_;
+  std::shared_ptr<sitos::InMemoryEngine> engine_;
+  std::shared_ptr<CaptureSink> sink_;
+  std::unique_ptr<sitos::StorageNode> node_;
+};
+
+TEST_F(StorageNodeSubscriberIntegrationTest, PutGetAndDeleteRoundTrip) {
+  const std::vector<std::byte> expected = {std::byte{0x00}, std::byte{0xA5}};
+  ASSERT_TRUE(transport_
+                  ->Put("sitos/subscriber_test/base/value", expected,
+                        sitos::Encoding{std::string(sitos::Encoding::kSitosV1)}, {})
+                  .IsOk());
+  ASSERT_TRUE(WaitFor([&] { return HasValue(engine_, "value", expected); }));
+
+  auto reply = std::make_shared<ReplyState>();
+  ASSERT_TRUE(transport_
+                  ->Get("sitos/subscriber_test/base/value",
+                        [reply](std::string_view key, std::span<const std::byte> payload,
+                                sitos::Encoding encoding) {
+                          std::lock_guard lock(reply->mutex);
+                          reply->key = std::string(key);
+                          reply->payload.assign(payload.begin(), payload.end());
+                          reply->encoding = std::move(encoding.id);
+                          ++reply->count;
+                          reply->condition.notify_all();
+                          return false;
+                        },
+                        2000ms)
+                  .IsOk());
+  {
+    std::unique_lock lock(reply->mutex);
+    ASSERT_TRUE(reply->condition.wait_for(lock, 3s, [&] { return reply->count == 1; }));
+  }
+  EXPECT_EQ(reply->key, "sitos/subscriber_test/base/value");
+  EXPECT_EQ(reply->payload, expected);
+  EXPECT_EQ(reply->encoding, sitos::Encoding::kSitosV1);
+
+  ASSERT_TRUE(transport_->Delete("sitos/subscriber_test/base/value", {}).IsOk());
+  ASSERT_TRUE(WaitFor([&] {
+    return !engine_->Get("value", [](std::string_view, sitos::Bytes) { return true; });
+  }));
+
+  auto after_delete = std::make_shared<ReplyState>();
+  ASSERT_TRUE(transport_
+                  ->Get("sitos/subscriber_test/base/value",
+                        [after_delete](std::string_view, std::span<const std::byte>,
+                                       sitos::Encoding) {
+                          std::lock_guard lock(after_delete->mutex);
+                          ++after_delete->count;
+                          after_delete->condition.notify_all();
+                          return true;
+                        },
+                        500ms)
+                  .IsOk());
+  std::unique_lock lock(after_delete->mutex);
+  EXPECT_FALSE(after_delete->condition.wait_for(lock, 700ms,
+                                                [&] { return after_delete->count != 0; }));
+}
+
+TEST_F(StorageNodeSubscriberIntegrationTest, SnapPutIsIgnoredAfterSamePublisherBarrier) {
+  const std::vector<std::byte> existing = {std::byte{0x11}};
+  const std::vector<std::byte> snap_payload = {std::byte{0x22}};
+  ASSERT_TRUE(engine_->Put("existing", existing));
+  ASSERT_TRUE(transport_
+                  ->Put("sitos/subscriber_test/snap/session1/ignored", snap_payload,
+                        sitos::Encoding{std::string(sitos::Encoding::kSitosV1)}, {})
+                  .IsOk());
+  const std::vector<std::byte> barrier = {std::byte{0x33}};
+  ASSERT_TRUE(transport_
+                  ->Put("sitos/subscriber_test/base/barrier", barrier,
+                        sitos::Encoding{std::string(sitos::Encoding::kSitosV1)}, {})
+                  .IsOk());
+  ASSERT_TRUE(WaitFor([&] { return HasValue(engine_, "barrier", barrier); }));
+  EXPECT_TRUE(sink_->HasWarning("unsupported subscriber key"));
+
+  EXPECT_FALSE(engine_->Get("session1/ignored", [](std::string_view, sitos::Bytes) {
+    return true;
+  }));
+  EXPECT_TRUE(HasValue(engine_, "existing", existing));
+}
+
+}  // namespace

--- a/tests/unit/storage_node_test.cpp
+++ b/tests/unit/storage_node_test.cpp
@@ -24,21 +24,30 @@ class LifetimeSink final : public LogSink {
   void Write(const LogRecord&) override {}
 };
 
+struct CapturedLogRecord {
+  LogLevel level;
+  std::string component;
+  std::string message;
+};
+
 class CaptureSink final : public LogSink {
  public:
   void Write(const LogRecord& record) override {
     std::lock_guard<std::mutex> lock(mutex);
-    records.push_back(record);
+    records.push_back(
+        {.level = record.level,
+         .component = std::string(record.component),
+         .message = std::string(record.message)});
   }
 
-  std::vector<LogRecord> Records() const {
+  std::vector<CapturedLogRecord> Records() const {
     std::lock_guard<std::mutex> lock(mutex);
     return records;
   }
 
  private:
   mutable std::mutex mutex;
-  std::vector<LogRecord> records;
+  std::vector<CapturedLogRecord> records;
 };
 
 class FailingEngine final : public StorageEngine {
@@ -96,8 +105,9 @@ class FakeTransport final : public Transport {
     std::vector<ReplyRecord> replies;
     auto query = TransportQuery::ForTesting(
         [&](std::string_view key, std::span<const std::byte> payload, Encoding encoding) {
-          replies.push_back({std::string(key), std::vector<std::byte>(payload.begin(), payload.end()),
-                             std::move(encoding)});
+          replies.push_back(
+              {std::string(key), std::vector<std::byte>(payload.begin(), payload.end()),
+               std::move(encoding)});
           if (fail_after_first && replies.size() == 1) {
             return Result<void>::Err(std::make_error_code(std::errc::io_error));
           }
@@ -277,119 +287,6 @@ TEST(StorageNodeQueryTest, StopDisablesExistingCallback) {
   EXPECT_FALSE(node.IsStarted());
 }
 
-TEST(StorageNodeQueryTest, DeclaresSubscriberAndRoutesBasePut) {
-  auto engine = std::make_shared<InMemoryEngine>();
-  FakeTransport transport;
-  StorageNode node;
-  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
-  EXPECT_EQ(transport.subscriber_keyexpr, "sitos/**");
-
-  const std::vector<std::byte> payload = {std::byte{0x01}, std::byte{0xFE}};
-  transport.InvokeSubscriber("sitos/base/foo/bar", TransportSample::Kind::Put, payload,
-                             Encoding{std::string(Encoding::kSitosV1)});
-  std::vector<std::byte> stored;
-  ASSERT_TRUE(engine->Get("foo/bar", [&](std::string_view, Bytes value) {
-    stored.assign(value.begin(), value.end());
-    return true;
-  }));
-  EXPECT_EQ(stored, payload);
-}
-
-TEST(StorageNodeQueryTest, UnknownEncodingWrapsPayloadAsBytes) {
-  auto engine = std::make_shared<InMemoryEngine>();
-  FakeTransport transport;
-  StorageNode node;
-  auto sink = std::make_shared<CaptureSink>();
-  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = sink}).IsOk());
-
-  const std::vector<std::byte> payload = {std::byte{0x01}, std::byte{0x02}, std::byte{0xFF}};
-  transport.InvokeSubscriber("sitos/base/raw", TransportSample::Kind::Put, payload,
-                             Encoding{"application/octet-stream"});
-  std::vector<std::byte> stored;
-  ASSERT_TRUE(engine->Get("raw", [&](std::string_view, Bytes value) {
-    stored.assign(value.begin(), value.end());
-    return true;
-  }));
-  EXPECT_EQ(stored, (std::vector<std::byte>{std::byte{0x04}, std::byte{0x01}, std::byte{0x02},
-                                             std::byte{0xFF}}));
-  auto records = sink->Records();
-  ASSERT_EQ(records.size(), 1u);
-  EXPECT_EQ(records[0].level, LogLevel::kWarning);
-  EXPECT_EQ(records[0].component, "node");
-  EXPECT_EQ(records[0].message, "unknown subscriber encoding; wrapped as bytes");
-  auto replies = transport.Invoke("sitos/base/raw");
-  ASSERT_EQ(replies.size(), 1u);
-  EXPECT_EQ(replies[0].payload, stored);
-  EXPECT_EQ(replies[0].encoding.id, Encoding::kSitosV1);
-}
-
-TEST(StorageNodeQueryTest, RoutesBaseDelete) {
-  auto engine = std::make_shared<InMemoryEngine>();
-  ASSERT_TRUE(engine->Put("foo", std::vector<std::byte>{std::byte{0x01}}));
-  FakeTransport transport;
-  StorageNode node;
-  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
-  transport.InvokeSubscriber("sitos/base/foo", TransportSample::Kind::Delete,
-                             {std::byte{0xFF}}, Encoding{"unknown"});
-  EXPECT_FALSE(engine->Get("foo", [](std::string_view, Bytes) { return true; }));
-}
-
-TEST(StorageNodeQueryTest, IgnoresUnsupportedSubscriberPathsWithWarnings) {
-  auto engine = std::make_shared<InMemoryEngine>();
-  FakeTransport transport;
-  StorageNode node;
-  auto sink = std::make_shared<CaptureSink>();
-  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = sink}).IsOk());
-
-  const std::vector<std::byte> payload = {std::byte{0x07}};
-  for (const auto* key : {"sitos/snap/s1/value", "sitos/session/s1/value",
-                          "sitos/meta/session/s1", "sitos/base/$batch", "sitos/base/bad*"}) {
-    transport.InvokeSubscriber(key, TransportSample::Kind::Put, payload,
-                               Encoding{"application/octet-stream"});
-  }
-  EXPECT_FALSE(engine->Get("value", [](std::string_view, Bytes) { return true; }));
-  auto records = sink->Records();
-  ASSERT_EQ(records.size(), 5u);
-  for (const auto& record : records) {
-    EXPECT_EQ(record.level, LogLevel::kWarning);
-    EXPECT_EQ(record.component, "node");
-    EXPECT_EQ(record.message, "unsupported subscriber key");
-  }
-}
-
-TEST(StorageNodeQueryTest, EngineFailureEmitsError) {
-  auto engine = std::make_shared<FailingEngine>();
-  FakeTransport transport;
-  StorageNode node;
-  auto sink = std::make_shared<CaptureSink>();
-  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = sink}).IsOk());
-  transport.InvokeSubscriber("sitos/base/value", TransportSample::Kind::Put,
-                             {std::byte{0x01}}, Encoding{std::string(Encoding::kSitosV1)});
-  transport.InvokeSubscriber("sitos/base/value", TransportSample::Kind::Delete, {}, {});
-  auto records = sink->Records();
-  ASSERT_EQ(records.size(), 2u);
-  EXPECT_EQ(records[0].level, LogLevel::kError);
-  EXPECT_EQ(records[0].message, "subscriber PUT failed");
-  EXPECT_EQ(records[1].level, LogLevel::kError);
-  EXPECT_EQ(records[1].message, "subscriber DELETE failed");
-}
-
-TEST(StorageNodeQueryTest, SubscriberCallbackBecomesInertAfterStop) {
-  auto engine = std::make_shared<InMemoryEngine>();
-  FakeTransport transport;
-  StorageNode node;
-  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
-  auto callback = transport.subscriber_callback;
-  node.Stop();
-  ASSERT_TRUE(callback);
-  std::vector<std::byte> payload = {std::byte{0x01}};
-  TransportSample sample{"sitos/base/foo", payload,
-                         Encoding{std::string(Encoding::kSitosV1)}, std::nullopt,
-                         TransportSample::Kind::Put};
-  callback(sample);
-  EXPECT_FALSE(engine->Get("foo", [](std::string_view, Bytes) { return true; }));
-}
-
 TEST(StorageNodeQueryTest, StopAndRestartReplacesDeclaration) {
   auto engine = std::make_shared<InMemoryEngine>();
   ASSERT_TRUE(engine->Put("foo", std::vector<std::byte>{std::byte{0x01}}));
@@ -435,7 +332,7 @@ TEST(StorageNodeSubscriberTest, WrapsUnknownEncodingAsBytesPayloadV1) {
   transport.InvokeSubscriber("sitos/base/opaque", TransportSample::Kind::Put, raw,
                              Encoding{"application/octet-stream"});
   const std::vector<std::byte> expected = {std::byte{0x04}, std::byte{0x01}, std::byte{0x02},
-                                             std::byte{0xFF}};
+                                           std::byte{0xFF}};
   ASSERT_TRUE(engine->Get("opaque", [&](std::string_view, Bytes value) {
     EXPECT_EQ(std::vector<std::byte>(value.begin(), value.end()), expected);
     return true;
@@ -444,8 +341,16 @@ TEST(StorageNodeSubscriberTest, WrapsUnknownEncodingAsBytesPayloadV1) {
   ASSERT_EQ(replies.size(), 1u);
   EXPECT_EQ(replies[0].payload, expected);
   EXPECT_EQ(replies[0].encoding.id, Encoding::kSitosV1);
+
+  transport.InvokeSubscriber("sitos/base/empty", TransportSample::Kind::Put, {}, {});
+  ASSERT_TRUE(engine->Get("empty", [&](std::string_view, Bytes value) {
+    EXPECT_EQ(std::vector<std::byte>(value.begin(), value.end()),
+              (std::vector<std::byte>{std::byte{0x04}}));
+    return true;
+  }));
+
   const auto records = sink->Records();
-  ASSERT_EQ(records.size(), 1u);
+  ASSERT_EQ(records.size(), 2u);
   EXPECT_EQ(records[0].level, LogLevel::kWarning);
   EXPECT_EQ(records[0].component, "node");
   EXPECT_EQ(records[0].message, "unknown subscriber encoding; wrapped as bytes");
@@ -468,6 +373,7 @@ TEST(StorageNodeSubscriberTest, IgnoresUnsupportedPathsAndWarns) {
   transport.InvokeSubscriber("sitos/meta/session/session-1", put, {std::byte{0x01}}, {});
   transport.InvokeSubscriber("sitos/base/$batch", put, {std::byte{0x01}}, {});
   transport.InvokeSubscriber("sitos/base/", put, {std::byte{0x01}}, {});
+  transport.InvokeSubscriber("sitos/base/bad*", put, {std::byte{0x01}}, {});
 
   EXPECT_FALSE(engine->Get("ignored", [](std::string_view, Bytes) { return true; }));
   ASSERT_TRUE(engine->Get("existing", [](std::string_view, Bytes value) {
@@ -476,7 +382,7 @@ TEST(StorageNodeSubscriberTest, IgnoresUnsupportedPathsAndWarns) {
     return true;
   }));
   const auto records = sink->Records();
-  ASSERT_EQ(records.size(), 6u);
+  ASSERT_EQ(records.size(), 7u);
   for (const auto& record : records) {
     EXPECT_EQ(record.level, LogLevel::kWarning);
     EXPECT_EQ(record.component, "node");
@@ -496,7 +402,7 @@ TEST(StorageNodeSubscriberTest, RetainedCallbackIsInertAfterStop) {
   EXPECT_FALSE(engine->Get("after-stop", [](std::string_view, Bytes) { return true; }));
 }
 
-TEST(StorageNodeSubscriberTest, LogsEngineWriteFailure) {
+TEST(StorageNodeSubscriberTest, LogsEngineWriteFailures) {
   auto engine = std::make_shared<FailingEngine>();
   FakeTransport transport;
   auto sink = std::make_shared<CaptureSink>();
@@ -505,11 +411,15 @@ TEST(StorageNodeSubscriberTest, LogsEngineWriteFailure) {
 
   transport.InvokeSubscriber("sitos/base/failure", TransportSample::Kind::Put,
                              {std::byte{0x01}}, Encoding{std::string(Encoding::kSitosV1)});
+  transport.InvokeSubscriber("sitos/base/failure", TransportSample::Kind::Delete, {}, {});
   const auto records = sink->Records();
-  ASSERT_EQ(records.size(), 1u);
+  ASSERT_EQ(records.size(), 2u);
   EXPECT_EQ(records[0].level, LogLevel::kError);
   EXPECT_EQ(records[0].component, "node");
   EXPECT_EQ(records[0].message, "subscriber PUT failed");
+  EXPECT_EQ(records[1].level, LogLevel::kError);
+  EXPECT_EQ(records[1].component, "node");
+  EXPECT_EQ(records[1].message, "subscriber DELETE failed");
 }
 
 }  // namespace

--- a/tests/unit/storage_node_test.cpp
+++ b/tests/unit/storage_node_test.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -21,6 +22,31 @@ namespace {
 class LifetimeSink final : public LogSink {
  public:
   void Write(const LogRecord&) override {}
+};
+
+class CaptureSink final : public LogSink {
+ public:
+  void Write(const LogRecord& record) override {
+    std::lock_guard<std::mutex> lock(mutex);
+    records.push_back(record);
+  }
+
+  std::vector<LogRecord> Records() const {
+    std::lock_guard<std::mutex> lock(mutex);
+    return records;
+  }
+
+ private:
+  mutable std::mutex mutex;
+  std::vector<LogRecord> records;
+};
+
+class FailingEngine final : public StorageEngine {
+ public:
+  bool Put(std::string_view, Bytes) override { return false; }
+  bool Delete(std::string_view) override { return false; }
+  bool Get(std::string_view, const EntrySink&) const override { return false; }
+  bool List(std::string_view, const EntrySink&) const override { return false; }
 };
 
 class FakeTransport final : public Transport {
@@ -44,9 +70,19 @@ class FakeTransport final : public Transport {
     return Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
   }
 
-  Subscription DeclareSubscriber(std::string_view,
-                                 std::function<void(const TransportSample&)>) override {
+  Subscription DeclareSubscriber(
+      std::string_view keyexpr,
+      std::function<void(const TransportSample&)> callback) override {
+    subscriber_keyexpr = std::string(keyexpr);
+    subscriber_callback = std::move(callback);
     return {};
+  }
+
+  void InvokeSubscriber(std::string key, TransportSample::Kind kind,
+                        std::vector<std::byte> payload, Encoding encoding) {
+    if (!subscriber_callback) return;
+    TransportSample sample{std::move(key), payload, std::move(encoding), std::nullopt, kind};
+    subscriber_callback(sample);
   }
 
   Queryable DeclareQueryable(std::string_view keyexpr,
@@ -74,6 +110,8 @@ class FakeTransport final : public Transport {
 
   std::string declared_keyexpr;
   std::function<void(TransportQuery&)> query_callback;
+  std::string subscriber_keyexpr;
+  std::function<void(const TransportSample&)> subscriber_callback;
 };
 
 TEST(StorageNodeQueryTest, ParsesExactBaseKey) {
@@ -147,8 +185,9 @@ TEST(StorageNodeQueryTest, RetainsInjectedLogSinkWhileStarted) {
   node.Stop();
   EXPECT_FALSE(weak_sink.expired());
 
-  // The test transport models undeclaration by releasing its callback.
+  // The test transport models undeclaration by releasing both callbacks.
   transport.query_callback = {};
+  transport.subscriber_callback = {};
   EXPECT_TRUE(weak_sink.expired());
 }
 
@@ -238,6 +277,119 @@ TEST(StorageNodeQueryTest, StopDisablesExistingCallback) {
   EXPECT_FALSE(node.IsStarted());
 }
 
+TEST(StorageNodeQueryTest, DeclaresSubscriberAndRoutesBasePut) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  EXPECT_EQ(transport.subscriber_keyexpr, "sitos/**");
+
+  const std::vector<std::byte> payload = {std::byte{0x01}, std::byte{0xFE}};
+  transport.InvokeSubscriber("sitos/base/foo/bar", TransportSample::Kind::Put, payload,
+                             Encoding{std::string(Encoding::kSitosV1)});
+  std::vector<std::byte> stored;
+  ASSERT_TRUE(engine->Get("foo/bar", [&](std::string_view, Bytes value) {
+    stored.assign(value.begin(), value.end());
+    return true;
+  }));
+  EXPECT_EQ(stored, payload);
+}
+
+TEST(StorageNodeQueryTest, UnknownEncodingWrapsPayloadAsBytes) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  StorageNode node;
+  auto sink = std::make_shared<CaptureSink>();
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = sink}).IsOk());
+
+  const std::vector<std::byte> payload = {std::byte{0x01}, std::byte{0x02}, std::byte{0xFF}};
+  transport.InvokeSubscriber("sitos/base/raw", TransportSample::Kind::Put, payload,
+                             Encoding{"application/octet-stream"});
+  std::vector<std::byte> stored;
+  ASSERT_TRUE(engine->Get("raw", [&](std::string_view, Bytes value) {
+    stored.assign(value.begin(), value.end());
+    return true;
+  }));
+  EXPECT_EQ(stored, (std::vector<std::byte>{std::byte{0x04}, std::byte{0x01}, std::byte{0x02},
+                                             std::byte{0xFF}}));
+  auto records = sink->Records();
+  ASSERT_EQ(records.size(), 1u);
+  EXPECT_EQ(records[0].level, LogLevel::kWarning);
+  EXPECT_EQ(records[0].component, "node");
+  EXPECT_EQ(records[0].message, "unknown subscriber encoding; wrapped as bytes");
+  auto replies = transport.Invoke("sitos/base/raw");
+  ASSERT_EQ(replies.size(), 1u);
+  EXPECT_EQ(replies[0].payload, stored);
+  EXPECT_EQ(replies[0].encoding.id, Encoding::kSitosV1);
+}
+
+TEST(StorageNodeQueryTest, RoutesBaseDelete) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  ASSERT_TRUE(engine->Put("foo", std::vector<std::byte>{std::byte{0x01}}));
+  FakeTransport transport;
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  transport.InvokeSubscriber("sitos/base/foo", TransportSample::Kind::Delete,
+                             {std::byte{0xFF}}, Encoding{"unknown"});
+  EXPECT_FALSE(engine->Get("foo", [](std::string_view, Bytes) { return true; }));
+}
+
+TEST(StorageNodeQueryTest, IgnoresUnsupportedSubscriberPathsWithWarnings) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  StorageNode node;
+  auto sink = std::make_shared<CaptureSink>();
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = sink}).IsOk());
+
+  const std::vector<std::byte> payload = {std::byte{0x07}};
+  for (const auto* key : {"sitos/snap/s1/value", "sitos/session/s1/value",
+                          "sitos/meta/session/s1", "sitos/base/$batch", "sitos/base/bad*"}) {
+    transport.InvokeSubscriber(key, TransportSample::Kind::Put, payload,
+                               Encoding{"application/octet-stream"});
+  }
+  EXPECT_FALSE(engine->Get("value", [](std::string_view, Bytes) { return true; }));
+  auto records = sink->Records();
+  ASSERT_EQ(records.size(), 5u);
+  for (const auto& record : records) {
+    EXPECT_EQ(record.level, LogLevel::kWarning);
+    EXPECT_EQ(record.component, "node");
+    EXPECT_EQ(record.message, "unsupported subscriber key");
+  }
+}
+
+TEST(StorageNodeQueryTest, EngineFailureEmitsError) {
+  auto engine = std::make_shared<FailingEngine>();
+  FakeTransport transport;
+  StorageNode node;
+  auto sink = std::make_shared<CaptureSink>();
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = sink}).IsOk());
+  transport.InvokeSubscriber("sitos/base/value", TransportSample::Kind::Put,
+                             {std::byte{0x01}}, Encoding{std::string(Encoding::kSitosV1)});
+  transport.InvokeSubscriber("sitos/base/value", TransportSample::Kind::Delete, {}, {});
+  auto records = sink->Records();
+  ASSERT_EQ(records.size(), 2u);
+  EXPECT_EQ(records[0].level, LogLevel::kError);
+  EXPECT_EQ(records[0].message, "subscriber PUT failed");
+  EXPECT_EQ(records[1].level, LogLevel::kError);
+  EXPECT_EQ(records[1].message, "subscriber DELETE failed");
+}
+
+TEST(StorageNodeQueryTest, SubscriberCallbackBecomesInertAfterStop) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  auto callback = transport.subscriber_callback;
+  node.Stop();
+  ASSERT_TRUE(callback);
+  std::vector<std::byte> payload = {std::byte{0x01}};
+  TransportSample sample{"sitos/base/foo", payload,
+                         Encoding{std::string(Encoding::kSitosV1)}, std::nullopt,
+                         TransportSample::Kind::Put};
+  callback(sample);
+  EXPECT_FALSE(engine->Get("foo", [](std::string_view, Bytes) { return true; }));
+}
+
 TEST(StorageNodeQueryTest, StopAndRestartReplacesDeclaration) {
   auto engine = std::make_shared<InMemoryEngine>();
   ASSERT_TRUE(engine->Put("foo", std::vector<std::byte>{std::byte{0x01}}));
@@ -250,6 +402,114 @@ TEST(StorageNodeQueryTest, StopAndRestartReplacesDeclaration) {
   auto replies = transport.Invoke("sitos/base/foo");
   ASSERT_EQ(replies.size(), 1u);
   EXPECT_EQ(replies[0].key, "sitos/base/foo");
+}
+
+TEST(StorageNodeSubscriberTest, DeclaresPrefixAndRoutesKnownPutAndDelete) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos"}).IsOk());
+  EXPECT_EQ(transport.subscriber_keyexpr, "sitos/**");
+
+  const std::vector<std::byte> payload = {std::byte{0x04}, std::byte{0xAA}};
+  transport.InvokeSubscriber("sitos/base/foo", TransportSample::Kind::Put, payload,
+                             Encoding{std::string(Encoding::kSitosV1)});
+  ASSERT_TRUE(engine->Get("foo", [&](std::string_view, Bytes value) {
+    EXPECT_EQ(std::vector<std::byte>(value.begin(), value.end()), payload);
+    return true;
+  }));
+
+  transport.InvokeSubscriber("sitos/base/foo", TransportSample::Kind::Delete, {std::byte{0xFF}},
+                             Encoding{"unknown"});
+  EXPECT_FALSE(engine->Get("foo", [](std::string_view, Bytes) { return true; }));
+}
+
+TEST(StorageNodeSubscriberTest, WrapsUnknownEncodingAsBytesPayloadV1) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  auto sink = std::make_shared<CaptureSink>();
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = sink}).IsOk());
+
+  const std::vector<std::byte> raw = {std::byte{0x01}, std::byte{0x02}, std::byte{0xFF}};
+  transport.InvokeSubscriber("sitos/base/opaque", TransportSample::Kind::Put, raw,
+                             Encoding{"application/octet-stream"});
+  const std::vector<std::byte> expected = {std::byte{0x04}, std::byte{0x01}, std::byte{0x02},
+                                             std::byte{0xFF}};
+  ASSERT_TRUE(engine->Get("opaque", [&](std::string_view, Bytes value) {
+    EXPECT_EQ(std::vector<std::byte>(value.begin(), value.end()), expected);
+    return true;
+  }));
+  const auto replies = transport.Invoke("sitos/base/opaque");
+  ASSERT_EQ(replies.size(), 1u);
+  EXPECT_EQ(replies[0].payload, expected);
+  EXPECT_EQ(replies[0].encoding.id, Encoding::kSitosV1);
+  const auto records = sink->Records();
+  ASSERT_EQ(records.size(), 1u);
+  EXPECT_EQ(records[0].level, LogLevel::kWarning);
+  EXPECT_EQ(records[0].component, "node");
+  EXPECT_EQ(records[0].message, "unknown subscriber encoding; wrapped as bytes");
+}
+
+TEST(StorageNodeSubscriberTest, IgnoresUnsupportedPathsAndWarns) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  ASSERT_TRUE(engine->Put("existing", std::vector<std::byte>{std::byte{0x07}}));
+  FakeTransport transport;
+  auto sink = std::make_shared<CaptureSink>();
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = sink}).IsOk());
+
+  const auto put = TransportSample::Kind::Put;
+  const auto del = TransportSample::Kind::Delete;
+  transport.InvokeSubscriber("sitos/snap/session-1/ignored", put, {std::byte{0x01}},
+                             Encoding{"unknown"});
+  transport.InvokeSubscriber("sitos/snap/session-1/ignored", del, {std::byte{0x01}}, {});
+  transport.InvokeSubscriber("sitos/session/session-1/ignored", put, {std::byte{0x01}}, {});
+  transport.InvokeSubscriber("sitos/meta/session/session-1", put, {std::byte{0x01}}, {});
+  transport.InvokeSubscriber("sitos/base/$batch", put, {std::byte{0x01}}, {});
+  transport.InvokeSubscriber("sitos/base/", put, {std::byte{0x01}}, {});
+
+  EXPECT_FALSE(engine->Get("ignored", [](std::string_view, Bytes) { return true; }));
+  ASSERT_TRUE(engine->Get("existing", [](std::string_view, Bytes value) {
+    EXPECT_EQ(std::vector<std::byte>(value.begin(), value.end()),
+              (std::vector<std::byte>{std::byte{0x07}}));
+    return true;
+  }));
+  const auto records = sink->Records();
+  ASSERT_EQ(records.size(), 6u);
+  for (const auto& record : records) {
+    EXPECT_EQ(record.level, LogLevel::kWarning);
+    EXPECT_EQ(record.component, "node");
+    EXPECT_EQ(record.message, "unsupported subscriber key");
+  }
+}
+
+TEST(StorageNodeSubscriberTest, RetainedCallbackIsInertAfterStop) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos"}).IsOk());
+  node.Stop();
+
+  transport.InvokeSubscriber("sitos/base/after-stop", TransportSample::Kind::Put,
+                             {std::byte{0x01}}, Encoding{std::string(Encoding::kSitosV1)});
+  EXPECT_FALSE(engine->Get("after-stop", [](std::string_view, Bytes) { return true; }));
+}
+
+TEST(StorageNodeSubscriberTest, LogsEngineWriteFailure) {
+  auto engine = std::make_shared<FailingEngine>();
+  FakeTransport transport;
+  auto sink = std::make_shared<CaptureSink>();
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = sink}).IsOk());
+
+  transport.InvokeSubscriber("sitos/base/failure", TransportSample::Kind::Put,
+                             {std::byte{0x01}}, Encoding{std::string(Encoding::kSitosV1)});
+  const auto records = sink->Records();
+  ASSERT_EQ(records.size(), 1u);
+  EXPECT_EQ(records[0].level, LogLevel::kError);
+  EXPECT_EQ(records[0].component, "node");
+  EXPECT_EQ(records[0].message, "subscriber PUT failed");
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Closes #10

StorageNode now declares a subscriber on `<prefix>/**`, routes base-scope PUT and DELETE samples to `StorageEngine`, rejects unsupported write paths with warning logs, and wraps unknown or absent Encoding payloads as payload-v1 BYTES. ZenohTransport now provides the production subscriber declaration and callback lifetime management.

## Requirements

- F04 — distribute writes through the shared zenoh key space
- C01 — preserve payload-v1 as the storage and wire payload format
- C02 — use Encoding to identify sitos payloads
- C03 — accept writes from clients using standard zenoh APIs

## Acceptance Criteria Verification

- [x] Declare the subscriber on `<prefix>/**` through `Transport::DeclareSubscriber`.
- [x] Route base PUT to `StorageEngine::Put` and base DELETE to `StorageEngine::Delete`.
- [x] Ignore snapshot, session, metadata, `$batch`, malformed, and otherwise unsupported paths with warning logs.
- [x] Preserve recognized `sitos.v1` payloads unchanged.
- [x] Wrap unknown or absent Encoding payloads as payload-v1 BYTES (`04` followed by the incoming bytes), including an empty payload as `04`.
- [x] Verify unknown Encoding through the real same-session Zenoh subscriber path and return it from GET as `sitos.v1`.
- [x] Keep retained callbacks inert after `StorageNode::Stop()`.
- [x] Log StorageEngine PUT and DELETE failures.

Validation:

- Windows MSVC/Debug, Zenoh ON: 146/146 CTest tests passed.
- Windows MSVC/Debug, Zenoh OFF: 121/121 CTest tests passed.
- Same-session subscriber integration executable repeated three times: 9/9 tests passed.
- `git diff --check` passed.
- Changed-file secret scan passed.

## RED-phase Confirmation

Against the pre-implementation production subscriber stub from `684ed6d`:

- `sitos_storage_node_subscriber_test.exe` failed both original integration tests.
- `PutGetAndDeleteRoundTrip`: waiting for the stored `value` timed out after 3.5 seconds.
- `SnapPutIsIgnoredAfterSamePublisherBarrier`: waiting for the `barrier` sample timed out after 3.5 seconds.

This demonstrated a real subscriber delivery failure rather than only a missing test helper.

## ADR Needed?

- [x] No
- [ ] Yes — ADR PR: #

The accepted wire Encoding decision remains ADR-0016; this PR does not change the wire protocol.

## Out of Scope

- Atomic declaration-failure propagation and rollback are tracked by #11.
- Session overlays (#12), batch decoding (#13), and ack tracking (#14) are not included.
- Broader concurrent Start/Stop lifecycle redesign remains in #11.
