### PR TITLE
[ADR] feat(storage): deliver validated batches (#13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           UBSAN_OPTIONS: halt_on_error=1
         run: >-
           ctest --test-dir build/sanitizer-${{ matrix.name }}
-          --output-on-failure -R 'StorageNodeLifecycleTest|StorageNodeSessionTest'
+          --output-on-failure -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest'
 
   build-windows:
     runs-on: windows-latest

--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -152,23 +152,33 @@ struct State /* excerpt */ {
     std::unordered_map<std::string, std::shared_ptr<const StorageReader>> snapshots;
     // sid → overlay engine (an InMemoryEngine; locks itself internally)
     std::unordered_map<std::string, std::shared_ptr<StorageEngine>> overlays;
+    // Serializes the complete subscriber application path, including batch
+    // entries, so ordinary writes cannot interleave a batch.
+    std::mutex subscriber_mutex;
     // sid → metadata backing meta/session/<sid> replies
     std::unordered_map<std::string, SessionMeta> sessions;
     std::shared_mutex session_mutex;  // protects the three tables above
 };
 ```
 
-Lock ordering: callbacks hold the ADR-0017 callback-gate lease and then take
-`session_mutex`; `CreateSession`/`CloseSession`/`ActiveSessions` enroll in the
-same gate (so `Stop()` waits for them) and then take only `session_mutex` — the
-ordering never cycles. Readers copy the `shared_ptr` out of a table and release
-`session_mutex` before replying, so `CloseSession` never invalidates an
-in-flight reply.
+Lock ordering: subscriber callbacks hold the ADR-0017 callback-gate lease,
+then take `subscriber_mutex`, and only then briefly take `session_mutex` to
+copy an overlay pointer. They release `session_mutex` before engine writes and
+log emission. This prevents ordinary writes from interleaving batch entries
+without holding a table lock around external code. `CreateSession`/
+`CloseSession`/`ActiveSessions` enroll in the same gate (so `Stop()` waits for
+them) and then take only `session_mutex`; the ordering never cycles. Readers
+copy the `shared_ptr` out of a table and release `session_mutex` before replying,
+so `CloseSession` never invalidates an in-flight reply.
 
 ### 4.3 Consistency Model
 
 * Write ordering: zenoh preserves the order of puts from the same publisher.
   It does not guarantee ordering across different publishers (last-write-wins)
+* Batch visibility: StorageNode validates all entries before the first write and
+  prevents subscriber messages from interleaving with batch entries. Queries do
+  not take `subscriber_mutex`, so a concurrent Get/List may observe a partially
+  applied batch
 * Relationship with puts around `CreateSession`: the snapshot contains
   “the contents already reflected in the engine at the moment StorageNode processes CreateSession”.
   The caller must confirm completion of all required base writes before starting a session

--- a/docs/03_wire_protocol.md
+++ b/docs/03_wire_protocol.md
@@ -14,15 +14,15 @@ A standard zenoh client can interoperate with sitos simply by following this spe
 <prefix>/buffers/<sid>/<key>
 <prefix>/meta/session/<sid>
 <prefix>/meta/ack/<uuid>
-<prefix>/base/$batch
-<prefix>/session/<sid>/$batch
+<prefix>/base/:batch                 # batch delivery [ADR-0018]
+<prefix>/session/<sid>/:batch        # batch delivery [ADR-0018]
 ```
 
 * `<prefix>`: Default is `sitos`. Configurable. One or more zenoh chunks
 * `<sid>`: session ID. `[0-9a-zA-Z_-]+` (UUID recommended). One chunk
 * `<key>`: User key. One or more chunks (hierarchical keys allowed)
 * `buffers/<sid>/<key>`: session-scoped large binary values. `<sid>` and `<key>` follow the
-  same grammar as other scopes. No `$batch` and no `snap` counterpart. The persistence mode
+  same grammar as other scopes. No `:batch` and no `snap` counterpart. The persistence mode
   (durable/ephemeral) is a host-side session option and is **not** encoded on the wire [ADR-0014]
 
 ### 1.2 User-key grammar
@@ -32,8 +32,9 @@ key    = chunk *( "/" chunk )
 chunk  = 1*( ALPHA / DIGIT / "_" / "-" / "." )
 ```
 
-* Prohibited: empty chunks, `*` `$` `?` `#` `@` whitespace (reserved characters in
-  zenoh key expressions), leading or trailing `/`
+* Prohibited: empty chunks, leading or trailing `/`, whitespace, and every character outside
+  the grammar above. In particular, `:batch` is a reserved control segment and cannot be a
+  user key
 * Case-sensitive
 * Recommended: represent hierarchy with `/` (example: `recon/fov`).
   Legacy `.`-separated keys (example: `recon.fov`) are legal as one chunk, but
@@ -127,7 +128,7 @@ Receiver interpretation rules:
 | Delete value | `delete` | Same as above (valid only for base; not allowed for snap) |
 | Read value | `get` | Same key as for writes, or `<prefix>/snap/<sid>/<key>` |
 | Prefix enumeration | `get` | `<prefix>/base/<chunk...>/**`, etc. |
-| Batch write | `put` (batch payload) | `<prefix>/base/$batch` / `<prefix>/session/<sid>/$batch` (§5) |
+| Batch write | `put` (batch payload) | `<prefix>/base/:batch` / `<prefix>/session/<sid>/:batch` (§5) |
 
 ## 4. Query semantics
 
@@ -154,9 +155,10 @@ zenoh wildcards operate on chunks (`*` = one chunk, `**` = zero or more chunks).
 
 ## 5. Batch format (`sitos.v1.batch`)
 
-Delivers multiple entries atomically in one zenoh put [F09].
-Put to key `<prefix>/base/$batch` or `<prefix>/session/<sid>/$batch`, and store all entries in
-the payload.
+Delivers multiple entries in one zenoh put [F09].
+Put to key `<prefix>/base/:batch` or `<prefix>/session/<sid>/:batch`, and store all entries in
+the payload. `:batch` is reserved because it is zenoh-valid while `$batch` is not; see
+[ADR-0018](adr/0018-use-zenoh-valid-batch-key-segment.md).
 
 ```
 offset  size  Contents
@@ -169,8 +171,11 @@ Repeated N times thereafter:
         vLen  Value body
 ```
 
-* After receiving a batch, StorageNode applies all entries to the engine / overlay before
-  processing the next message (guaranteeing order and atomicity within the batch)
+* StorageNode validates and materializes all entries before its first engine write. It then applies
+  them in encoded order before processing the next subscriber message. Invalid batches perform no
+  writes; an engine write failure is logged and does not roll back an earlier successful write.
+  This sequencing does not provide reader atomicity: a concurrent get or list may observe a
+  partially applied batch.
 * Subscribers (ParamCache) also subscribe to the batch key and apply the same format
   (because it is included in the normal subscription ranges `session/<sid>/**` and `base/**`,
   it can be received through the same path as ordinary delta subscriptions)
@@ -184,7 +189,7 @@ Repeated N times thereafter:
 
 `batch_base_two_entries`:
 
-* put key: `sitos/base/$batch`
+* put key: `sitos/base/:batch`
 * entries:
   1. key=`recon/fov`, value=`DP 240.0`
   2. key=`recon/kernel`, value=`STR "sharp"`

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -89,7 +89,7 @@ major behaviors.
 | `SnapshotIsIsolatedFromBasePut` | F05/N02 | A base put after CreateSession does not affect snap reads |
 | `SnapshotFallbackCopiesForInMemory` | N03 | InMemory snapshot works with the same semantics |
 | `AttachDoesNotMissConcurrentPut` | F06 | Does not miss a concurrent put during Attach |
-| `BatchIsReceivedBySessionSubscriber` | F09 | `$batch` is received by a `session/<sid>/**` subscription |
+| `BatchIsReceivedBySessionSubscriber` | F09 / ADR-0018 | `:batch` is received by a `session/<sid>/**` subscription |
 | `SpanHandleSurvivesOverwrite` | N01/P02 | old SpanHandle/ndarray remains valid after an update |
 | `RawZenohClientCanPutAndGet` | C03 | Single-value interoperability using only zenoh-python |
 | `RawZenohClientCanSendBatch` | C03/F09 | Batch interoperability using only zenoh-python |
@@ -98,19 +98,22 @@ major behaviors.
 
 ## 4.2 Lifecycle sanitizer runs
 
