### PR TITLE
[ADR] feat(transport): add client result foundation (#85)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,8 @@ endfunction()
 
 # Core library
 add_library(sitos STATIC
+  src/client_config.cpp
+  src/status.cpp
   src/param_value.cpp
   src/batch.cpp
   src/key.cpp

--- a/docs/04_api_cpp.md
+++ b/docs/04_api_cpp.md
@@ -32,23 +32,48 @@ public:
     static std::optional<ParamValue> Decode(std::span<const std::byte> payload);
 };
 
-/// Result with error information
+/// Result with an exclusive value or ErrorInfo state. See include/sitos/result.hpp.
 template<typename T>
-struct Result {
-    std::optional<T> value;
-    Status status;            // enum class Status { Ok, NotFound, TypeMismatch,
-                              //   Timeout, Disconnected, ReadOnly, InvalidKey, Error }
-    std::string message;      // Human-readable details
-    explicit operator bool() const { return status == Status::Ok; }
+class Result {
+public:
+    static Result Ok(T value);
+    static Result Err(std::error_code cause);
+    static Result Err(Status status, std::string message = {},
+                      std::error_code cause = {});
+    template<typename U> static Result ErrFrom(const Result<U>& source);
+    bool IsOk() const noexcept;
+    Status StatusCode() const noexcept;
+    std::string_view Message() const noexcept;
+    const T& Value() const &;  // Requires IsOk().
+    T& Value() &;              // Requires IsOk().
+    T&& Value() &&;            // Requires IsOk().
+    const std::error_code& Error() const;  // Requires !IsOk().
 };
 
-/// Specialization for void. Used by APIs that return only Status (`Result<void>`).
-template<>
-struct Result<void> {
+/// Result<void> has the same status/error observers without a value.
+template<> class Result<void>;
+
+/// Public error state containing stable classification, diagnostics, and native cause.
+struct ErrorInfo {
     Status status;
     std::string message;
-    explicit operator bool() const { return status == Status::Ok; }
+    std::error_code cause;
 };
+
+enum class Status {
+    Ok, NotFound, TypeMismatch, Timeout, Disconnected, ReadOnly, InvalidKey,
+    InvalidArgument, Error
+};
+const std::error_category& StatusErrorCategory() noexcept;
+std::error_code MakeErrorCode(Status status);
+
+/// Shared client configuration. Empty JSON is invalid; nullopt selects Zenoh defaults.
+struct ClientConfig {
+    std::string prefix = "sitos";
+    std::optional<std::string> zenoh_config_json;
+    std::chrono::milliseconds query_timeout{5000};
+};
+Result<void> ValidateClientConfig(const ClientConfig& config);
 
 struct Config {
     std::string prefix = "sitos";
@@ -95,6 +120,7 @@ zenoh session injection [X04] is performed by converting the session to
 | `Disconnected` | zenoh session disconnected, StorageNode stopped | `sitos.DisconnectedError` |
 | `ReadOnly` | put/delete through the library API to `snap/<sid>/**` | `sitos.ReadOnlyError` |
 | `InvalidKey` | Key/scope/session id violates the grammar | `ValueError` |
+| `InvalidArgument` | Invalid configuration or operation argument | `ValueError` |
 | `Error` | Other implementation-dependent error (RocksDB status, etc.) | `sitos.SitosError` |
 
 Python `get(..., default=...)` does not raise for `NotFound` only; it returns default.

--- a/docs/04_api_cpp.md
+++ b/docs/04_api_cpp.md
@@ -53,6 +53,9 @@ public:
 /// Result<void> has the same status/error observers without a value.
 template<> class Result<void>;
 
+// Message() borrows the diagnostic string. Its view remains valid only while
+// the Result and its error state live, and assignment or move invalidates it.
+
 /// Public error state containing stable classification, diagnostics, and native cause.
 struct ErrorInfo {
     Status status;
@@ -60,9 +63,17 @@ struct ErrorInfo {
     std::error_code cause;
 };
 
+// Numeric values are stable because MakeErrorCode publishes them.
 enum class Status {
-    Ok, NotFound, TypeMismatch, Timeout, Disconnected, ReadOnly, InvalidKey,
-    InvalidArgument, Error
+    Ok = 0,
+    NotFound = 1,
+    TypeMismatch = 2,
+    Timeout = 3,
+    Disconnected = 4,
+    ReadOnly = 5,
+    InvalidKey = 6,
+    InvalidArgument = 7,
+    Error = 8
 };
 const std::error_category& StatusErrorCategory() noexcept;
 std::error_code MakeErrorCode(Status status);

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -49,7 +49,6 @@ to `nullptr`. Configuration text is never retained or included in diagnostics.
 Client-facing status classification and `ClientConfig` validation are dependency-free and
 live in `status.hpp`, `result.hpp`, and `client_config.hpp`.
 
-Only the transport adapter uses the zenoh-c API directly.
 Higher-level components see only the following abstract API.
 
 ```cpp

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -39,6 +39,16 @@ zenoh-c >= 1.9.0, < 2.0
 
 ## 3. Transport adapter
 
+Only the transport adapter uses the zenoh-c API directly. `OpenZenohTransport` accepts an
+optional complete JSON5 configuration and returns `Result<std::unique_ptr<Transport>>`;
+`nullopt` selects `z_config_default()`, an empty or malformed configuration is
+`Status::InvalidArgument`, and parse-success/session-open failures retain their native
+cause. `MakeZenohTransport()` remains the compatibility wrapper that converts any failure
+to `nullptr`. Configuration text is never retained or included in diagnostics.
+
+Client-facing status classification and `ClientConfig` validation are dependency-free and
+live in `status.hpp`, `result.hpp`, and `client_config.hpp`.
+
 Only the transport adapter uses the zenoh-c API directly.
 Higher-level components see only the following abstract API.
 

--- a/docs/adr/0019-client-result-status-configuration.md
+++ b/docs/adr/0019-client-result-status-configuration.md
@@ -1,6 +1,6 @@
 # ADR-0019: Additive client result and configuration foundation
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-07-16
 
 ## Context

--- a/docs/adr/0019-client-result-status-configuration.md
+++ b/docs/adr/0019-client-result-status-configuration.md
@@ -6,9 +6,10 @@
 ## Context
 
 Higher-level synchronous clients need stable status classification, diagnostic
-messages, native error causes, and shared connection configuration. The
-existing `Result<T>` only carried an error code and is already used by the
-transport and storage APIs, so replacing it would break source compatibility.
+messages, native error causes, and shared connection configuration. The error
+state of the existing implemented `Result<T>` only carried a `std::error_code`
+and is already used by the transport and storage APIs, so replacing it would
+break source compatibility.
 
 ## Decision
 

--- a/docs/adr/0019-client-result-status-configuration.md
+++ b/docs/adr/0019-client-result-status-configuration.md
@@ -1,0 +1,42 @@
+# ADR-0019: Additive client result and configuration foundation
+
+- Status: Proposed
+- Date: 2026-07-16
+
+## Context
+
+Higher-level synchronous clients need stable status classification, diagnostic
+messages, native error causes, and shared connection configuration. The
+existing `Result<T>` only carried an error code and is already used by the
+transport and storage APIs, so replacing it would break source compatibility.
+
+## Decision
+
+Add a public `Status` enumeration and status error category, and extend
+`Result<T>` additively while preserving its existing factories, state queries,
+value accessors, and native `Error()` cause. Results use exclusive value/error
+states. New errors carry `ErrorInfo{Status, message, cause}`; `ErrFrom` copies
+error information between result value types without requiring the source
+value to be copyable. Legacy error-code construction uses the closed portable
+`std::errc` mapping defined in the public result contract.
+
+Add dependency-free `ClientConfig` and `ValidateClientConfig`. Prefix grammar,
+positive query timeout, and empty optional JSON configuration are validated
+before transport work. Nonempty JSON5 is parsed as a complete Zenoh
+configuration by the transport adapter. The public `OpenZenohTransport`
+factory returns a status-bearing result, while `MakeZenohTransport` remains a
+lossy nullptr-returning compatibility wrapper.
+
+The public umbrella header contains the existing dependency-free API. Library
+sources continue to include direct headers, and no raw Zenoh header is exposed
+outside `src/transport/`.
+
+## Consequences
+
+- Existing transport and storage callers continue to compile and retain native
+  error-code comparisons.
+- ParamStore and ParamCache can share configuration and status semantics.
+- The synchronous Get completion and callback lifetime contract remains a
+  separate decision in ADR-0020.
+- This ADR must be accepted after implementation review and before merging the
+  issue.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,3 +23,4 @@ See [docs/10_adr_process.md](../10_adr_process.md) for the process.
 | [0016](0016-use-canonical-zenoh-bytes-encodings.md) | Use canonical zenoh bytes encodings |
 | [0017](0017-atomic-storage-node-lifecycle.md) | Use atomic, quiescent StorageNode lifecycle transitions |
 | [0018](0018-use-zenoh-valid-batch-key-segment.md) | Use a zenoh-valid batch key segment |
+| [0019](0019-client-result-status-configuration.md) | Additive client result and configuration foundation |

--- a/include/sitos/client_config.hpp
+++ b/include/sitos/client_config.hpp
@@ -1,0 +1,25 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SITOS_CLIENT_CONFIG_HPP
+#define SITOS_CLIENT_CONFIG_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+
+#include "sitos/result.hpp"
+
+namespace sitos {
+
+struct ClientConfig {
+  std::string prefix = "sitos";
+  std::optional<std::string> zenoh_config_json;
+  std::chrono::milliseconds query_timeout{5000};
+};
+
+Result<void> ValidateClientConfig(const ClientConfig& config);
+
+}  // namespace sitos
+
+#endif  // SITOS_CLIENT_CONFIG_HPP

--- a/include/sitos/result.hpp
+++ b/include/sitos/result.hpp
@@ -1,0 +1,183 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SITOS_RESULT_HPP
+#define SITOS_RESULT_HPP
+
+#include <cassert>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#include "sitos/status.hpp"
+
+namespace sitos {
+
+/// Error state carried by Result. `cause` is always the effective, nonzero
+/// native or synthesized error code returned by Result::Error().
+struct ErrorInfo {
+  Status status;
+  std::string message;
+  std::error_code cause;
+};
+
+namespace detail {
+
+inline Status StatusFromErrorCode(const std::error_code& error) noexcept {
+  // Only the portable generic category participates in the closed mapping.
+  // In particular, custom categories must not be classified by their names or
+  // diagnostic messages.
+  if (&error.category() != &std::generic_category()) return Status::Error;
+  if (error == std::errc::invalid_argument) return Status::InvalidArgument;
+  if (error == std::errc::timed_out) return Status::Timeout;
+  if (error == std::errc::not_connected || error == std::errc::connection_aborted ||
+      error == std::errc::connection_refused || error == std::errc::connection_reset ||
+      error == std::errc::network_down || error == std::errc::network_reset ||
+      error == std::errc::network_unreachable || error == std::errc::host_unreachable ||
+      error == std::errc::broken_pipe) {
+    return Status::Disconnected;
+  }
+  return Status::Error;
+}
+
+inline ErrorInfo MakeErrorInfo(Status status, std::string message,
+                               std::error_code cause) {
+  assert(status != Status::Ok);
+  if (status == Status::Ok) status = Status::Error;
+  if (!cause) cause = MakeErrorCode(status);
+  return ErrorInfo{status, std::move(message), cause};
+}
+
+inline ErrorInfo MakeLegacyErrorInfo(std::error_code cause) {
+  assert(static_cast<bool>(cause));
+  if (!cause) return MakeErrorInfo(Status::Error, {}, {});
+  return MakeErrorInfo(StatusFromErrorCode(cause), {}, cause);
+}
+
+}  // namespace detail
+
+/// A move-friendly, exclusive success-or-error result.
+template <typename T>
+class Result {
+ public:
+  static Result Ok(T value) { return Result(std::move(value)); }
+
+  static Result Err(std::error_code cause) {
+    return Result(detail::MakeLegacyErrorInfo(cause));
+  }
+
+  static Result Err(Status status, std::string message = {}, std::error_code cause = {}) {
+    return Result(detail::MakeErrorInfo(status, std::move(message), cause));
+  }
+
+  bool IsOk() const noexcept { return std::holds_alternative<T>(state_); }
+  explicit operator bool() const noexcept { return IsOk(); }
+
+  /// Returns Status::Ok and an empty view for a successful result.
+  Status StatusCode() const noexcept {
+    if (IsOk()) return Status::Ok;
+    return std::get<ErrorInfo>(state_).status;
+  }
+
+  /// Returns a view into the error state's diagnostic message.
+  /// The view is invalidated by Result assignment or move.
+  std::string_view Message() const noexcept {
+    if (IsOk()) return {};
+    return std::get<ErrorInfo>(state_).message;
+  }
+
+  /// Requires IsOk().
+  const T& Value() const & {
+    assert(IsOk());
+    return std::get<T>(state_);
+  }
+  /// Requires IsOk().
+  T& Value() & {
+    assert(IsOk());
+    return std::get<T>(state_);
+  }
+  /// Requires IsOk().
+  T&& Value() && {
+    assert(IsOk());
+    return std::move(std::get<T>(state_));
+  }
+
+  /// Requires !IsOk(). The returned reference is owned by this Result.
+  const std::error_code& Error() const {
+    assert(!IsOk());
+    return std::get<ErrorInfo>(state_).cause;
+  }
+
+  /// Propagates an error without accessing or copying source's value.
+  template <typename U>
+  static Result ErrFrom(const Result<U>& source) {
+    assert(!source.IsOk());
+    if (source.IsOk()) return Err(Status::Error);
+    const auto& info = std::get<ErrorInfo>(source.state_);
+    return Result(info);
+  }
+
+ private:
+  explicit Result(T value) : state_(std::move(value)) {}
+  explicit Result(ErrorInfo info) : state_(std::move(info)) {}
+
+  template <typename>
+  friend class Result;
+  std::variant<T, ErrorInfo> state_;
+};
+
+template <>
+class Result<void> {
+ public:
+  static Result Ok() { return Result(std::monostate{}); }
+
+  static Result Err(std::error_code cause) {
+    return Result(detail::MakeLegacyErrorInfo(cause));
+  }
+
+  static Result Err(Status status, std::string message = {}, std::error_code cause = {}) {
+    return Result(detail::MakeErrorInfo(status, std::move(message), cause));
+  }
+
+  bool IsOk() const noexcept { return std::holds_alternative<std::monostate>(state_); }
+  explicit operator bool() const noexcept { return IsOk(); }
+
+  Status StatusCode() const noexcept {
+    if (IsOk()) return Status::Ok;
+    return std::get<ErrorInfo>(state_).status;
+  }
+
+  std::string_view Message() const noexcept {
+    if (IsOk()) return {};
+    return std::get<ErrorInfo>(state_).message;
+  }
+
+  /// Requires !IsOk(). The returned reference is owned by this Result.
+  const std::error_code& Error() const {
+    assert(!IsOk());
+    return std::get<ErrorInfo>(state_).cause;
+  }
+
+  template <typename U>
+  static Result ErrFrom(const Result<U>& source) {
+    assert(!source.IsOk());
+    if (source.IsOk()) return Err(Status::Error);
+    const auto& info = std::get<ErrorInfo>(source.state_);
+    return Result(info);
+  }
+
+ private:
+  explicit Result(std::monostate state) : state_(state) {}
+  explicit Result(ErrorInfo info) : state_(std::move(info)) {}
+
+  template <typename>
+  friend class Result;
+  std::variant<std::monostate, ErrorInfo> state_;
+};
+
+}  // namespace sitos
+
+#endif  // SITOS_RESULT_HPP

--- a/include/sitos/result.hpp
+++ b/include/sitos/result.hpp
@@ -43,8 +43,7 @@ inline Status StatusFromErrorCode(const std::error_code& error) noexcept {
   return Status::Error;
 }
 
-inline ErrorInfo MakeErrorInfo(Status status, std::string message,
-                               std::error_code cause) {
+inline ErrorInfo MakeErrorInfo(Status status, std::string message, std::error_code cause) {
   assert(status != Status::Ok);
   if (status == Status::Ok) status = Status::Error;
   if (!cause) cause = MakeErrorCode(status);
@@ -57,6 +56,42 @@ inline ErrorInfo MakeLegacyErrorInfo(std::error_code cause) {
   return MakeErrorInfo(StatusFromErrorCode(cause), {}, cause);
 }
 
+template <typename State>
+bool ResultIsOk(const State& state) noexcept {
+  return state.index() == 0;
+}
+
+template <typename State>
+Status ResultStatus(const State& state) noexcept {
+  if (state.valueless_by_exception()) return Status::Error;
+  if (ResultIsOk(state)) return Status::Ok;
+  return std::get<1>(state).status;
+}
+
+template <typename State>
+std::string_view ResultMessage(const State& state) noexcept {
+  if (state.valueless_by_exception() || ResultIsOk(state)) return {};
+  return std::get<1>(state).message;
+}
+
+template <typename State>
+const ErrorInfo& ResultError(const State& state) {
+  assert(state.index() == 1);
+  return std::get<1>(state);
+}
+
+template <typename State, typename Source>
+void AssignResultState(State& target, Source&& source) {
+  try {
+    target = std::forward<Source>(source);
+  } catch (...) {
+    if (target.valueless_by_exception()) {
+      target.template emplace<1>(MakeErrorInfo(Status::Error, {}, {}));
+    }
+    throw;
+  }
+}
+
 }  // namespace detail
 
 /// A move-friendly, exclusive success-or-error result.
@@ -65,64 +100,70 @@ class Result {
  public:
   static Result Ok(T value) { return Result(std::move(value)); }
 
-  static Result Err(std::error_code cause) {
-    return Result(detail::MakeLegacyErrorInfo(cause));
-  }
+  static Result Err(std::error_code cause) { return Result(detail::MakeLegacyErrorInfo(cause)); }
 
   static Result Err(Status status, std::string message = {}, std::error_code cause = {}) {
     return Result(detail::MakeErrorInfo(status, std::move(message), cause));
   }
 
-  bool IsOk() const noexcept { return std::holds_alternative<T>(state_); }
+  Result(const Result&) = default;
+  Result(Result&&) noexcept(std::is_nothrow_move_constructible_v<T>) = default;
+
+  Result& operator=(const Result& other)
+    requires(std::is_copy_constructible_v<T> && std::is_copy_assignable_v<T>)
+  {
+    if (this != &other) detail::AssignResultState(state_, other.state_);
+    return *this;
+  }
+
+  Result& operator=(Result&& other) noexcept(std::is_nothrow_move_constructible_v<T> &&
+                                             std::is_nothrow_move_assignable_v<T>)
+    requires(std::is_move_constructible_v<T> && std::is_move_assignable_v<T>)
+  {
+    if (this != &other) detail::AssignResultState(state_, std::move(other.state_));
+    return *this;
+  }
+
+  bool IsOk() const noexcept { return detail::ResultIsOk(state_); }
   explicit operator bool() const noexcept { return IsOk(); }
 
   /// Returns Status::Ok and an empty view for a successful result.
-  Status StatusCode() const noexcept {
-    if (IsOk()) return Status::Ok;
-    return std::get<ErrorInfo>(state_).status;
-  }
+  Status StatusCode() const noexcept { return detail::ResultStatus(state_); }
 
-  /// Returns a view into the error state's diagnostic message.
+  /// Returns a view that remains valid only while this Result's error state lives.
   /// The view is invalidated by Result assignment or move.
-  std::string_view Message() const noexcept {
-    if (IsOk()) return {};
-    return std::get<ErrorInfo>(state_).message;
-  }
+  std::string_view Message() const noexcept { return detail::ResultMessage(state_); }
 
   /// Requires IsOk().
-  const T& Value() const & {
+  const T& Value() const& {
     assert(IsOk());
-    return std::get<T>(state_);
+    return std::get<0>(state_);
   }
   /// Requires IsOk().
   T& Value() & {
     assert(IsOk());
-    return std::get<T>(state_);
+    return std::get<0>(state_);
   }
   /// Requires IsOk().
   T&& Value() && {
     assert(IsOk());
-    return std::move(std::get<T>(state_));
+    return std::move(std::get<0>(state_));
   }
 
   /// Requires !IsOk(). The returned reference is owned by this Result.
-  const std::error_code& Error() const {
-    assert(!IsOk());
-    return std::get<ErrorInfo>(state_).cause;
-  }
+  const std::error_code& Error() const { return detail::ResultError(state_).cause; }
 
   /// Propagates an error without accessing or copying source's value.
   template <typename U>
   static Result ErrFrom(const Result<U>& source) {
     assert(!source.IsOk());
     if (source.IsOk()) return Err(Status::Error);
-    const auto& info = std::get<ErrorInfo>(source.state_);
-    return Result(info);
+    return Result(detail::ResultError(source.state_));
   }
 
  private:
-  explicit Result(T value) : state_(std::move(value)) {}
-  explicit Result(ErrorInfo info) : state_(std::move(info)) {}
+  explicit Result(T value) : state_(std::in_place_index<0>, std::move(value)) {}
+  explicit Result(ErrorInfo info) : state_(std::in_place_index<1>, std::move(info)) {}
 
   template <typename>
   friend class Result;
@@ -134,44 +175,34 @@ class Result<void> {
  public:
   static Result Ok() { return Result(std::monostate{}); }
 
-  static Result Err(std::error_code cause) {
-    return Result(detail::MakeLegacyErrorInfo(cause));
-  }
+  static Result Err(std::error_code cause) { return Result(detail::MakeLegacyErrorInfo(cause)); }
 
   static Result Err(Status status, std::string message = {}, std::error_code cause = {}) {
     return Result(detail::MakeErrorInfo(status, std::move(message), cause));
   }
 
-  bool IsOk() const noexcept { return std::holds_alternative<std::monostate>(state_); }
+  bool IsOk() const noexcept { return detail::ResultIsOk(state_); }
   explicit operator bool() const noexcept { return IsOk(); }
 
-  Status StatusCode() const noexcept {
-    if (IsOk()) return Status::Ok;
-    return std::get<ErrorInfo>(state_).status;
-  }
+  Status StatusCode() const noexcept { return detail::ResultStatus(state_); }
 
-  std::string_view Message() const noexcept {
-    if (IsOk()) return {};
-    return std::get<ErrorInfo>(state_).message;
-  }
+  /// Returns a view that remains valid only while this Result's error state lives.
+  /// The view is invalidated by Result assignment or move.
+  std::string_view Message() const noexcept { return detail::ResultMessage(state_); }
 
   /// Requires !IsOk(). The returned reference is owned by this Result.
-  const std::error_code& Error() const {
-    assert(!IsOk());
-    return std::get<ErrorInfo>(state_).cause;
-  }
+  const std::error_code& Error() const { return detail::ResultError(state_).cause; }
 
   template <typename U>
   static Result ErrFrom(const Result<U>& source) {
     assert(!source.IsOk());
     if (source.IsOk()) return Err(Status::Error);
-    const auto& info = std::get<ErrorInfo>(source.state_);
-    return Result(info);
+    return Result(detail::ResultError(source.state_));
   }
 
  private:
-  explicit Result(std::monostate state) : state_(state) {}
-  explicit Result(ErrorInfo info) : state_(std::move(info)) {}
+  explicit Result(std::monostate state) : state_(std::in_place_index<0>, state) {}
+  explicit Result(ErrorInfo info) : state_(std::in_place_index<1>, std::move(info)) {}
 
   template <typename>
   friend class Result;

--- a/include/sitos/sitos.hpp
+++ b/include/sitos/sitos.hpp
@@ -1,0 +1,20 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SITOS_SITOS_HPP
+#define SITOS_SITOS_HPP
+
+#include "sitos/batch.hpp"
+#include "sitos/client_config.hpp"
+#include "sitos/in_memory_engine.hpp"
+#include "sitos/key.hpp"
+#include "sitos/logging.hpp"
+#include "sitos/param_value.hpp"
+#include "sitos/result.hpp"
+#include "sitos/session.hpp"
+#include "sitos/status.hpp"
+#include "sitos/storage_engine.hpp"
+#include "sitos/storage_node.hpp"
+#include "sitos/transport.hpp"
+
+#endif  // SITOS_SITOS_HPP

--- a/include/sitos/status.hpp
+++ b/include/sitos/status.hpp
@@ -1,0 +1,33 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SITOS_STATUS_HPP
+#define SITOS_STATUS_HPP
+
+#include <system_error>
+
+namespace sitos {
+
+/// Stable high-level classification for recoverable API failures.
+enum class Status {
+  Ok,
+  NotFound,
+  TypeMismatch,
+  Timeout,
+  Disconnected,
+  ReadOnly,
+  InvalidKey,
+  InvalidArgument,
+  Error,
+};
+
+/// Returns the process-wide error category used by MakeErrorCode.
+const std::error_category& StatusErrorCategory() noexcept;
+
+/// Converts a non-success Status to a stable std::error_code.
+/// Status::Ok is invalid and is normalized to Status::Error in release builds.
+std::error_code MakeErrorCode(Status status);
+
+}  // namespace sitos
+
+#endif  // SITOS_STATUS_HPP

--- a/include/sitos/status.hpp
+++ b/include/sitos/status.hpp
@@ -10,15 +10,15 @@ namespace sitos {
 
 /// Stable high-level classification for recoverable API failures.
 enum class Status {
-  Ok,
-  NotFound,
-  TypeMismatch,
-  Timeout,
-  Disconnected,
-  ReadOnly,
-  InvalidKey,
-  InvalidArgument,
-  Error,
+  Ok = 0,
+  NotFound = 1,
+  TypeMismatch = 2,
+  Timeout = 3,
+  Disconnected = 4,
+  ReadOnly = 5,
+  InvalidKey = 6,
+  InvalidArgument = 7,
+  Error = 8,
 };
 
 /// Returns the process-wide error category used by MakeErrorCode.

--- a/include/sitos/transport.hpp
+++ b/include/sitos/transport.hpp
@@ -174,8 +174,6 @@ class Transport {
 
 }  // namespace sitos
 
-/// Factory function for the default zenoh-based transport.
-/// Returns nullptr when zenoh support is disabled or the zenoh session cannot be opened.
 namespace sitos {
 
 /// Opens a zenoh transport using an optional complete JSON5 configuration.

--- a/include/sitos/transport.hpp
+++ b/include/sitos/transport.hpp
@@ -19,87 +19,14 @@
 #include <utility>
 #include <vector>
 
+#include "sitos/result.hpp"
+
 namespace sitos {
 
 namespace transport_test_access {
 class SubscriptionTestAccess;
 class DeclarationHandleTestAccess;
 }
-
-/// A simple result type that holds either a value or an error code.
-/// Modeled after a minimal subset of std::expected (C++23).
-template <typename T>
-class Result {
- public:
-  static Result Ok(T value) {
-    Result r;
-    r.value_ = std::move(value);
-    return r;
-  }
-
-  static Result Err(std::error_code ec) {
-    Result r;
-    r.error_ = ec;
-    return r;
-  }
-
-  bool IsOk() const { return !error_.has_value(); }
-  explicit operator bool() const { return IsOk(); }
-
-  /// Requires IsOk().
-  const T& Value() const & {
-    assert(IsOk());
-    return *value_;
-  }
-  /// Requires IsOk().
-  T& Value() & {
-    assert(IsOk());
-    return *value_;
-  }
-  T&& Value() && {
-    assert(IsOk());
-    return std::move(*value_);
-  }
-
-  /// Requires !IsOk().
-  const std::error_code& Error() const {
-    assert(!IsOk());
-    return *error_;
-  }
-
- private:
-  Result() = default;
-  std::optional<T> value_;
-  std::optional<std::error_code> error_;
-};
-
-template <>
-class Result<void> {
- public:
-  static Result Ok() {
-    Result r;
-    return r;
-  }
-
-  static Result Err(std::error_code ec) {
-    Result r;
-    r.error_ = ec;
-    return r;
-  }
-
-  bool IsOk() const { return !error_.has_value(); }
-  explicit operator bool() const { return IsOk(); }
-
-  /// Requires !IsOk().
-  const std::error_code& Error() const {
-    assert(!IsOk());
-    return *error_;
-  }
-
- private:
-  Result() = default;
-  std::optional<std::error_code> error_;
-};
 
 /// Transport-independent schema identifiers for encoded payloads.
 ///
@@ -250,6 +177,13 @@ class Transport {
 /// Factory function for the default zenoh-based transport.
 /// Returns nullptr when zenoh support is disabled or the zenoh session cannot be opened.
 namespace sitos {
+
+/// Opens a zenoh transport using an optional complete JSON5 configuration.
+/// An absent configuration selects the zenoh default configuration.
+Result<std::unique_ptr<Transport>> OpenZenohTransport(
+    std::optional<std::string_view> config_json = std::nullopt);
+
+/// Compatibility factory that returns nullptr when opening fails.
 std::unique_ptr<Transport> MakeZenohTransport();
 }  // namespace sitos
 

--- a/src/client_config.cpp
+++ b/src/client_config.cpp
@@ -1,0 +1,23 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/client_config.hpp"
+
+#include "sitos/key.hpp"
+
+namespace sitos {
+
+Result<void> ValidateClientConfig(const ClientConfig& config) {
+  if (!IsValidPrefix(config.prefix)) {
+    return Result<void>::Err(Status::InvalidKey, "invalid client prefix");
+  }
+  if (config.query_timeout <= std::chrono::milliseconds::zero()) {
+    return Result<void>::Err(Status::InvalidArgument, "query timeout must be positive");
+  }
+  if (config.zenoh_config_json.has_value() && config.zenoh_config_json->empty()) {
+    return Result<void>::Err(Status::InvalidArgument, "zenoh configuration must not be empty");
+  }
+  return Result<void>::Ok();
+}
+
+}  // namespace sitos

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -1,0 +1,56 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/status.hpp"
+
+#include <cassert>
+#include <string>
+
+namespace sitos {
+namespace {
+
+class StatusCategory final : public std::error_category {
+ public:
+  const char* name() const noexcept override { return "sitos.status"; }
+
+  std::string message(int value) const override {
+    switch (static_cast<Status>(value)) {
+      case Status::Ok:
+        return "ok";
+      case Status::NotFound:
+        return "not found";
+      case Status::TypeMismatch:
+        return "type mismatch";
+      case Status::Timeout:
+        return "timeout";
+      case Status::Disconnected:
+        return "disconnected";
+      case Status::ReadOnly:
+        return "read-only";
+      case Status::InvalidKey:
+        return "invalid key";
+      case Status::InvalidArgument:
+        return "invalid argument";
+      case Status::Error:
+        return "error";
+    }
+    return "error";
+  }
+};
+
+}  // namespace
+
+const std::error_category& StatusErrorCategory() noexcept {
+  static const StatusCategory kCategory;
+  return kCategory;
+}
+
+std::error_code MakeErrorCode(Status status) {
+  if (status == Status::Ok) {
+    assert(false && "Status::Ok has no error code");
+    status = Status::Error;
+  }
+  return {static_cast<int>(status), StatusErrorCategory()};
+}
+
+}  // namespace sitos

--- a/src/transport/config_failure.hpp
+++ b/src/transport/config_failure.hpp
@@ -1,0 +1,18 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SITOS_TRANSPORT_CONFIG_FAILURE_HPP
+#define SITOS_TRANSPORT_CONFIG_FAILURE_HPP
+
+#include "sitos/status.hpp"
+
+namespace sitos::transport_detail {
+
+/// Classifies configuration creation failures without inspecting native text.
+constexpr Status ConfigFailureStatus(bool user_config_provided) noexcept {
+  return user_config_provided ? Status::InvalidArgument : Status::Error;
+}
+
+}  // namespace sitos::transport_detail
+
+#endif  // SITOS_TRANSPORT_CONFIG_FAILURE_HPP

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -17,6 +17,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <new>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -137,6 +138,22 @@ class ZenohOwned {
 
   T obj_{};
   bool moved_ = true;  // default-constructed state is "empty/moved-from"
+};
+
+// T invokes transfer from its constructor, after make_unique has allocated storage.
+template <typename T, typename Transfer>
+std::unique_ptr<T> MakeUniqueWithDeferredTransfer(Transfer&& transfer) {
+  return std::make_unique<T>(std::forward<Transfer>(transfer));
+}
+
+class AllocationFailureProbe {
+ public:
+  template <typename Transfer>
+  explicit AllocationFailureProbe(Transfer&& transfer) {
+    std::invoke(std::forward<Transfer>(transfer));
+  }
+
+  static void* operator new(std::size_t) { throw std::bad_alloc(); }
 };
 
 // Build a z_owned_keyexpr_t from a string. Returns an error Result if zenoh
@@ -271,6 +288,17 @@ std::optional<std::string> BuildWireEncoding(const Encoding& encoding) {
 
 Encoding NormalizeWireEncoding(std::string wire_encoding) {
   return NormalizeEncoding(std::move(wire_encoding));
+}
+
+bool AllocationFailurePrecedesOwnershipTransfer() {
+  bool ownership_transferred = false;
+  try {
+    static_cast<void>(MakeUniqueWithDeferredTransfer<AllocationFailureProbe>(
+        [&ownership_transferred] { ownership_transferred = true; }));
+  } catch (const std::bad_alloc&) {
+    return !ownership_transferred;
+  }
+  return false;
 }
 
 }  // namespace transport_test_access
@@ -597,8 +625,11 @@ class ZenohTransport : public Transport {
   }
 
  public:
-  explicit ZenohTransport(z_moved_config_t* config)
-      : open_result_(OpenZenohSession(&session_, config)), session_valid_(open_result_ == Z_OK) {}
+  template <typename ConfigTransfer>
+  explicit ZenohTransport(ConfigTransfer&& config_transfer)
+      : open_result_(OpenZenohSession(
+            &session_, std::invoke(std::forward<ConfigTransfer>(config_transfer)))),
+        session_valid_(open_result_ == Z_OK) {}
 
   bool IsSessionValid() const { return session_valid_; }
   z_result_t OpenResult() const { return open_result_; }
@@ -777,7 +808,8 @@ sitos::Result<std::unique_ptr<sitos::Transport>> sitos::OpenZenohTransport(
   }
 
   config.mark_valid();
-  auto transport = std::make_unique<sitos::ZenohTransport>(config.moved());
+  auto transport = MakeUniqueWithDeferredTransfer<sitos::ZenohTransport>(
+      [&config] { return config.moved(); });
   if (!transport->IsSessionValid()) {
     return Result<std::unique_ptr<Transport>>::Err(Status::Error,
                                                    "failed to open zenoh session",

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -553,10 +553,8 @@ void Queryable::Reset() noexcept {
 
 namespace {
 
-bool OpenZenohSession(z_owned_session_t* session) {
-  z_owned_config_t config;
-  if (z_config_default(&config) != Z_OK) return false;
-  return z_open(session, z_move(config), nullptr) == Z_OK;
+z_result_t OpenZenohSession(z_owned_session_t* session, z_moved_config_t* config) {
+  return z_open(session, config, nullptr);
 }
 
 }  // namespace
@@ -598,9 +596,11 @@ class ZenohTransport : public Transport {
   }
 
  public:
-  ZenohTransport() : session_valid_(OpenZenohSession(&session_)) {}
+  explicit ZenohTransport(z_moved_config_t* config)
+      : open_result_(OpenZenohSession(&session_, config)), session_valid_(open_result_ == Z_OK) {}
 
   bool IsSessionValid() const { return session_valid_; }
+  z_result_t OpenResult() const { return open_result_; }
 
   ~ZenohTransport() override {
     if (session_valid_) {
@@ -746,13 +746,45 @@ class ZenohTransport : public Transport {
 
  private:
   z_owned_session_t session_{};
+  z_result_t open_result_ = -1;
   bool session_valid_ = false;
 };
 
 }  // namespace sitos
 
+sitos::Result<std::unique_ptr<sitos::Transport>> sitos::OpenZenohTransport(
+    std::optional<std::string_view> config_json) {
+  if (config_json.has_value() && config_json->empty()) {
+    return Result<std::unique_ptr<Transport>>::Err(Status::InvalidArgument,
+                                                   "zenoh configuration must not be empty");
+  }
+
+  ZenohOwned<z_owned_config_t> config;
+  z_result_t config_result = Z_OK;
+  if (config_json.has_value()) {
+    config_result =
+        zc_config_from_substr(config.get(), config_json->data(), config_json->size());
+  } else {
+    config_result = z_config_default(config.get());
+  }
+  if (config_result != Z_OK) {
+    return Result<std::unique_ptr<Transport>>::Err(Status::InvalidArgument,
+                                                   "invalid zenoh configuration",
+                                                   MakeError(config_result));
+  }
+
+  config.mark_valid();
+  auto transport = std::make_unique<sitos::ZenohTransport>(config.moved());
+  if (!transport->IsSessionValid()) {
+    return Result<std::unique_ptr<Transport>>::Err(Status::Error,
+                                                   "failed to open zenoh session",
+                                                   MakeError(transport->OpenResult()));
+  }
+  return Result<std::unique_ptr<Transport>>::Ok(std::move(transport));
+}
+
 std::unique_ptr<sitos::Transport> sitos::MakeZenohTransport() {
-  auto t = std::make_unique<sitos::ZenohTransport>();
-  if (!t->IsSessionValid()) return nullptr;
-  return t;
+  auto result = OpenZenohTransport();
+  if (!result.IsOk()) return nullptr;
+  return std::move(result).Value();
 }

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -23,6 +23,7 @@
 
 #include "sitos/transport.hpp"
 
+#include "config_failure.hpp"
 #include "declaration_handle_lifecycle.hpp"
 #include "zenoh_transport_test_access.hpp"
 
@@ -768,9 +769,11 @@ sitos::Result<std::unique_ptr<sitos::Transport>> sitos::OpenZenohTransport(
     config_result = z_config_default(config.get());
   }
   if (config_result != Z_OK) {
-    return Result<std::unique_ptr<Transport>>::Err(Status::InvalidArgument,
-                                                   "invalid zenoh configuration",
-                                                   MakeError(config_result));
+    const bool user_config_provided = config_json.has_value();
+    const auto status = transport_detail::ConfigFailureStatus(user_config_provided);
+    const char* message = user_config_provided ? "invalid zenoh configuration"
+                                               : "failed to create default zenoh configuration";
+    return Result<std::unique_ptr<Transport>>::Err(status, message, MakeError(config_result));
   }
 
   config.mark_valid();

--- a/src/transport/zenoh_transport_test_access.hpp
+++ b/src/transport/zenoh_transport_test_access.hpp
@@ -21,6 +21,9 @@ std::optional<std::string> BuildWireEncoding(const Encoding& encoding);
 /// Applies the production receive-side normalization to a wire Encoding string.
 Encoding NormalizeWireEncoding(std::string wire_encoding);
 
+/// Verifies allocation failure occurs before a constructor argument transfers ownership.
+bool AllocationFailurePrecedesOwnershipTransfer();
+
 /// Internal access for Subscription ownership regression tests.
 class SubscriptionTestAccess {
  public:

--- a/src/transport_stub.cpp
+++ b/src/transport_stub.cpp
@@ -43,6 +43,16 @@ void Queryable::Reset() noexcept {
   transport_internal::InvokeResetHandler(reset_handler_);
 }
 
-std::unique_ptr<Transport> MakeZenohTransport() { return nullptr; }
+Result<std::unique_ptr<Transport>> OpenZenohTransport(std::optional<std::string_view>) {
+  return Result<std::unique_ptr<Transport>>::Err(
+      Status::Error, "zenoh support is disabled",
+      std::make_error_code(std::errc::operation_not_supported));
+}
+
+std::unique_ptr<Transport> MakeZenohTransport() {
+  auto result = OpenZenohTransport();
+  if (!result.IsOk()) return nullptr;
+  return std::move(result).Value();
+}
 
 }  // namespace sitos

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(sitos_client_transport_factory_test unit/client_transport_factory
 target_link_libraries(sitos_client_transport_factory_test PRIVATE GTest::gtest_main sitos::sitos)
 if(SITOS_WITH_ZENOH)
   target_compile_definitions(sitos_client_transport_factory_test PRIVATE SITOS_WITH_ZENOH=1)
+  target_include_directories(sitos_client_transport_factory_test PRIVATE ${PROJECT_SOURCE_DIR}/src)
   sitos_copy_zenohc(sitos_client_transport_factory_test)
 endif()
 sitos_enable_warnings(sitos_client_transport_factory_test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,10 +12,21 @@ include(GoogleTest)
 
 set(SITOS_FIXTURE_DIR "${CMAKE_SOURCE_DIR}/tests/fixtures/payload_v1")
 
-add_executable(sitos_public_headers_compile_test consumer/public_headers_compile.cpp)
-target_link_libraries(sitos_public_headers_compile_test PRIVATE sitos::sitos)
-sitos_enable_warnings(sitos_public_headers_compile_test)
-add_test(NAME sitos_public_headers_compile_test COMMAND sitos_public_headers_compile_test)
+function(add_sitos_public_header_compile_test target source)
+  add_executable(${target} ${source})
+  target_link_libraries(${target} PRIVATE sitos::sitos)
+  sitos_enable_warnings(${target})
+  add_test(NAME ${target} COMMAND ${target})
+endfunction()
+
+add_sitos_public_header_compile_test(
+  sitos_public_headers_compile_test consumer/public_headers_compile.cpp)
+add_sitos_public_header_compile_test(
+  sitos_status_header_compile_test consumer/status_header_compile.cpp)
+add_sitos_public_header_compile_test(
+  sitos_result_header_compile_test consumer/result_header_compile.cpp)
+add_sitos_public_header_compile_test(
+  sitos_client_config_header_compile_test consumer/client_config_header_compile.cpp)
 
 add_executable(sitos_bootstrap_test unit/bootstrap_test.cpp)
 target_link_libraries(sitos_bootstrap_test PRIVATE GTest::gtest_main sitos::sitos)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,11 @@ include(GoogleTest)
 
 set(SITOS_FIXTURE_DIR "${CMAKE_SOURCE_DIR}/tests/fixtures/payload_v1")
 
+add_executable(sitos_public_headers_compile_test consumer/public_headers_compile.cpp)
+target_link_libraries(sitos_public_headers_compile_test PRIVATE sitos::sitos)
+sitos_enable_warnings(sitos_public_headers_compile_test)
+add_test(NAME sitos_public_headers_compile_test COMMAND sitos_public_headers_compile_test)
+
 add_executable(sitos_bootstrap_test unit/bootstrap_test.cpp)
 target_link_libraries(sitos_bootstrap_test PRIVATE GTest::gtest_main sitos::sitos)
 sitos_enable_warnings(sitos_bootstrap_test)
@@ -23,6 +28,25 @@ target_compile_definitions(sitos_param_value_test PRIVATE
   SITOS_FIXTURE_DIR="${SITOS_FIXTURE_DIR}")
 sitos_enable_warnings(sitos_param_value_test)
 gtest_discover_tests(sitos_param_value_test)
+
+add_executable(sitos_result_test unit/result_test.cpp)
+target_link_libraries(sitos_result_test PRIVATE GTest::gtest_main sitos::sitos)
+sitos_enable_warnings(sitos_result_test)
+gtest_discover_tests(sitos_result_test)
+
+add_executable(sitos_client_config_test unit/client_config_test.cpp)
+target_link_libraries(sitos_client_config_test PRIVATE GTest::gtest_main sitos::sitos)
+sitos_enable_warnings(sitos_client_config_test)
+gtest_discover_tests(sitos_client_config_test)
+
+add_executable(sitos_client_transport_factory_test unit/client_transport_factory_test.cpp)
+target_link_libraries(sitos_client_transport_factory_test PRIVATE GTest::gtest_main sitos::sitos)
+if(SITOS_WITH_ZENOH)
+  target_compile_definitions(sitos_client_transport_factory_test PRIVATE SITOS_WITH_ZENOH=1)
+  sitos_copy_zenohc(sitos_client_transport_factory_test)
+endif()
+sitos_enable_warnings(sitos_client_transport_factory_test)
+gtest_discover_tests(sitos_client_transport_factory_test)
 
 add_executable(sitos_key_test unit/key_test.cpp)
 target_link_libraries(sitos_key_test PRIVATE GTest::gtest_main sitos::sitos)

--- a/tests/consumer/client_config_header_compile.cpp
+++ b/tests/consumer/client_config_header_compile.cpp
@@ -1,0 +1,9 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/client_config.hpp"
+
+int main() {
+  sitos::ClientConfig config;
+  return sitos::ValidateClientConfig(config).IsOk() ? 0 : 1;
+}

--- a/tests/consumer/public_headers_compile.cpp
+++ b/tests/consumer/public_headers_compile.cpp
@@ -1,0 +1,21 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/batch.hpp"
+#include "sitos/client_config.hpp"
+#include "sitos/in_memory_engine.hpp"
+#include "sitos/key.hpp"
+#include "sitos/logging.hpp"
+#include "sitos/param_value.hpp"
+#include "sitos/result.hpp"
+#include "sitos/session.hpp"
+#include "sitos/sitos.hpp"
+#include "sitos/status.hpp"
+#include "sitos/storage_engine.hpp"
+#include "sitos/storage_node.hpp"
+#include "sitos/transport.hpp"
+
+int main() {
+  sitos::ClientConfig config;
+  return sitos::ValidateClientConfig(config).IsOk() ? 0 : 1;
+}

--- a/tests/consumer/public_headers_compile.cpp
+++ b/tests/consumer/public_headers_compile.cpp
@@ -1,21 +1,13 @@
 // Copyright 2026 sitos contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sitos/batch.hpp"
-#include "sitos/client_config.hpp"
-#include "sitos/in_memory_engine.hpp"
-#include "sitos/key.hpp"
-#include "sitos/logging.hpp"
-#include "sitos/param_value.hpp"
-#include "sitos/result.hpp"
-#include "sitos/session.hpp"
 #include "sitos/sitos.hpp"
-#include "sitos/status.hpp"
-#include "sitos/storage_engine.hpp"
-#include "sitos/storage_node.hpp"
-#include "sitos/transport.hpp"
 
 int main() {
   sitos::ClientConfig config;
-  return sitos::ValidateClientConfig(config).IsOk() ? 0 : 1;
+  auto validation = sitos::ValidateClientConfig(config);
+  sitos::ParamValue value(1);
+  sitos::InMemoryEngine engine;
+  static_cast<void>(engine);
+  return validation.IsOk() && value.As<int>() == 1 ? 0 : 1;
 }

--- a/tests/consumer/result_header_compile.cpp
+++ b/tests/consumer/result_header_compile.cpp
@@ -1,0 +1,9 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/result.hpp"
+
+int main() {
+  auto result = sitos::Result<int>::Ok(1);
+  return result.Value() == 1 ? 0 : 1;
+}

--- a/tests/consumer/status_header_compile.cpp
+++ b/tests/consumer/status_header_compile.cpp
@@ -1,0 +1,9 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/status.hpp"
+
+int main() {
+  const auto error = sitos::MakeErrorCode(sitos::Status::Error);
+  return error ? 0 : 1;
+}

--- a/tests/unit/client_config_test.cpp
+++ b/tests/unit/client_config_test.cpp
@@ -1,0 +1,55 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <chrono>
+#include <optional>
+
+#include <gtest/gtest.h>
+
+#include "sitos/client_config.hpp"
+
+namespace sitos {
+namespace {
+
+TEST(ClientConfigTest, HasRequiredDefaults) {
+  const ClientConfig config;
+  EXPECT_EQ(config.prefix, "sitos");
+  EXPECT_FALSE(config.zenoh_config_json.has_value());
+  EXPECT_EQ(config.query_timeout, std::chrono::milliseconds(5000));
+  EXPECT_TRUE(ValidateClientConfig(config).IsOk());
+}
+
+TEST(ClientConfigTest, RejectsInvalidPrefix) {
+  ClientConfig config;
+  config.prefix = "sitos/**";
+  const auto result = ValidateClientConfig(config);
+  ASSERT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), Status::InvalidKey);
+}
+
+TEST(ClientConfigTest, RejectsNonpositiveTimeout) {
+  ClientConfig config;
+  config.query_timeout = std::chrono::milliseconds::zero();
+  auto result = ValidateClientConfig(config);
+  ASSERT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), Status::InvalidArgument);
+
+  config.query_timeout = std::chrono::milliseconds(-1);
+  result = ValidateClientConfig(config);
+  ASSERT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), Status::InvalidArgument);
+}
+
+TEST(ClientConfigTest, RejectsEmptyJsonButDoesNotParseNonemptyJson) {
+  ClientConfig config;
+  config.zenoh_config_json = std::string{};
+  auto result = ValidateClientConfig(config);
+  ASSERT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), Status::InvalidArgument);
+
+  config.zenoh_config_json = "not JSON5";
+  EXPECT_TRUE(ValidateClientConfig(config).IsOk());
+}
+
+}  // namespace
+}  // namespace sitos

--- a/tests/unit/client_transport_factory_test.cpp
+++ b/tests/unit/client_transport_factory_test.cpp
@@ -1,0 +1,47 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <optional>
+#include <string_view>
+#include <system_error>
+
+#include <gtest/gtest.h>
+
+#include "sitos/transport.hpp"
+
+namespace sitos {
+namespace {
+
+#if defined(SITOS_WITH_ZENOH)
+TEST(ClientTransportFactoryTest, RejectsEmptyAndMalformedConfiguration) {
+  const auto empty = OpenZenohTransport(std::string_view{});
+  ASSERT_FALSE(empty.IsOk());
+  EXPECT_EQ(empty.StatusCode(), Status::InvalidArgument);
+
+  const auto malformed = OpenZenohTransport(std::string_view{"not JSON5"});
+  ASSERT_FALSE(malformed.IsOk());
+  EXPECT_EQ(malformed.StatusCode(), Status::InvalidArgument);
+}
+
+
+TEST(ClientTransportFactoryTest, OpensDefaultAndCompleteJson5Configuration) {
+  auto default_transport = OpenZenohTransport();
+  ASSERT_TRUE(default_transport.IsOk()) << default_transport.Message();
+
+  auto configured_transport = OpenZenohTransport(std::string_view{"{mode: 'peer'}"});
+  ASSERT_TRUE(configured_transport.IsOk()) << configured_transport.Message();
+
+  EXPECT_NE(MakeZenohTransport(), nullptr);
+}
+#else
+TEST(ClientTransportFactoryTest, ReportsZenohDisabled) {
+  const auto result = OpenZenohTransport();
+  ASSERT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), Status::Error);
+  EXPECT_EQ(result.Error(), std::make_error_code(std::errc::operation_not_supported));
+  EXPECT_EQ(MakeZenohTransport(), nullptr);
+}
+#endif
+
+}  // namespace
+}  // namespace sitos

--- a/tests/unit/client_transport_factory_test.cpp
+++ b/tests/unit/client_transport_factory_test.cpp
@@ -11,6 +11,7 @@
 
 #if defined(SITOS_WITH_ZENOH)
 #include "transport/config_failure.hpp"
+#include "transport/zenoh_transport_test_access.hpp"
 #endif
 
 namespace sitos {
@@ -20,6 +21,10 @@ namespace {
 TEST(ClientTransportFactoryTest, ClassifiesConfigurationCreationFailuresBySource) {
   EXPECT_EQ(transport_detail::ConfigFailureStatus(false), Status::Error);
   EXPECT_EQ(transport_detail::ConfigFailureStatus(true), Status::InvalidArgument);
+}
+
+TEST(ClientTransportFactoryTest, AllocationFailurePrecedesConfigOwnershipTransfer) {
+  EXPECT_TRUE(transport_test_access::AllocationFailurePrecedesOwnershipTransfer());
 }
 
 TEST(ClientTransportFactoryTest, RejectsEmptyAndMalformedConfiguration) {

--- a/tests/unit/client_transport_factory_test.cpp
+++ b/tests/unit/client_transport_factory_test.cpp
@@ -1,18 +1,27 @@
 // Copyright 2026 sitos contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <gtest/gtest.h>
+
 #include <optional>
 #include <string_view>
 #include <system_error>
 
-#include <gtest/gtest.h>
-
 #include "sitos/transport.hpp"
+
+#if defined(SITOS_WITH_ZENOH)
+#include "transport/config_failure.hpp"
+#endif
 
 namespace sitos {
 namespace {
 
 #if defined(SITOS_WITH_ZENOH)
+TEST(ClientTransportFactoryTest, ClassifiesConfigurationCreationFailuresBySource) {
+  EXPECT_EQ(transport_detail::ConfigFailureStatus(false), Status::Error);
+  EXPECT_EQ(transport_detail::ConfigFailureStatus(true), Status::InvalidArgument);
+}
+
 TEST(ClientTransportFactoryTest, RejectsEmptyAndMalformedConfiguration) {
   const auto empty = OpenZenohTransport(std::string_view{});
   ASSERT_FALSE(empty.IsOk());
@@ -22,7 +31,6 @@ TEST(ClientTransportFactoryTest, RejectsEmptyAndMalformedConfiguration) {
   ASSERT_FALSE(malformed.IsOk());
   EXPECT_EQ(malformed.StatusCode(), Status::InvalidArgument);
 }
-
 
 TEST(ClientTransportFactoryTest, OpensDefaultAndCompleteJson5Configuration) {
   auto default_transport = OpenZenohTransport();

--- a/tests/unit/result_test.cpp
+++ b/tests/unit/result_test.cpp
@@ -1,15 +1,17 @@
 // Copyright 2026 sitos contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sitos/result.hpp"
+
+#include <gtest/gtest.h>
+
 #include <cassert>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <system_error>
 #include <utility>
 
-#include <gtest/gtest.h>
-
-#include "sitos/result.hpp"
 #include "sitos/status.hpp"
 
 namespace sitos {
@@ -84,6 +86,47 @@ class CustomErrorCategory final : public std::error_category {
   std::string message(int) const override { return "custom"; }
 };
 
+class ThrowingMoveValue {
+ public:
+  explicit ThrowingMoveValue(int value) : value_(value) {}
+  ThrowingMoveValue(const ThrowingMoveValue&) = delete;
+  ThrowingMoveValue& operator=(const ThrowingMoveValue&) = delete;
+
+  ThrowingMoveValue(ThrowingMoveValue&& other) {
+    if (throw_on_move_) throw std::runtime_error("move failed");
+    value_ = other.value_;
+  }
+
+  ThrowingMoveValue& operator=(ThrowingMoveValue&& other) {
+    if (throw_on_move_) throw std::runtime_error("move failed");
+    value_ = other.value_;
+    return *this;
+  }
+
+  static void SetThrowOnMove(bool enabled) { throw_on_move_ = enabled; }
+
+ private:
+  static inline bool throw_on_move_ = false;
+  int value_;
+};
+
+TEST(ResultTest, AssignmentFailurePreservesAnObservableErrorState) {
+  auto target = Result<ThrowingMoveValue>::Err(Status::NotFound);
+  auto source = Result<ThrowingMoveValue>::Ok(ThrowingMoveValue{7});
+
+  ThrowingMoveValue::SetThrowOnMove(true);
+  EXPECT_THROW(target = std::move(source), std::runtime_error);
+  ThrowingMoveValue::SetThrowOnMove(false);
+
+  const std::error_code* error = nullptr;
+  EXPECT_NO_THROW(error = &target.Error());
+  ASSERT_NE(error, nullptr);
+  EXPECT_NE(error->value(), 0);
+  EXPECT_FALSE(target.IsOk());
+  EXPECT_EQ(target.StatusCode(), Status::Error);
+  EXPECT_TRUE(target.Message().empty());
+}
+
 TEST(ResultTest, UnknownLegacyErrorsRemainErrors) {
   const auto cause = std::make_error_code(std::errc::file_exists);
   auto result = Result<void>::Err(cause);
@@ -104,14 +147,18 @@ TEST(ResultTest, UnknownLegacyErrorsRemainErrors) {
 
 #ifndef NDEBUG
 TEST(ResultTest, WrongStateAccessesAssert) {
-  EXPECT_DEATH({
-    auto result = Result<int>::Err(Status::Error);
-    static_cast<void>(result.Value());
-  }, "");
-  EXPECT_DEATH({
-    auto result = Result<int>::Ok(1);
-    static_cast<void>(result.Error());
-  }, "");
+  EXPECT_DEATH(
+      {
+        auto result = Result<int>::Err(Status::Error);
+        static_cast<void>(result.Value());
+      },
+      "");
+  EXPECT_DEATH(
+      {
+        auto result = Result<int>::Ok(1);
+        static_cast<void>(result.Error());
+      },
+      "");
 }
 #endif
 

--- a/tests/unit/result_test.cpp
+++ b/tests/unit/result_test.cpp
@@ -78,6 +78,12 @@ TEST(ResultTest, MapsPortableLegacyErrors) {
             Status::Disconnected);
 }
 
+class CustomErrorCategory final : public std::error_category {
+ public:
+  const char* name() const noexcept override { return "custom"; }
+  std::string message(int) const override { return "custom"; }
+};
+
 TEST(ResultTest, UnknownLegacyErrorsRemainErrors) {
   const auto cause = std::make_error_code(std::errc::file_exists);
   auto result = Result<void>::Err(cause);
@@ -88,7 +94,26 @@ TEST(ResultTest, UnknownLegacyErrorsRemainErrors) {
   result = Result<void>::Err(no_such_file);
   EXPECT_EQ(result.StatusCode(), Status::Error);
   EXPECT_EQ(result.Error(), no_such_file);
+
+  static const CustomErrorCategory category;
+  const std::error_code custom(17, category);
+  result = Result<void>::Err(custom);
+  EXPECT_EQ(result.StatusCode(), Status::Error);
+  EXPECT_EQ(result.Error(), custom);
 }
+
+#ifndef NDEBUG
+TEST(ResultTest, WrongStateAccessesAssert) {
+  EXPECT_DEATH({
+    auto result = Result<int>::Err(Status::Error);
+    static_cast<void>(result.Value());
+  }, "");
+  EXPECT_DEATH({
+    auto result = Result<int>::Ok(1);
+    static_cast<void>(result.Error());
+  }, "");
+}
+#endif
 
 TEST(ResultTest, VoidSuccessHasNoError) {
   auto result = Result<void>::Ok();

--- a/tests/unit/result_test.cpp
+++ b/tests/unit/result_test.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cassert>
 #include <memory>
 #include <stdexcept>
@@ -178,10 +179,22 @@ TEST(ResultTest, ZeroErrorCodeIsNormalized) {
 }
 #endif
 
-TEST(StatusTest, ErrorCodeUsesStableCategory) {
-  const auto error = MakeErrorCode(Status::Timeout);
-  EXPECT_NE(error.value(), 0);
-  EXPECT_EQ(&error.category(), &StatusErrorCategory());
+TEST(StatusTest, ErrorCodeUsesStableCategoryAndValues) {
+  constexpr std::array kValues{
+      std::pair{Status::Ok, 0},           std::pair{Status::NotFound, 1},
+      std::pair{Status::TypeMismatch, 2}, std::pair{Status::Timeout, 3},
+      std::pair{Status::Disconnected, 4}, std::pair{Status::ReadOnly, 5},
+      std::pair{Status::InvalidKey, 6},   std::pair{Status::InvalidArgument, 7},
+      std::pair{Status::Error, 8},
+  };
+
+  for (const auto& [status, value] : kValues) {
+    EXPECT_EQ(static_cast<int>(status), value);
+    if (status == Status::Ok) continue;
+    const auto error = MakeErrorCode(status);
+    EXPECT_EQ(error.value(), value);
+    EXPECT_EQ(&error.category(), &StatusErrorCategory());
+  }
 }
 
 }  // namespace

--- a/tests/unit/result_test.cpp
+++ b/tests/unit/result_test.cpp
@@ -1,0 +1,116 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cassert>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "sitos/result.hpp"
+#include "sitos/status.hpp"
+
+namespace sitos {
+namespace {
+
+TEST(ResultTest, PreservesValueAndErrorStates) {
+  auto value = Result<int>::Ok(42);
+  EXPECT_TRUE(value.IsOk());
+  EXPECT_EQ(value.StatusCode(), Status::Ok);
+  EXPECT_TRUE(value.Message().empty());
+  EXPECT_EQ(value.Value(), 42);
+
+  auto error = Result<int>::Err(Status::NotFound, "missing");
+  EXPECT_FALSE(error.IsOk());
+  EXPECT_EQ(error.StatusCode(), Status::NotFound);
+  EXPECT_EQ(error.Message(), "missing");
+  EXPECT_EQ(error.Error().category(), StatusErrorCategory());
+}
+
+TEST(ResultTest, PreservesNativeCause) {
+  const auto cause = std::make_error_code(std::errc::file_exists);
+  auto result = Result<int>::Err(Status::Error, "failed", cause);
+  EXPECT_EQ(result.StatusCode(), Status::Error);
+  EXPECT_EQ(result.Message(), "failed");
+  EXPECT_EQ(result.Error(), cause);
+}
+
+TEST(ResultTest, ErrFromPreservesFailureAcrossValueTypes) {
+  auto source = Result<std::unique_ptr<int>>::Err(Status::Disconnected, "offline");
+  auto result = Result<void>::ErrFrom(source);
+  EXPECT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), Status::Disconnected);
+  EXPECT_EQ(result.Message(), "offline");
+  EXPECT_EQ(result.Error(), source.Error());
+}
+
+TEST(ResultTest, SupportsMoveOnlyValues) {
+  auto result = Result<std::unique_ptr<int>>::Ok(std::make_unique<int>(7));
+  auto value = std::move(result).Value();
+  ASSERT_NE(value, nullptr);
+  EXPECT_EQ(*value, 7);
+}
+
+TEST(ResultTest, MapsPortableLegacyErrors) {
+  EXPECT_EQ(Result<void>::Err(std::make_error_code(std::errc::invalid_argument)).StatusCode(),
+            Status::InvalidArgument);
+  EXPECT_EQ(Result<void>::Err(std::make_error_code(std::errc::timed_out)).StatusCode(),
+            Status::Timeout);
+  EXPECT_EQ(Result<void>::Err(std::make_error_code(std::errc::not_connected)).StatusCode(),
+            Status::Disconnected);
+  EXPECT_EQ(Result<void>::Err(std::make_error_code(std::errc::connection_aborted)).StatusCode(),
+            Status::Disconnected);
+  EXPECT_EQ(Result<void>::Err(std::make_error_code(std::errc::connection_refused)).StatusCode(),
+            Status::Disconnected);
+  EXPECT_EQ(Result<void>::Err(std::make_error_code(std::errc::connection_reset)).StatusCode(),
+            Status::Disconnected);
+  EXPECT_EQ(Result<void>::Err(std::make_error_code(std::errc::network_down)).StatusCode(),
+            Status::Disconnected);
+  EXPECT_EQ(Result<void>::Err(std::make_error_code(std::errc::network_reset)).StatusCode(),
+            Status::Disconnected);
+  EXPECT_EQ(Result<void>::Err(std::make_error_code(std::errc::network_unreachable)).StatusCode(),
+            Status::Disconnected);
+  EXPECT_EQ(Result<void>::Err(std::make_error_code(std::errc::host_unreachable)).StatusCode(),
+            Status::Disconnected);
+  EXPECT_EQ(Result<void>::Err(std::make_error_code(std::errc::broken_pipe)).StatusCode(),
+            Status::Disconnected);
+}
+
+TEST(ResultTest, UnknownLegacyErrorsRemainErrors) {
+  const auto cause = std::make_error_code(std::errc::file_exists);
+  auto result = Result<void>::Err(cause);
+  EXPECT_EQ(result.StatusCode(), Status::Error);
+  EXPECT_EQ(result.Error(), cause);
+
+  const auto no_such_file = std::make_error_code(std::errc::no_such_file_or_directory);
+  result = Result<void>::Err(no_such_file);
+  EXPECT_EQ(result.StatusCode(), Status::Error);
+  EXPECT_EQ(result.Error(), no_such_file);
+}
+
+TEST(ResultTest, VoidSuccessHasNoError) {
+  auto result = Result<void>::Ok();
+  EXPECT_TRUE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), Status::Ok);
+  EXPECT_TRUE(result.Message().empty());
+}
+
+#if defined(NDEBUG)
+TEST(ResultTest, ZeroErrorCodeIsNormalized) {
+  auto result = Result<void>::Err(std::error_code{});
+  EXPECT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), Status::Error);
+  EXPECT_NE(result.Error().value(), 0);
+}
+#endif
+
+TEST(StatusTest, ErrorCodeUsesStableCategory) {
+  const auto error = MakeErrorCode(Status::Timeout);
+  EXPECT_NE(error.value(), 0);
+  EXPECT_EQ(&error.category(), &StatusErrorCategory());
+}
+
+}  // namespace
+}  // namespace sitos


### PR DESCRIPTION
Closes #85

## Summary

- Add the dependency-free Status and additive Result/ErrorInfo foundation.
- Add ClientConfig validation and the Result-returning Zenoh factory.
- Add the public umbrella header and consumer compile coverage.

## Requirements

- #85 client Result, Status, configuration, and factory foundation
- Preserve legacy Result<T> factories, state checks, move-only values, ref-qualified Value(), and native Error() comparisons.
- Keep Zenoh-specific APIs confined to src/transport/.

## Acceptance Criteria Verification

- [x] Status error category and all required status values are public.
- [x] Result<T> uses exclusive value/error state and supports StatusCode(), Message(), Err(Status, ...), and ErrFrom.
- [x] Legacy std::error_code construction preserves native causes and uses the closed portable std::errc mapping.
- [x] ClientConfig defaults and ValidateClientConfig validation are covered.
- [x] OpenZenohTransport parses complete nonempty JSON5 with zc_config_from_substr and preserves MakeZenohTransport compatibility.
- [x] Zenoh-disabled factory behavior is covered.
- [x] Umbrella and individual public headers compile without Zenoh.
- [x] ADR-0019 is Accepted and documentation is updated.

## RED-phase Confirmation

Retrospectively reproduced RED on origin/main (db734dc) in a temporary worktree after adding the AC tests before production implementation. MSVC failed correctly because the new public headers did not exist:

- `fatal error C1083: ... 'sitos/result.hpp': No such file or directory`
- `fatal error C1083: ... 'sitos/client_config.hpp': No such file or directory`

The temporary worktree was removed after capturing the output. This is retrospective RED evidence; history was not rewritten.

A later Fable-review regression was also run RED before its implementation: after adding
`AllocationFailurePrecedesConfigOwnershipTransfer`, MSVC failed to link with `LNK2019`
because `AllocationFailurePrecedesOwnershipTransfer()` did not yet exist. Commit `ddb7e59`
then implemented deferred transfer and made the focused test pass.

## Validation

- Zenoh OFF: MSVC/Ninja build and 175/175 tests passed.
- Zenoh ON: MSVC/Ninja build and 206/206 tests passed.
- Factory-focused Zenoh ON tests passed 3/3.
- `git diff --check` passed.

## Review Follow-up

- Fixed Result assignment recovery so a throwing cross-alternative assignment cannot leave an unobservable valueless state.
- Distinguished default Zenoh configuration creation failures from invalid caller JSON.
- Isolated umbrella and individual public-header consumer compilation.
- Stabilized and tested every published Status numeric value.
- Replied to and resolved all five CodeRabbit threads; the compatibility-sensitive rvalue-accessor suggestion was intentionally declined with rationale.
- Judged all seven Sonar findings individually; intentional generic/C++20/readability findings were Accepted with rationale, leaving OPEN=0 and the quality gate passing.
- Applied the verified Fable follow-ups: config ownership transfer now occurs only after transport allocation, stale factory guidance and duplicate policy text were removed, and Status-preserving forwarding is tracked by #88 before #86.

## ADR Needed

ADR-0019 was changed to Accepted after final review and immediately before merge readiness.

## Scope

Transport::Get completion semantics (#86), ParamStore (#15), ParamCache, and acknowledgement/retry behavior remain out of scope.


