### PR TITLE
docs(plan): fix milestone inconsistency and refresh issue breakdown (#79)

### DIFF
--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -439,8 +439,8 @@ so it is not a v0.2 blocker. Include it by v1.0.
 Lane A (core):      #1 → #4 → #6 → #7 → #8
 Lane B (zenoh):     #2 → #3 → #9 → #10 → #11 → #12 → #18 → #19/#20
                                             ├→ #13 → #15/#16
+                                            ├→ #14 → #17 (also needs #15)
                                             └→ #56 (also needs #8 from Lane A)
-                                                #14 → #17
 Lane C (Python):    #22 (any time after #4) → #23/#24/#25 → #26 → #27/#28
 Lane D (quality):   #29/#30, #31/#32, #33, #34/#35 (as dependencies complete)
 Lane E (optional):  #57 HTTP gateway (after #56, #16, #19; see M6)

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -17,9 +17,9 @@ Milestone = release boundary).
 |---|---|---|
 | **v0.1** | The zenoh-independent core works. Payload fixtures and InMemoryEngine contract tests are green | #1, #4, #5, #6, #7 |
 | **v0.2** | StorageNode/ParamStore/ParamCache work in C++ through same-process zenoh sessions | #2, #3, #9–#13, #15, #18, #19, #21 |
-| **v0.3** | Basic Python APIs work (InMemory, ParamStore, ParamCache, NumPy read) | #22, #23, #24, #25, #27 |
+| **v0.3** | Basic Python APIs work (InMemory, ParamStore, ParamCache, NumPy read) | #16, #22, #23, #24, #25, #27 |
 | **v0.4** | RocksDB, single-value interop, bench, examples, and session-scoped buffers are in place | #8, #29, #31, #32, #33, #56 |
-| **v1.0** | Public OSS quality. docs/release/wheels/ack/batch interop/GIL/custom engine and the optional HTTP gateway completed | #14, #16, #17, #20, #26, #28, #30, #34, #35, #57 |
+| **v1.0** | Public OSS quality. docs/release/wheels/ack/batch interop/GIL/custom engine and the optional HTTP gateway completed | #14, #17, #20, #26, #28, #30, #34, #35, #57 |
 
 `ack`-related work (#14, #17) is useful, but implementation is heavy relative to initial value,
 so it is not a v0.2 blocker. Include it by v1.0.
@@ -204,7 +204,7 @@ so it is not a v0.2 blocker. Include it by v1.0.
 * Depends on: #11, #13
 
 ### #16 ParamStore: Subscribe
-* Milestone: v1.0
+* Milestone: v0.3
 * References: [04] §2, [01] F13
 * Implementation targets: `include/sitos/param_store.hpp`, `src/param_store.cpp`,
   `tests/integration/param_store_subscribe_test.cpp`
@@ -438,10 +438,12 @@ so it is not a v0.2 blocker. Include it by v1.0.
 ```
 Lane A (core):      #1 → #4 → #6 → #7 → #8
 Lane B (zenoh):     #2 → #3 → #9 → #10 → #11 → #12 → #18 → #19/#20
-                                            └→ #13 → #15/#16
+                                            ├→ #13 → #15/#16
+                                            └→ #56 (also needs #8 from Lane A)
                                                 #14 → #17
 Lane C (Python):    #22 (any time after #4) → #23/#24/#25 → #26 → #27/#28
 Lane D (quality):   #29/#30, #31/#32, #33, #34/#35 (as dependencies complete)
+Lane E (optional):  #57 HTTP gateway (after #56, #16, #19; see M6)
 ```
 
 Each Issue is assumed to correspond to one PR. The PR must describe the corresponding requirement IDs

--- a/docs/development_workflow.md
+++ b/docs/development_workflow.md
@@ -12,8 +12,8 @@ Because implementation is assumed to be performed by AI coding agents,
 ```
 main ─────●───────●───────●──────●──► (always releasable)
            \     /  \     /
-            issue/3-param-value
-                     issue/6-in-memory-engine
+            feat/3-param-value
+                     feat/6-in-memory-engine
 ```
 
 * **main is always green** (required CI paths). Direct pushes are prohibited;


### PR DESCRIPTION
## Requirements

- Closes #79
- Resolve the docs-side half of the plan-review inconsistencies (the GitHub
  metadata half — #16 milestone and `issue/NN-` → `feat/NN-` in issue bodies —
  was already applied out-of-band and is not part of this diff).

> Supersedes #81, which GitHub auto-closed when its head branch was renamed
> from `docs/79-...` to `feat/79-...` to follow the repository branch convention.
> Same content plus the PR-81 review fixes below.

## Changes

`docs/07_issue_breakdown.md`:
- Release-boundary table: move #16 from the v1.0 row to the v0.3 row.
- #16 section: `Milestone: v1.0` → `v0.3`.
- Lane diagram: add #56 (branches off #12, also needs #8), #14 → #17 as a
  sibling branch (noting #17's #15 dependency), and #57 (Lane E, optional HTTP
  gateway tail, after #56/#16/#19).

`docs/development_workflow.md`:
- §1 trunk diagram: `issue/3-...` / `issue/6-...` → `feat/` naming, consistent
  with the normative rule on line 23 (updated by #44 but the ASCII diagram was
  missed).

## Rationale for the #16 move

#23 (Python ParamStore, v0.3) requires a Subscribe round-trip in its AC1, which
depends on C++ #16 (ParamStore: Subscribe). #16 was placed in v1.0, so v0.3
depended on a later milestone. #16 is not ack-related (it depends only on #15,
which is v0.2), so pulling it forward to v0.3 is the minimal fix and does not
disturb the ack deferral rationale for #14/#17.

## Acceptance Criteria Verification

1. Milestone table, per-issue sections, and lane diagram in `docs/07` match the
   GitHub milestone assignments (including #16 = v0.3, already set on GitHub). ✅
2. No issue depends on an issue in a later milestone (the only prior violation,
   #23 → #16, is resolved). ✅
3. No open **implementation** issue instructs implementers to use `issue/`
   branch naming (applied out-of-band; the tracking issue #79 still contains
   `issue/NN-` in its explanatory prose, which is expected and closes with this PR). ✅
4. No `docs/` file references `issue/` branch naming — verified with
   `grep -rn "issue/[0-9]" docs/` returning nothing. ✅

## Out of Scope

The GitHub metadata edits tracked in #79 (already completed): #16 milestone move
and the `issue/NN-` → `feat/NN-` rewrite across open issue bodies.