-Issue #11 lifecycle tests have reproducible sanitizer configurations. TSan runs the
-zenoh-independent fake-Transport stress path; ASan/UBSan runs the same path separately:
+Issue #11 lifecycle tests and Issue #13 batch sequencing tests have reproducible
+sanitizer configurations. TSan runs the zenoh-independent fake-Transport stress
+paths; ASan/UBSan runs the same paths separately:
 
 ```sh
 cmake -S . -B build/tsan -G Ninja -DCMAKE_BUILD_TYPE=Debug \
   -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF -DSITOS_ENABLE_TSAN=ON
 cmake --build build/tsan
-ctest --test-dir build/tsan --output-on-failure -R StorageNodeLifecycleTest
+ctest --test-dir build/tsan --output-on-failure \
+  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest'
 
 cmake -S . -B build/asan -G Ninja -DCMAKE_BUILD_TYPE=Debug \
   -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF -DSITOS_ENABLE_ASAN_UBSAN=ON
 cmake --build build/asan
-ctest --test-dir build/asan --output-on-failure -R StorageNodeLifecycleTest
+ctest --test-dir build/asan --output-on-failure \
+  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest'
 ```
 
 For a platform where the zenoh-c standalone runtime supports sanitizer instrumentation,

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -176,10 +176,12 @@ so it is not a v0.2 blocker. Include it by v1.0.
 * References: [03] §5, [02] §6.1
 * Implementation targets: `include/sitos/batch.hpp`, `src/batch.cpp`, `src/storage_node.cpp`,
   `tests/integration/batch_test.cpp`
-* Scope: Receiving process for `$batch` keys (`base/$batch`, `session/<sid>/$batch`)
-  (atomic apply), and ParamCache receiving batch through the normal subscription range
-* Acceptance criteria: integration tests — all batch entries applied and ordered, received through normal subscription,
-  expansion into per-key notifications
+* Scope: StorageNode receives and applies `:batch` keys (`base/:batch`,
+  `session/<sid>/:batch`) after full validation, with node-local subscriber ordering;
+  prove the original batch sample is received through the normal subscription range.
+  ParamCache expansion into per-key notifications is deferred to Issue #16.
+* Acceptance criteria: integration tests — all batch entries applied and ordered,
+  received as one original sample through the normal subscription range
 * Depends on: #11, #12
 
 ### #14 ack protocol
@@ -230,7 +232,7 @@ so it is not a v0.2 blocker. Include it by v1.0.
 * Scope: independent `<prefix>/buffers/<sid>/<key>` scope; single put = full-payload push to
   live subscribers + store to a per-session disk engine (`kDurable`) / push-only (`kEphemeral`);
   get from the per-session engine; querying-subscriber late-join; purge on `CloseSession`.
-  No `$batch`, no snapshot
+  No `:batch`, no snapshot
 * Acceptance criteria: key round-trip; push==get byte equality; late-join no-loss;
   `kEphemeral` no-store/no-get; `CloseSession` purge → not-found; ParamCache scope isolation
   (`session/**` never receives `buffers/**`); raw-zenoh interop
@@ -366,7 +368,7 @@ so it is not a v0.2 blocker. Include it by v1.0.
 * Milestone: v1.0
 * References: [03] §5–6, [01] C03, [06] §4
 * Implementation targets: `tests/interop/test_raw_zenoh_batch_ack.py`
-* Scope: Verify `$batch` and ack using only zenoh-python + struct
+* Scope: Verify `:batch` and ack using only zenoh-python + struct
 * Acceptance criteria: batch/ack test written only from the wire specification is green
 * Depends on: #13, #14
 

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -148,7 +148,7 @@ If latest stable fails:
 The following must not change after zenoh updates:
 
 * Byte sequences of the `sitos.v1` payload fixtures
-* key paths (`base`, `session`, `snap`, `$batch`, `meta`)
+* key paths (`base`, `session`, `snap`, `:batch`, `meta`)
 * The loss-prevention sequence of `ParamCache::Attach`
 * Snapshot isolation semantics
 * Python API exception mapping

--- a/docs/adr/0014-session-scoped-buffers.md
+++ b/docs/adr/0014-session-scoped-buffers.md
@@ -52,7 +52,7 @@ selected per session by a `BufferPersistence` mode (`kDurable` = push + store,
 
 ## Design notes (normative for the implementation)
 
-* Key space: `<prefix>/buffers/<sid>/<key>`. No `$batch`, no `snap` counterpart.
+* Key space: `<prefix>/buffers/<sid>/<key>`. No `:batch`, no `snap` counterpart.
 * `KeyKind::Buffer` added to `key.hpp`; `BuildBufferKey(sid, key)` and a
   `ParseKey` branch; `<sid>` and `<key>` reuse the existing grammar (§1.2).
 * Storage: a disk StorageEngine instance is created per session for `kDurable`.

--- a/docs/adr/0018-use-zenoh-valid-batch-key-segment.md
+++ b/docs/adr/0018-use-zenoh-valid-batch-key-segment.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed — 2026-07-15
+Accepted — 2026-07-15
 
 ## Context
 

--- a/docs/adr/0018-use-zenoh-valid-batch-key-segment.md
+++ b/docs/adr/0018-use-zenoh-valid-batch-key-segment.md
@@ -1,0 +1,64 @@
+# ADR-0018: Use a zenoh-valid batch key segment
+
+## Status
+
+Proposed — 2026-07-15
+
+## Context
+
+The original batch wire path reserved the terminal segment `$batch`. During
+Issue #13's same-session zenoh-c 1.9.0 RED phase, `Transport::Put(.../$batch, ...)`
+failed while an ordinary sibling key on the same transport succeeded.
+`z_keyexpr_from_str_autocanonize` also rejects it: `$` participates in zenoh's
+`$*` wildcard syntax. The first replacement candidate, `@batch`, could be put
+but neither `<prefix>/**` nor `session/<sid>/**` received it, so StorageNode
+never applied the sample.
+
+Focused same-session probes then verified that `~batch`, `%batch`, `+batch`,
+`:batch`, and `!batch` are valid zenoh-c key expressions and are delivered
+through a normal `/**` subscription. A batch path must also be outside the sitos
+user-key grammar and communicate that it is a reserved control operation.
+
+## Decision
+
+We will reserve `:batch` as the terminal batch segment. Batch puts use
+`<prefix>/base/:batch` and `<prefix>/session/<sid>/:batch`. The colon marks a
+named control operation and is outside the sitos user-key grammar. No `$batch`,
+`@batch`, or `~batch` compatibility alias is provided because no v0.2 batch
+wire was released.
+
+## Consequences
+
+* Good: batch paths are valid zenoh-c 1.9.0 key expressions and remain outside
+  the user-key grammar.
+* Good: normal `base/**` and `session/<sid>/**` subscriptions receive the
+  original batch sample without a separate declaration.
+* Good: `:batch` reads as a named control segment rather than application data.
+* Bad: pre-release documentation and fixtures using `$batch`, `@batch`, or
+  `~batch` must be updated.
+* Neutral: retired candidates remain invalid sitos batch keys and cause zero
+  StorageNode mutation.
+
+## Options Considered
+
+* **Keep `$batch` with escaping or unchecked Zenoh APIs** — rejected because
+  zenoh-c rejects it as a key expression and unchecked construction would evade
+  transport validation.
+* **Use `@batch`** — rejected because it does not intersect the normal zenoh
+  wildcard subscriptions required for StorageNode and ParamCache delivery.
+* **Use `~batch`** — technically valid and wildcard-deliverable, but rejected
+  because its home-directory and approximation associations do not clearly
+  identify a control operation.
+* **Use `%batch`, `+batch`, or `!batch`** — technically valid and
+  wildcard-deliverable, but rejected to avoid percent-encoding, form/URL, and
+  shell/YAML punctuation concerns.
+* **Use an ordinary user-key segment** — rejected because it could collide with
+  application data.
+
+## References
+
+* Issue #13
+* `BatchIntegrationTest.BatchIsReceivedBySessionSubscriber` proves `:batch`
+  reaches `session/<sid>/**` and is applied by StorageNode on zenoh-c 1.9.0.
+* [Wire protocol](../03_wire_protocol.md)
+* [ADR process](../10_adr_process.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,3 +22,4 @@ See [docs/10_adr_process.md](../10_adr_process.md) for the process.
 | [0015](0015-optional-http-gateway-component.md) | Ship an optional HTTP gateway component on cpp-httplib |
 | [0016](0016-use-canonical-zenoh-bytes-encodings.md) | Use canonical zenoh bytes encodings |
 | [0017](0017-atomic-storage-node-lifecycle.md) | Use atomic, quiescent StorageNode lifecycle transitions |
+| [0018](0018-use-zenoh-valid-batch-key-segment.md) | Use a zenoh-valid batch key segment |

--- a/include/sitos/key.hpp
+++ b/include/sitos/key.hpp
@@ -26,9 +26,9 @@ struct Scope {
 /// Key kind, used by the incoming-key parser for StorageNode routing.
 /// See docs/03_wire_protocol.md §1.1.
 enum class KeyKind {
-  Base,         ///< <prefix>/base/<key> (or <prefix>/base/$batch)
-  Session,      ///< <prefix>/session/<sid>/<key> (or $batch)
-  Snapshot,     ///< <prefix>/snap/<sid>/<key> (read-only; no $batch)
+  Base,         ///< <prefix>/base/<key> (or <prefix>/base/:batch)
+  Session,      ///< <prefix>/session/<sid>/<key> (or :batch)
+  Snapshot,     ///< <prefix>/snap/<sid>/<key> (read-only; no :batch)
   MetaSession,  ///< <prefix>/meta/session/<sid>
   MetaAck,      ///< <prefix>/meta/ack/<uuid>
 };
@@ -42,16 +42,16 @@ struct ParsedKey {
   /// Ack UUID for MetaAck. Empty for all other kinds.
   std::string uuid;
   /// Relative user key for Base / Session / Snapshot. Empty for Meta paths and
-  /// for $batch paths (where is_batch is true instead).
+  /// for :batch paths (where is_batch is true instead).
   std::string relative_key;
-  /// True for the special <prefix>/base/$batch and <prefix>/session/<sid>/$batch
+  /// True for the special <prefix>/base/:batch and <prefix>/session/<sid>/:batch
   /// paths. Only Base and Session may be batch.
   bool is_batch = false;
 };
 
 /// Validates a user key according to wire protocol §1.2. Rejects empty
-/// chunks, leading/trailing '/', and zenoh-reserved characters (*$?#@ and
-/// whitespace).
+/// chunks, leading/trailing '/', whitespace, and every character outside
+/// [0-9A-Za-z_.-], including the ':' batch-control marker.
 bool IsValidKey(std::string_view key);
 
 /// Validates a session id according to wire protocol §1.1 ([0-9a-zA-Z_-]+,
@@ -74,8 +74,8 @@ std::optional<Scope> ParseScope(std::string_view scope);
 std::optional<std::string> BuildKey(std::string_view prefix, std::string_view scope,
                                     std::string_view user_key);
 
-/// Builds a $batch key for the given scope: <prefix>/base/$batch or
-/// <prefix>/session/<sid>/$batch. Batch is not defined for snap; returns
+/// Builds a :batch key for the given scope: <prefix>/base/:batch or
+/// <prefix>/session/<sid>/:batch. Batch is not defined for snap; returns
 /// std::nullopt for a snap scope.
 std::optional<std::string> BuildBatchKey(std::string_view prefix, std::string_view scope);
 

--- a/include/sitos/storage_node.hpp
+++ b/include/sitos/storage_node.hpp
@@ -159,9 +159,15 @@ class StorageNode {
     std::size_t in_flight = 0;
     bool accepting = false;
 
+    // Subscriber callbacks enter the callback gate, then take
+    // subscriber_mutex before optionally looking up a session under
+    // session_mutex. This prevents ordinary writes from interleaving a batch;
+    // session locks are released before engine writes.
+    std::mutex subscriber_mutex;
+
     // Session tables. Guarded by session_mutex. Callbacks and session
     // operations alike enter the callback gate before locking session_mutex,
-    // so the gate -> session_mutex ordering is uniform and never cycles.
+    // so the gate -> subscriber_mutex -> session_mutex ordering never cycles.
     std::shared_mutex session_mutex;
     SnapshotTable snapshots;
     OverlayTable overlays;

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -49,7 +49,7 @@ bool IsValidChunkSequence(std::string_view value) {
 }
 
 // The special batch segment, always the last chunk of a batch key.
-constexpr std::string_view kBatchSegment = "$batch";
+constexpr std::string_view kBatchSegment = ":batch";
 
 bool IsValidIdChar(char c) {
   return std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-';
@@ -217,7 +217,7 @@ std::optional<ParsedKey> ParseKey(std::string_view prefix, std::string_view full
   }
   std::string_view rest = *rest_opt;
 
-  // base/<key...> and base/$batch
+  // base/<key...> and base/:batch
   if (rest == "base") {
     // <prefix>/base with no user key is not a valid value key.
     return std::nullopt;
@@ -234,7 +234,7 @@ std::optional<ParsedKey> ParseKey(std::string_view prefix, std::string_view full
       return ParsedKey{KeyKind::Base, "", "", std::string(tail), false};
     }
     if (head == "session") {
-      // session/<sid>/<key...> or session/<sid>/$batch
+      // session/<sid>/<key...> or session/<sid>/:batch
       auto sid_split = SplitFirst(tail);
       if (!sid_split) {
         return std::nullopt;  // session/ with no sid/key
@@ -252,7 +252,7 @@ std::optional<ParsedKey> ParseKey(std::string_view prefix, std::string_view full
       return ParsedKey{KeyKind::Session, std::string(sid), "", std::string(value), false};
     }
     if (head == "snap") {
-      // snap/<sid>/<key...> — read-only, no $batch.
+      // snap/<sid>/<key...> — read-only, no :batch.
       auto sid_split = SplitFirst(tail);
       if (!sid_split) {
         return std::nullopt;
@@ -262,7 +262,7 @@ std::optional<ParsedKey> ParseKey(std::string_view prefix, std::string_view full
         return std::nullopt;
       }
       if (!IsValidKey(value)) {
-        return std::nullopt;  // rejects snap/<sid>/$batch too ($ fails IsValidKey)
+        return std::nullopt;  // rejects snap/<sid>/:batch as a read-only batch path
       }
       return ParsedKey{KeyKind::Snapshot, std::string(sid), "", std::string(value), false};
     }

--- a/src/storage_node.cpp
+++ b/src/storage_node.cpp
@@ -16,6 +16,7 @@
 #include <utility>
 #include <vector>
 
+#include "sitos/batch.hpp"
 #include "sitos/in_memory_engine.hpp"
 #include "sitos/key.hpp"
 #include "sitos/param_value.hpp"
@@ -131,17 +132,34 @@ constexpr std::string_view kUnknownSubscriberEncoding =
 constexpr std::string_view kSubscriberPutFailed = "subscriber PUT failed";
 constexpr std::string_view kSubscriberDeleteFailed = "subscriber DELETE failed";
 constexpr std::string_view kSubscriberCallbackFailed = "subscriber callback exception";
+constexpr std::string_view kMalformedBatchPayload = "malformed batch payload";
+constexpr std::string_view kInvalidBatchEntry = "invalid batch entry key";
+constexpr std::string_view kInvalidBatchOperation = "invalid batch operation or encoding";
 constexpr std::string_view kReadOnlySnapshotKey = "read-only snapshot key";
 constexpr std::string_view kUnknownSession = "unknown session";
 constexpr std::string_view kQueryCallbackFailed = "query callback exception";
 
+struct SubscriberDiagnostic {
+  LogLevel level;
+  std::string_view message;
+};
+
+using SubscriberDiagnostics = std::vector<SubscriberDiagnostic>;
+
+bool IsBatchPut(const TransportSample& sample) {
+  return sample.kind == TransportSample::Kind::Put &&
+         sample.encoding.id == Encoding::kSitosV1Batch;
+}
+
 // Applies a put/delete sample to a target engine (base engine or session
-// overlay), mirroring the wire-encoding rules for base writes.
-void ApplyWrite(const std::shared_ptr<LogSink>& log_sink, StorageEngine& target,
+// overlay), mirroring the wire-encoding rules for base writes. Diagnostics are
+// retained until the subscriber sequencer is released, so an injected sink is
+// never called while node application state is locked.
+void ApplyWrite(SubscriberDiagnostics& diagnostics, StorageEngine& target,
                 std::string_view relative_key, const TransportSample& sample) {
   if (sample.kind == TransportSample::Kind::Delete) {
     if (!target.Delete(relative_key)) {
-      EmitLog(log_sink, LogLevel::kError, kNodeComponent, kSubscriberDeleteFailed);
+      diagnostics.push_back({LogLevel::kError, kSubscriberDeleteFailed});
     }
     return;
   }
@@ -149,13 +167,53 @@ void ApplyWrite(const std::shared_ptr<LogSink>& log_sink, StorageEngine& target,
   Bytes value = sample.payload;
   std::vector<std::byte> wrapped;
   if (sample.encoding.id != Encoding::kSitosV1) {
-    EmitLog(log_sink, LogLevel::kWarning, kNodeComponent, kUnknownSubscriberEncoding);
+    diagnostics.push_back({LogLevel::kWarning, kUnknownSubscriberEncoding});
     auto bytes = std::vector<std::byte>(sample.payload.begin(), sample.payload.end());
     wrapped = ParamValue(std::move(bytes)).Encode();
     value = wrapped;
   }
   if (!target.Put(relative_key, value)) {
-    EmitLog(log_sink, LogLevel::kError, kNodeComponent, kSubscriberPutFailed);
+    diagnostics.push_back({LogLevel::kError, kSubscriberPutFailed});
+  }
+}
+
+struct EncodedBatchEntry {
+  std::string key;
+  std::vector<std::byte> value;
+};
+
+// Validates and materializes every batch entry before the first engine write.
+// StorageEngine has no transactional API: failed writes are logged and later
+// validated entries are still attempted in their encoded order.
+void ApplyBatch(SubscriberDiagnostics& diagnostics, StorageEngine& target,
+                std::span<const std::byte> payload) {
+  auto decoded = DecodeBatch(payload);
+  if (!decoded) {
+    diagnostics.push_back({LogLevel::kWarning, kMalformedBatchPayload});
+    return;
+  }
+
+  std::vector<EncodedBatchEntry> entries;
+  entries.reserve(decoded->size());
+  for (const auto& entry : *decoded) {
+    if (!IsValidKey(entry.key)) {
+      diagnostics.push_back({LogLevel::kWarning, kInvalidBatchEntry});
+      return;
+    }
+    entries.push_back({entry.key, entry.value.Encode()});
+  }
+
+  for (const auto& entry : entries) {
+    if (!target.Put(entry.key, entry.value)) {
+      diagnostics.push_back({LogLevel::kError, kSubscriberPutFailed});
+    }
+  }
+}
+
+void EmitDiagnostics(const std::shared_ptr<LogSink>& log_sink,
+                     const SubscriberDiagnostics& diagnostics) {
+  for (const auto& diagnostic : diagnostics) {
+    EmitLog(log_sink, diagnostic.level, kNodeComponent, diagnostic.message);
   }
 }
 
@@ -316,38 +374,63 @@ void StorageNode::OnSample(const std::shared_ptr<State>& state, const TransportS
   auto lease = state->Enter();
   if (!lease) return;
   try {
-    const auto parsed = ParseKey(state->prefix, sample.key);
-    // Batch application is out of scope (#13); invalid keys are unsupported.
-    if (!parsed || parsed->is_batch) {
-      EmitLog(state->log_sink, LogLevel::kWarning, kNodeComponent, kUnsupportedSubscriberKey);
-      return;
-    }
-
-    switch (parsed->kind) {
-      case KeyKind::Base:
-        ApplyWrite(state->log_sink, *state->engine, parsed->relative_key, sample);
-        return;
-      case KeyKind::Session: {
-        std::shared_ptr<StorageEngine> overlay;
-        {
-          std::shared_lock lock(state->session_mutex);
-          auto it = state->overlays.find(parsed->sid);
-          if (it != state->overlays.end()) overlay = it->second;
+    SubscriberDiagnostics diagnostics;
+    {
+      // The gate lease is acquired first. Serializing the entire subscriber
+      // path prevents an ordinary write from becoming visible between batch
+      // entries. Diagnostics are emitted only after releasing this lock.
+      std::scoped_lock application_lock(state->subscriber_mutex);
+      const auto parsed = ParseKey(state->prefix, sample.key);
+      if (!parsed) {
+        diagnostics.push_back({LogLevel::kWarning, kUnsupportedSubscriberKey});
+      } else if (parsed->is_batch) {
+        // ParseKey only marks Base and Session paths as batch paths.
+        if (!IsBatchPut(sample)) {
+          diagnostics.push_back({LogLevel::kWarning, kInvalidBatchOperation});
+        } else if (parsed->kind == KeyKind::Base) {
+          ApplyBatch(diagnostics, *state->engine, sample.payload);
+        } else {
+          std::shared_ptr<StorageEngine> overlay;
+          {
+            std::shared_lock lock(state->session_mutex);
+            auto it = state->overlays.find(parsed->sid);
+            if (it != state->overlays.end()) overlay = it->second;
+          }
+          if (!overlay) {
+            diagnostics.push_back({LogLevel::kWarning, kUnknownSession});
+          } else {
+            ApplyBatch(diagnostics, *overlay, sample.payload);
+          }
         }
-        if (!overlay) {
-          EmitLog(state->log_sink, LogLevel::kWarning, kNodeComponent, kUnknownSession);
-          return;
+      } else {
+        switch (parsed->kind) {
+          case KeyKind::Base:
+            ApplyWrite(diagnostics, *state->engine, parsed->relative_key, sample);
+            break;
+          case KeyKind::Session: {
+            std::shared_ptr<StorageEngine> overlay;
+            {
+              std::shared_lock lock(state->session_mutex);
+              auto it = state->overlays.find(parsed->sid);
+              if (it != state->overlays.end()) overlay = it->second;
+            }
+            if (!overlay) {
+              diagnostics.push_back({LogLevel::kWarning, kUnknownSession});
+            } else {
+              ApplyWrite(diagnostics, *overlay, parsed->relative_key, sample);
+            }
+            break;
+          }
+          case KeyKind::Snapshot:
+            diagnostics.push_back({LogLevel::kWarning, kReadOnlySnapshotKey});
+            break;
+          default:  // MetaSession, MetaAck (#14): not writable via subscriber.
+            diagnostics.push_back({LogLevel::kWarning, kUnsupportedSubscriberKey});
+            break;
         }
-        ApplyWrite(state->log_sink, *overlay, parsed->relative_key, sample);
-        return;
       }
-      case KeyKind::Snapshot:
-        EmitLog(state->log_sink, LogLevel::kWarning, kNodeComponent, kReadOnlySnapshotKey);
-        return;
-      default:  // MetaSession, MetaAck (#14): not writable via subscriber.
-        EmitLog(state->log_sink, LogLevel::kWarning, kNodeComponent, kUnsupportedSubscriberKey);
-        return;
     }
+    EmitDiagnostics(state->log_sink, diagnostics);
   } catch (...) {
     EmitLog(state->log_sink, LogLevel::kError, kNodeComponent, kSubscriberCallbackFailed);
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -112,4 +112,12 @@ if(SITOS_WITH_ZENOH)
   sitos_enable_warnings(sitos_storage_node_session_test)
   sitos_copy_zenohc(sitos_storage_node_session_test)
   gtest_discover_tests(sitos_storage_node_session_test)
+
+  add_executable(sitos_batch_test
+    integration/batch_test.cpp)
+  target_link_libraries(sitos_batch_test
+    PRIVATE GTest::gtest_main sitos::sitos)
+  sitos_enable_warnings(sitos_batch_test)
+  sitos_copy_zenohc(sitos_batch_test)
+  gtest_discover_tests(sitos_batch_test)
 endif()

--- a/tests/integration/batch_test.cpp
+++ b/tests/integration/batch_test.cpp
@@ -1,0 +1,156 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// End-to-end batch delivery over one same-process zenoh session.
+
+#include "sitos/batch.hpp"
+#include "sitos/in_memory_engine.hpp"
+#include "sitos/logging.hpp"
+#include "sitos/param_value.hpp"
+#include "sitos/storage_node.hpp"
+#include "sitos/transport.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using namespace std::chrono_literals;
+
+struct ObservedSample {
+  std::string key;
+  std::vector<std::byte> payload;
+  std::string encoding;
+  int count = 0;
+};
+
+class CaptureSink final : public sitos::LogSink {
+ public:
+  void Write(const sitos::LogRecord& record) override {
+    std::lock_guard lock(mutex_);
+    messages_.emplace_back(record.message);
+  }
+
+  std::vector<std::string> Messages() const {
+    std::lock_guard lock(mutex_);
+    return messages_;
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  std::vector<std::string> messages_;
+};
+
+std::optional<std::vector<std::byte>> GetOne(sitos::Transport& transport,
+                                             std::string_view key) {
+  std::mutex mutex;
+  std::condition_variable cv;
+  std::optional<std::vector<std::byte>> payload;
+  if (!transport
+           .Get(key,
+                [&](std::string_view, std::span<const std::byte> value, sitos::Encoding) {
+                  std::lock_guard lock(mutex);
+                  payload = std::vector<std::byte>(value.begin(), value.end());
+                  cv.notify_all();
+                  return false;
+                },
+                200ms)
+           .IsOk()) {
+    return std::nullopt;
+  }
+  std::unique_lock lock(mutex);
+  if (!cv.wait_for(lock, 300ms, [&] { return payload.has_value(); })) return std::nullopt;
+  return payload;
+}
+
+// A transport Put only confirms submission. Retry exact queries until the
+// subscriber has applied the batch to the selected overlay.
+std::optional<std::vector<std::byte>> GetOneEventually(sitos::Transport& transport,
+                                                        std::string_view key) {
+  for (int attempt = 0; attempt < 20; ++attempt) {
+    if (auto payload = GetOne(transport, key)) return payload;
+  }
+  return std::nullopt;
+}
+
+}  // namespace
+
+TEST(BatchIntegrationTest, BatchIsReceivedBySessionSubscriber) {
+  auto transport = sitos::MakeZenohTransport();
+  ASSERT_TRUE(transport);
+  auto engine = std::make_shared<sitos::InMemoryEngine>();
+  sitos::StorageNode node;
+  auto log_sink = std::make_shared<CaptureSink>();
+  constexpr std::string_view kPrefix = "sitos/batch_test";
+  ASSERT_TRUE(node.Start(engine, *transport,
+                         {.prefix = std::string(kPrefix), .log_sink = log_sink})
+                  .IsOk());
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+
+  auto observed = std::make_shared<ObservedSample>();
+  auto mutex = std::make_shared<std::mutex>();
+  auto cv = std::make_shared<std::condition_variable>();
+  auto observer_result = transport->DeclareSubscriber(
+      "sitos/batch_test/session/s1/**",
+      [observed, mutex, cv](const sitos::TransportSample& sample) {
+        std::lock_guard lock(*mutex);
+        observed->key = sample.key;
+        observed->payload.assign(sample.payload.begin(), sample.payload.end());
+        observed->encoding = sample.encoding.id;
+        ++observed->count;
+        cv->notify_all();
+      });
+  ASSERT_TRUE(observer_result.IsOk());
+  sitos::Subscription observer = std::move(observer_result).Value();
+
+  const std::vector<std::pair<std::string, sitos::ParamValue>> entries = {
+      {"first", sitos::ParamValue(std::int64_t{1})},
+      {"second", sitos::ParamValue("two")},
+  };
+  const auto batch = sitos::EncodeBatch(entries);
+  auto put_result = transport->Put(
+      "sitos/batch_test/session/s1/:batch", batch,
+      sitos::Encoding{std::string(sitos::Encoding::kSitosV1Batch)}, {});
+  ASSERT_TRUE(put_result.IsOk()) << put_result.Error().message();
+
+  auto first = GetOneEventually(*transport, "sitos/batch_test/session/s1/first");
+  ASSERT_TRUE(first.has_value()) << [&] {
+    std::string diagnostics;
+    for (const auto& message : log_sink->Messages()) {
+      if (!diagnostics.empty()) diagnostics.append(", ");
+      diagnostics.append(message);
+    }
+    return diagnostics;
+  }();
+
+  {
+    std::unique_lock lock(*mutex);
+    ASSERT_TRUE(cv->wait_for(lock, 3s, [&] { return observed->count == 1; }));
+    EXPECT_EQ(observed->key, "sitos/batch_test/session/s1/:batch");
+    EXPECT_EQ(observed->payload, batch);
+    EXPECT_EQ(observed->encoding, sitos::Encoding::kSitosV1Batch);
+  }
+
+  auto first_value = sitos::ParamValue::Decode(*first);
+  ASSERT_TRUE(first_value.has_value());
+  EXPECT_EQ(first_value->As<std::int64_t>(), 1);
+  auto second = GetOneEventually(*transport, "sitos/batch_test/session/s1/second");
+  ASSERT_TRUE(second.has_value());
+  auto second_value = sitos::ParamValue::Decode(*second);
+  ASSERT_TRUE(second_value.has_value());
+  EXPECT_EQ(second_value->As<std::string>(), "two");
+
+  observer = sitos::Subscription{};
+  node.Stop();
+}

--- a/tests/unit/key_test.cpp
+++ b/tests/unit/key_test.cpp
@@ -157,24 +157,24 @@ TEST(KeyBuilderTest, RejectsInvalidComponents) {
   EXPECT_FALSE(BuildKey("sitos prefix", "base", "recon/fov"));
 }
 
-// --- $batch builders (docs/03 §1.1) ---
+// --- :batch builders (docs/03 §1.1) ---
 
 TEST(BatchKeyBuilderTest, BuildsBaseBatch) {
   auto key = BuildBatchKey("sitos", "base");
   ASSERT_TRUE(key.has_value());
-  EXPECT_EQ(*key, "sitos/base/$batch");
+  EXPECT_EQ(*key, "sitos/base/:batch");
 }
 
 TEST(BatchKeyBuilderTest, BuildsSessionBatch) {
   auto key = BuildBatchKey("sitos", "session/abc-123");
   ASSERT_TRUE(key.has_value());
-  EXPECT_EQ(*key, "sitos/session/abc-123/$batch");
+  EXPECT_EQ(*key, "sitos/session/abc-123/:batch");
 }
 
 TEST(BatchKeyBuilderTest, BuildsBatchWithCustomPrefix) {
   auto key = BuildBatchKey("my/app", "base");
   ASSERT_TRUE(key.has_value());
-  EXPECT_EQ(*key, "my/app/base/$batch");
+  EXPECT_EQ(*key, "my/app/base/:batch");
 }
 
 TEST(BatchKeyBuilderTest, RejectsSnapBatch) {
@@ -190,9 +190,9 @@ TEST(BatchKeyBuilderTest, RejectsInvalidBatchScope) {
 }
 
 TEST(BatchKeyBuilderTest, UserKeyCannotSmuggleBatch) {
-  // '$' is reserved, so BuildKey rejects "$batch" as a user key. Batch paths
-  // can only be produced through BuildBatchKey.
-  EXPECT_FALSE(BuildKey("sitos", "base", "$batch"));
+  // ':' is outside the user-key grammar, so batch paths can only be produced
+  // through BuildBatchKey.
+  EXPECT_FALSE(BuildKey("sitos", "base", ":batch"));
 }
 
 // --- meta builders (docs/03 §1.1) ---
@@ -231,7 +231,7 @@ TEST(ParseKeyTest, ParsesBaseKey) {
 }
 
 TEST(ParseKeyTest, ParsesBaseBatchKey) {
-  auto p = ParseKey("sitos", "sitos/base/$batch");
+  auto p = ParseKey("sitos", "sitos/base/:batch");
   ASSERT_TRUE(p.has_value());
   EXPECT_EQ(p->kind, KeyKind::Base);
   EXPECT_TRUE(p->relative_key.empty());
@@ -248,7 +248,7 @@ TEST(ParseKeyTest, ParsesSessionKey) {
 }
 
 TEST(ParseKeyTest, ParsesSessionBatchKey) {
-  auto p = ParseKey("sitos", "sitos/session/abc-123/$batch");
+  auto p = ParseKey("sitos", "sitos/session/abc-123/:batch");
   ASSERT_TRUE(p.has_value());
   EXPECT_EQ(p->kind, KeyKind::Session);
   EXPECT_EQ(p->sid, "abc-123");
@@ -305,9 +305,15 @@ TEST(ParseKeyTest, RejectsInvalidKinds) {
   EXPECT_FALSE(ParseKey("sitos", "sitos/meta/ack/bad/uuid"));
 }
 
-TEST(ParseKeyTest, RejectsSnapshotBatch) {
-  // snap has no $batch path; $ fails IsValidKey so the parse is rejected.
-  EXPECT_FALSE(ParseKey("sitos", "sitos/snap/abc-123/$batch"));
+TEST(ParseKeyTest, RejectsUnsupportedBatchForms) {
+  // snap has no :batch path, and retired wire candidates remain invalid.
+  EXPECT_FALSE(ParseKey("sitos", "sitos/snap/abc-123/:batch"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/base/$batch"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/base/@batch"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/base/~batch"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/session/abc-123/$batch"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/session/abc-123/@batch"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/session/abc-123/~batch"));
 }
 
 TEST(ParseKeyTest, RejectsInvalidRelativeKey) {

--- a/tests/unit/storage_node_test.cpp
+++ b/tests/unit/storage_node_test.cpp
@@ -12,6 +12,7 @@
 #include <condition_variable>
 #include <functional>
 #include <future>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -20,6 +21,7 @@
 #include <utility>
 #include <vector>
 
+#include "sitos/batch.hpp"
 #include "sitos/in_memory_engine.hpp"
 #include "sitos/logging.hpp"
 #include "sitos/param_value.hpp"
@@ -682,7 +684,7 @@ TEST(StorageNodeSubscriberTest, IgnoresUnsupportedPathsAndWarns) {
   transport.InvokeSubscriber("sitos/snap/session-1/ignored", del, {std::byte{0x01}}, {});
   transport.InvokeSubscriber("sitos/session/session-1/ignored", put, {std::byte{0x01}}, {});
   transport.InvokeSubscriber("sitos/meta/session/session-1", put, {std::byte{0x01}}, {});
-  transport.InvokeSubscriber("sitos/base/$batch", put, {std::byte{0x01}}, {});
+  transport.InvokeSubscriber("sitos/base/:batch", put, {std::byte{0x01}}, {});
   transport.InvokeSubscriber("sitos/base/", put, {std::byte{0x01}}, {});
   transport.InvokeSubscriber("sitos/base/bad*", put, {std::byte{0x01}}, {});
 
@@ -761,7 +763,260 @@ void PutSession(FakeTransport& transport, std::string_view sid, std::string_view
       TransportSample::Kind::Put, std::move(value), kV1);
 }
 
+std::vector<std::byte> MakeBatch(
+    std::initializer_list<std::pair<std::string, ParamValue>> entries) {
+  return EncodeBatch(std::span<const std::pair<std::string, ParamValue>>(entries.begin(),
+                                                                          entries.size()));
+}
+
+class FirstPutBlockingEngine final : public StorageEngine {
+ public:
+  bool Put(std::string_view key, Bytes value) override {
+    std::unique_lock lock(mutex_);
+    if (puts_.empty()) {
+      first_put_entered_ = true;
+      cv_.notify_all();
+      cv_.wait(lock, [this] { return release_; });
+    }
+    puts_.push_back(std::string(key));
+    values_[std::string(key)] = std::vector<std::byte>(value.begin(), value.end());
+    return true;
+  }
+
+  bool Delete(std::string_view) override { return false; }
+  bool Get(std::string_view key, const EntrySink& sink) const override {
+    std::lock_guard lock(mutex_);
+    auto it = values_.find(std::string(key));
+    if (it == values_.end()) return false;
+    sink(it->first, it->second);
+    return true;
+  }
+  bool List(std::string_view, const EntrySink&) const override { return false; }
+
+  void WaitForFirstPut() {
+    std::unique_lock lock(mutex_);
+    ASSERT_TRUE(cv_.wait_for(lock, std::chrono::seconds(2), [this] { return first_put_entered_; }));
+  }
+  void Release() {
+    std::lock_guard lock(mutex_);
+    release_ = true;
+    cv_.notify_all();
+  }
+  std::vector<std::string> Puts() const {
+    std::lock_guard lock(mutex_);
+    return puts_;
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  std::condition_variable cv_;
+  bool first_put_entered_ = false;
+  bool release_ = false;
+  std::vector<std::string> puts_;
+  std::map<std::string, std::vector<std::byte>, std::less<>> values_;
+};
+
+class FirstPutFailingEngine final : public StorageEngine {
+ public:
+  bool Put(std::string_view key, Bytes value) override {
+    puts.push_back(std::string(key));
+    if (puts.size() == 1) return false;
+    return backing.Put(key, value);
+  }
+  bool Delete(std::string_view) override { return false; }
+  bool Get(std::string_view key, const EntrySink& sink) const override {
+    return backing.Get(key, sink);
+  }
+  bool List(std::string_view prefix, const EntrySink& sink) const override {
+    return backing.List(prefix, sink);
+  }
+
+  std::vector<std::string> puts;
+
+ private:
+  InMemoryEngine backing;
+};
+
 }  // namespace
+
+TEST(StorageNodeBatchTest, BaseBatchAppliesEntriesInOrderAndUsesPayloadV1) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos"}).IsOk());
+
+  const auto batch = MakeBatch({{"a", ParamValue(std::int64_t{1})},
+                                {"b", ParamValue("two")},
+                                {"a", ParamValue(std::int64_t{3})}});
+  transport.InvokeSubscriber("sitos/base/:batch", TransportSample::Kind::Put, batch,
+                             Encoding{std::string(Encoding::kSitosV1Batch)});
+
+  const auto a = transport.Invoke("sitos/base/a");
+  ASSERT_EQ(a.size(), 1u);
+  EXPECT_EQ(a[0].encoding.id, Encoding::kSitosV1);
+  auto a_value = ParamValue::Decode(a[0].payload);
+  ASSERT_TRUE(a_value.has_value());
+  EXPECT_EQ(a_value->As<std::int64_t>(), 3);
+  const auto b = transport.Invoke("sitos/base/b");
+  ASSERT_EQ(b.size(), 1u);
+  auto b_value = ParamValue::Decode(b[0].payload);
+  ASSERT_TRUE(b_value.has_value());
+  EXPECT_EQ(b_value->As<std::string>(), "two");
+}
+
+TEST(StorageNodeBatchTest, SessionBatchOnlyUpdatesSelectedOverlay) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos"}).IsOk());
+  ASSERT_TRUE(node.CreateSession("one").IsOk());
+  ASSERT_TRUE(node.CreateSession("two").IsOk());
+
+  const auto batch = MakeBatch({{"setting", ParamValue("value")}});
+  transport.InvokeSubscriber("sitos/session/one/:batch", TransportSample::Kind::Put, batch,
+                             Encoding{std::string(Encoding::kSitosV1Batch)});
+
+  ASSERT_EQ(transport.Invoke("sitos/session/one/setting").size(), 1u);
+  EXPECT_TRUE(transport.Invoke("sitos/session/two/setting").empty());
+  EXPECT_TRUE(transport.Invoke("sitos/base/setting").empty());
+}
+
+TEST(StorageNodeBatchTest, RejectsInvalidBatchBeforeAnyMutationAndWarns) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  auto sink = std::make_shared<CaptureSink>();
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = sink}).IsOk());
+
+  auto truncated = MakeBatch({{"first", ParamValue(std::int64_t{1})},
+                              {"truncated", ParamValue(std::int64_t{2})}});
+  truncated.pop_back();
+  transport.InvokeSubscriber("sitos/base/:batch", TransportSample::Kind::Put, truncated,
+                             Encoding{std::string(Encoding::kSitosV1Batch)});
+  const auto invalid_key = MakeBatch({{"good", ParamValue(std::int64_t{1})},
+                                      {"bad*", ParamValue(std::int64_t{2})}});
+  transport.InvokeSubscriber("sitos/base/:batch", TransportSample::Kind::Put, invalid_key,
+                             Encoding{std::string(Encoding::kSitosV1Batch)});
+
+  EXPECT_TRUE(transport.Invoke("sitos/base/first").empty());
+  EXPECT_TRUE(transport.Invoke("sitos/base/good").empty());
+  const auto records = sink->Records();
+  ASSERT_EQ(records.size(), 2u);
+  EXPECT_EQ(records[0].level, LogLevel::kWarning);
+  EXPECT_EQ(records[1].level, LogLevel::kWarning);
+}
+
+TEST(StorageNodeBatchTest, RejectsTrailingBytesAndUnknownTagWithoutMutation) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  auto sink = std::make_shared<CaptureSink>();
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = sink}).IsOk());
+
+  auto trailing = MakeBatch({{"trailing", ParamValue(std::int64_t{1})}});
+  trailing.push_back(std::byte{0x00});
+  transport.InvokeSubscriber("sitos/base/:batch", TransportSample::Kind::Put, trailing,
+                             Encoding{std::string(Encoding::kSitosV1Batch)});
+
+  // One entry: count, key length, key, invalid tag, and zero value length.
+  const std::vector<std::byte> unknown_tag = {
+      std::byte{0x01}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00},
+      std::byte{0x01}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00},
+      std::byte{'x'},  std::byte{0xFF}, std::byte{0x00}, std::byte{0x00},
+      std::byte{0x00}, std::byte{0x00}};
+  transport.InvokeSubscriber("sitos/base/:batch", TransportSample::Kind::Put, unknown_tag,
+                             Encoding{std::string(Encoding::kSitosV1Batch)});
+
+  EXPECT_TRUE(transport.Invoke("sitos/base/trailing").empty());
+  EXPECT_TRUE(transport.Invoke("sitos/base/x").empty());
+  const auto records = sink->Records();
+  ASSERT_EQ(records.size(), 2u);
+  EXPECT_EQ(records[0].message, "malformed batch payload");
+  EXPECT_EQ(records[1].message, "malformed batch payload");
+}
+
+TEST(StorageNodeBatchTest, RejectsWrongOperationAndEncodingButPreservesOrdinaryFallback) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  auto sink = std::make_shared<CaptureSink>();
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = sink}).IsOk());
+  const auto batch = MakeBatch({{"entry", ParamValue(std::int64_t{1})}});
+
+  transport.InvokeSubscriber("sitos/base/:batch", TransportSample::Kind::Put, batch, kV1);
+  transport.InvokeSubscriber("sitos/base/:batch", TransportSample::Kind::Delete, {},
+                             Encoding{std::string(Encoding::kSitosV1Batch)});
+  transport.InvokeSubscriber("sitos/base/$batch", TransportSample::Kind::Put, batch,
+                             Encoding{std::string(Encoding::kSitosV1Batch)});
+  transport.InvokeSubscriber("sitos/base/@batch", TransportSample::Kind::Put, batch,
+                             Encoding{std::string(Encoding::kSitosV1Batch)});
+  transport.InvokeSubscriber("sitos/base/ordinary", TransportSample::Kind::Put, batch,
+                             Encoding{std::string(Encoding::kSitosV1Batch)});
+
+  EXPECT_TRUE(transport.Invoke("sitos/base/entry").empty());
+  transport.InvokeSubscriber("sitos/session/nope/:batch", TransportSample::Kind::Put, batch,
+                             Encoding{std::string(Encoding::kSitosV1Batch)});
+  transport.InvokeSubscriber("sitos/snap/nope/:batch", TransportSample::Kind::Put, batch,
+                             Encoding{std::string(Encoding::kSitosV1Batch)});
+  EXPECT_TRUE(transport.Invoke("sitos/session/nope/entry").empty());
+  const auto ordinary = transport.Invoke("sitos/base/ordinary");
+  ASSERT_EQ(ordinary.size(), 1u);
+  ASSERT_FALSE(ordinary[0].payload.empty());
+  EXPECT_EQ(ordinary[0].payload[0], std::byte{0x04});
+  EXPECT_EQ(sink->Records().size(), 7u);
+}
+
+TEST(StorageNodeBatchTest, ContinuesAfterEngineFailureInEncodedOrder) {
+  auto engine = std::make_shared<FirstPutFailingEngine>();
+  FakeTransport transport;
+  auto sink = std::make_shared<CaptureSink>();
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = sink}).IsOk());
+  const auto batch = MakeBatch({{"first", ParamValue(std::int64_t{1})},
+                                {"later", ParamValue(std::int64_t{2})}});
+
+  transport.InvokeSubscriber("sitos/base/:batch", TransportSample::Kind::Put, batch,
+                             Encoding{std::string(Encoding::kSitosV1Batch)});
+
+  EXPECT_EQ(engine->puts, (std::vector<std::string>{"first", "later"}));
+  EXPECT_TRUE(transport.Invoke("sitos/base/first").empty());
+  ASSERT_EQ(transport.Invoke("sitos/base/later").size(), 1u);
+  const auto records = sink->Records();
+  ASSERT_EQ(records.size(), 1u);
+  EXPECT_EQ(records[0].level, LogLevel::kError);
+}
+
+TEST(StorageNodeBatchTest, SerializesBatchAndOrdinaryWritesAndStopWaits) {
+  auto engine = std::make_shared<FirstPutBlockingEngine>();
+  FakeTransport transport;
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos"}).IsOk());
+  const auto batch = MakeBatch({{"first", ParamValue(std::int64_t{1})},
+                                {"second", ParamValue(std::int64_t{2})}});
+
+  std::thread batch_callback([&] {
+    transport.InvokeSubscriber("sitos/base/:batch", TransportSample::Kind::Put, batch,
+                               Encoding{std::string(Encoding::kSitosV1Batch)});
+  });
+  engine->WaitForFirstPut();
+  std::thread ordinary_callback([&] {
+    PutBase(transport, "ordinary", {std::byte{0x04}, std::byte{0x01}});
+  });
+
+  std::atomic<bool> stopped{false};
+  std::thread stopper([&] {
+    node.Stop();
+    stopped.store(true, std::memory_order_release);
+  });
+  EXPECT_FALSE(stopped.load(std::memory_order_acquire));
+  engine->Release();
+  batch_callback.join();
+  ordinary_callback.join();
+  stopper.join();
+
+  EXPECT_EQ(engine->Puts(), (std::vector<std::string>{"first", "second", "ordinary"}));
+  EXPECT_TRUE(stopped.load(std::memory_order_acquire));
+}
 
 TEST(StorageNodeSessionTest, SnapshotIsIsolatedFromBasePut) {
   auto engine = std::make_shared<InMemoryEngine>();

--- a/tests/unit/storage_node_test.cpp
+++ b/tests/unit/storage_node_test.cpp
@@ -864,6 +864,23 @@ TEST(StorageNodeBatchTest, BaseBatchAppliesEntriesInOrderAndUsesPayloadV1) {
   EXPECT_EQ(b_value->As<std::string>(), "two");
 }
 
+TEST(StorageNodeBatchTest, EmptyBatchIsValidNoOp) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  auto sink = std::make_shared<CaptureSink>();
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = sink}).IsOk());
+
+  PutBase(transport, "existing", {std::byte{0x04}, std::byte{0x01}});
+  transport.InvokeSubscriber("sitos/base/:batch", TransportSample::Kind::Put, MakeBatch({}),
+                             Encoding{std::string(Encoding::kSitosV1Batch)});
+
+  const auto existing = transport.Invoke("sitos/base/existing");
+  ASSERT_EQ(existing.size(), 1u);
+  EXPECT_EQ(existing[0].payload, (std::vector<std::byte>{std::byte{0x04}, std::byte{0x01}}));
+  EXPECT_TRUE(sink->Records().empty());
+}
+
 TEST(StorageNodeBatchTest, SessionBatchOnlyUpdatesSelectedOverlay) {
   auto engine = std::make_shared<InMemoryEngine>();
   FakeTransport transport;

--- a/tests/unit/storage_node_test.cpp
+++ b/tests/unit/storage_node_test.cpp
@@ -677,8 +677,8 @@ TEST(StorageNodeSubscriberTest, IgnoresUnsupportedPathsAndWarns) {
 
   const auto put = TransportSample::Kind::Put;
   const auto del = TransportSample::Kind::Delete;
-  // snap/** is read-only; session/<sid> with no active session is unknown; the
-  // remaining paths (meta write, batch, invalid base keys) are unsupported.
+  // snap/** is read-only; session/<sid> with no active session is unknown; an
+  // incorrectly encoded batch and remaining invalid paths are rejected.
   transport.InvokeSubscriber("sitos/snap/session-1/ignored", put, {std::byte{0x01}},
                              Encoding{"unknown"});
   transport.InvokeSubscriber("sitos/snap/session-1/ignored", del, {std::byte{0x01}}, {});
@@ -696,7 +696,7 @@ TEST(StorageNodeSubscriberTest, IgnoresUnsupportedPathsAndWarns) {
   }));
   const std::vector<std::string> expected_messages = {
       "read-only snapshot key", "read-only snapshot key",  "unknown session",
-      "unsupported subscriber key", "unsupported subscriber key",
+      "unsupported subscriber key", "invalid batch operation or encoding",
       "unsupported subscriber key", "unsupported subscriber key"};
   const auto records = sink->Records();
   ASSERT_EQ(records.size(), expected_messages.size());
@@ -967,6 +967,8 @@ TEST(StorageNodeBatchTest, RejectsWrongOperationAndEncodingButPreservesOrdinaryF
                              Encoding{std::string(Encoding::kSitosV1Batch)});
   transport.InvokeSubscriber("sitos/base/@batch", TransportSample::Kind::Put, batch,
                              Encoding{std::string(Encoding::kSitosV1Batch)});
+  transport.InvokeSubscriber("sitos/base/~batch", TransportSample::Kind::Put, batch,
+                             Encoding{std::string(Encoding::kSitosV1Batch)});
   transport.InvokeSubscriber("sitos/base/ordinary", TransportSample::Kind::Put, batch,
                              Encoding{std::string(Encoding::kSitosV1Batch)});
 
@@ -980,7 +982,7 @@ TEST(StorageNodeBatchTest, RejectsWrongOperationAndEncodingButPreservesOrdinaryF
   ASSERT_EQ(ordinary.size(), 1u);
   ASSERT_FALSE(ordinary[0].payload.empty());
   EXPECT_EQ(ordinary[0].payload[0], std::byte{0x04});
-  EXPECT_EQ(sink->Records().size(), 7u);
+  EXPECT_EQ(sink->Records().size(), 8u);
 }
 
 TEST(StorageNodeBatchTest, ContinuesAfterEngineFailureInEncodedOrder) {
@@ -1003,7 +1005,7 @@ TEST(StorageNodeBatchTest, ContinuesAfterEngineFailureInEncodedOrder) {
   EXPECT_EQ(records[0].level, LogLevel::kError);
 }
 
-TEST(StorageNodeBatchTest, SerializesBatchAndOrdinaryWritesAndStopWaits) {
+TEST(StorageNodeBatchTest, SerializesBatchAndOrdinaryWrites) {
   auto engine = std::make_shared<FirstPutBlockingEngine>();
   FakeTransport transport;
   StorageNode node;
@@ -1016,22 +1018,47 @@ TEST(StorageNodeBatchTest, SerializesBatchAndOrdinaryWritesAndStopWaits) {
                                Encoding{std::string(Encoding::kSitosV1Batch)});
   });
   engine->WaitForFirstPut();
+  std::promise<void> ordinary_started;
+  auto ordinary_ready = ordinary_started.get_future();
   std::thread ordinary_callback([&] {
+    ordinary_started.set_value();
     PutBase(transport, "ordinary", {std::byte{0x04}, std::byte{0x01}});
   });
+  ordinary_ready.wait();
+  EXPECT_TRUE(engine->Puts().empty());
 
-  std::atomic<bool> stopped{false};
-  std::thread stopper([&] {
-    node.Stop();
-    stopped.store(true, std::memory_order_release);
-  });
-  EXPECT_FALSE(stopped.load(std::memory_order_acquire));
   engine->Release();
   batch_callback.join();
   ordinary_callback.join();
-  stopper.join();
-
   EXPECT_EQ(engine->Puts(), (std::vector<std::string>{"first", "second", "ordinary"}));
+}
+
+TEST(StorageNodeBatchTest, StopWaitsForInFlightBatch) {
+  auto engine = std::make_shared<FirstPutBlockingEngine>();
+  FakeTransport transport;
+  StorageNode node;
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos"}).IsOk());
+  const auto batch = MakeBatch({{"first", ParamValue(std::int64_t{1})}});
+
+  std::thread batch_callback([&] {
+    transport.InvokeSubscriber("sitos/base/:batch", TransportSample::Kind::Put, batch,
+                               Encoding{std::string(Encoding::kSitosV1Batch)});
+  });
+  engine->WaitForFirstPut();
+  std::atomic<bool> stopped{false};
+  std::promise<void> stopper_called;
+  auto stopper_ready = stopper_called.get_future();
+  std::thread stopper([&] {
+    stopper_called.set_value();
+    node.Stop();
+    stopped.store(true, std::memory_order_release);
+  });
+  stopper_ready.wait();
+  EXPECT_FALSE(stopped.load(std::memory_order_acquire));
+
+  engine->Release();
+  batch_callback.join();
+  stopper.join();
   EXPECT_TRUE(stopped.load(std::memory_order_acquire));
 }
 


### PR DESCRIPTION
Closes #13

## Summary

Deliver validated base/session batches through the normal subscriber range and
reserve `:batch` as the Zenoh-valid batch control segment.

## Scope

- [x] StorageNode subscriber handles `<prefix>/base/:batch` and
      `<prefix>/session/<sid>/:batch` (batch codec from #4)
- [x] All entries of a batch are applied to the engine/overlay before the next
      message is processed (atomicity within the node)
- [x] Malformed batch payloads are rejected with a warning (nothing applied)
- [x] Verify batch keys fall inside the normal subscription ranges
      (`base/**`, `session/<sid>/**`) so subscribers need no extra declarations —
      test name `BatchIsReceivedBySessionSubscriber`
- [x] `tests/integration/batch_test.cpp`

## Requirements

- [x] F09: receive and apply one `sitos.v1.batch` sample at `base/:batch` or
  `session/<sid>/:batch`.
- [x] C01: decode every entry as payload-v1 and persist normal payload-v1 bytes.
- [x] C02: validate the complete batch before its first write; malformed input
  performs zero writes.
- [x] ADR-0018: use Zenoh-valid and wildcard-deliverable `:batch`; `$batch`,
  `@batch`, and `~batch` remain rejected with zero mutation.

## Acceptance Criteria Verification

- Base/session batches apply in encoded order; duplicate keys are later-wins.
- Invalid key, truncation, trailing bytes, unknown tag, wrong Encoding/operation,
  unsupported scope, and unknown session paths log and do not mutate.
- The node serializes subscriber application, so an ordinary write cannot
  interleave a batch. Stop waits for an in-flight batch. Concurrent queries are
  not reader-atomic and may observe a partially applied batch, as documented.
- `BatchIsReceivedBySessionSubscriber` proves a normal `session/<sid>/**`
  observer receives exactly the original `:batch` sample and the node applies it.
- No StorageEngine transaction API, ParamStore, ParamCache, ack, or wire aliases
  were added.

## RED-phase Confirmation

Initial StorageNode batch RED:

```text
ctest --test-dir build-off -R StorageNodeBatchTest
4/6 batch tests failed: base/session batches were logged as
"unsupported subscriber key" and no entries were stored.
```

The required Zenoh integration exposed the historical wire defect: `$batch`
failed at `Transport::Put`, while `@batch` submitted but was not delivered to
normal `/**` subscribers. Focused same-session probes verified that `:batch` is
accepted and delivered through the normal wildcard range.

Before the final commit history was restacked, the `:batch` acceptance tests
were changed before production:

```text
ctest --test-dir build-off -C Debug --output-on-failure \
  -R "sitos_key_test|StorageNodeBatchTest"

11% tests passed, 8 tests failed out of 9
StorageNodeBatchTest.BaseBatchAppliesEntriesInOrderAndUsesPayloadV1: expected 1 reply, got 0
StorageNodeBatchTest.RejectsWrongOperationAndEncodingButPreservesOrdinaryFallback:
  retired ~batch was still applied
```

## Validation

- Windows/MSVC, Zenoh OFF: 156/156 tests passed.
- Windows/MSVC, Zenoh ON: 184/184 tests passed.
- `BatchIntegrationTest.BatchIsReceivedBySessionSubscriber`: 3/3 repeated runs passed.
- `git diff --check`, changed-code 100-column check, internal-keyword check, and
  changed-file secret scan passed.
- Review follow-ups were folded into their owning commits, and the resulting
  Git tree was fully revalidated before the force-with-lease update.

## ADR Needed

Yes — ADR-0018 is **Accepted**. It selects `:batch` after zenoh-c 1.9.0
construction, wildcard-intersection, same-session delivery validation, and
completed adversarial review.
