### PR TITLE
fix(transport): preserve status across forwarding (#88)

### DIFF
--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -47,7 +47,11 @@ cause. `MakeZenohTransport()` remains the compatibility wrapper that converts an
 to `nullptr`. Configuration text is never retained or included in diagnostics.
 
 Client-facing status classification and `ClientConfig` validation are dependency-free and
-live in `status.hpp`, `result.hpp`, and `client_config.hpp`.
+live in `status.hpp`, `result.hpp`, and `client_config.hpp`. The adapter explicitly classifies
+known disconnected and invalid-argument conditions while retaining their native Zenoh causes
+through `Result::Error()`. Type-changing internal propagation uses `Result::ErrFrom` to retain
+Status, message, and cause; native Zenoh failures without a reliable semantic classification
+remain `Status::Error`.
 
 Higher-level components see only the following abstract API.
 

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -48,10 +48,10 @@ to `nullptr`. Configuration text is never retained or included in diagnostics.
 
 Client-facing status classification and `ClientConfig` validation are dependency-free and
 live in `status.hpp`, `result.hpp`, and `client_config.hpp`. The adapter explicitly classifies
-known disconnected and invalid-argument conditions while retaining their native Zenoh causes
-through `Result::Error()`. Type-changing internal propagation uses `Result::ErrFrom` to retain
-Status, message, and cause; native Zenoh failures without a reliable semantic classification
-remain `Status::Error`.
+known disconnected and invalid-argument conditions with synthesized adapter causes through
+`Result::Error()`. Native Zenoh failures retain their original causes. Type-changing internal
+propagation uses `Result::ErrFrom` to retain Status, message, and cause; native Zenoh failures
+without a reliable semantic classification remain `Status::Error`.
 
 Higher-level components see only the following abstract API.
 

--- a/src/storage_node.cpp
+++ b/src/storage_node.cpp
@@ -258,12 +258,12 @@ Result<void> StorageNode::Start(std::shared_ptr<StorageEngine> engine, Transport
   const std::string declaration_key = state->prefix + "/**";
   auto queryable_result = transport.DeclareQueryable(
       declaration_key, [state](TransportQuery& query) { OnQuery(state, query); });
-  if (!queryable_result.IsOk()) return Result<void>::Err(queryable_result.Error());
+  if (!queryable_result.IsOk()) return Result<void>::ErrFrom(queryable_result);
   Queryable queryable = std::move(queryable_result).Value();
 
   auto subscriber_result = transport.DeclareSubscriber(
       declaration_key, [state](const TransportSample& sample) { OnSample(state, sample); });
-  if (!subscriber_result.IsOk()) return Result<void>::Err(subscriber_result.Error());
+  if (!subscriber_result.IsOk()) return Result<void>::ErrFrom(subscriber_result);
   Subscription subscriber = std::move(subscriber_result).Value();
 
   {

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -36,12 +36,9 @@ namespace sitos {
 
 namespace {
 
-// Error codes for conditions zenoh-c does not distinguish. These are
-// negative so they never collide with z_result_t values (>= 0).
-//
-// NOTE: full migration to the project "Status" enum (docs/04_api_cpp.md §1)
-// is tracked separately; these named sentinels are an interim improvement
-// over the bare MakeError(-1) magic number.
+// Adapter-defined error codes for conditions zenoh-c does not distinguish.
+// Semantic sentinel branches classify these codes explicitly into Status while
+// retaining them as the diagnostic cause, rather than using bare magic numbers.
 enum class TransportErrc {
   kErrDisconnected = -1,  // session not opened or already closed
   kErrInvalidArg = -2,    // invalid argument (e.g. negative timeout)

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -82,6 +82,12 @@ std::error_code MakeError(z_result_t rc) {
 
 std::error_code MakeError(TransportErrc ec) { return {static_cast<int>(ec), ZenohCategory()}; }
 
+template <typename T>
+Result<T> SemanticTransportError(Status status, TransportErrc code) {
+  const auto cause = MakeError(code);
+  return Result<T>::Err(status, cause.message(), cause);
+}
+
 // RAII wrapper for any z_owned_*_t. Calls z_drop(z_move(obj)) on destruction
 // and on close of the owning scope, removing the manual z_drop chains that
 // were previously duplicated across Put()/Reply(). Move-only; copying is
@@ -338,27 +344,27 @@ Result<void> TransportQuery::Reply(std::string_view key, std::span<const std::by
   if (test_reply_handler_) return test_reply_handler_(key, payload, encoding);
 
   if (!impl_ || !impl_->callback_state) {
-    return Result<void>::Err(MakeError(TransportErrc::kErrNoQuery));
+    return SemanticTransportError<void>(Status::Error, TransportErrc::kErrNoQuery);
   }
 
   auto enc = MakeEncoding(encoding);
-  if (!enc.IsOk()) return Result<void>::Err(enc.Error());
+  if (!enc.IsOk()) return Result<void>::ErrFrom(enc);
 
   auto ke = MakeKeyexpr(key);
-  if (!ke.IsOk()) return Result<void>::Err(ke.Error());
+  if (!ke.IsOk()) return Result<void>::ErrFrom(ke);
 
   auto p = MakeBytes(payload);
-  if (!p.IsOk()) return Result<void>::Err(p.Error());
+  if (!p.IsOk()) return Result<void>::ErrFrom(p);
 
   auto callback_state = impl_->callback_state;
   auto queryable = callback_state->queryable;
-  if (!queryable) return Result<void>::Err(MakeError(TransportErrc::kErrNoQuery));
+  if (!queryable) return SemanticTransportError<void>(Status::Error, TransportErrc::kErrNoQuery);
 
   // Hold the lock through z_query_reply() so Queryable::~Queryable() cannot
   // drop the underlying queryable while zenoh uses the loaned query.
   std::lock_guard<std::mutex> lock(queryable->mutex);
   if (!callback_state->active.load() || !queryable->alive || !callback_state->query) {
-    return Result<void>::Err(MakeError(TransportErrc::kErrNoQuery));
+    return SemanticTransportError<void>(Status::Error, TransportErrc::kErrNoQuery);
   }
 
   z_query_reply_options_t opts;
@@ -582,6 +588,8 @@ void Queryable::Reset() noexcept {
 
 namespace {
 
+struct DisconnectedTransportTag {};
+
 z_result_t OpenZenohSession(z_owned_session_t* session, z_moved_config_t* config) {
   return z_open(session, config, nullptr);
 }
@@ -625,6 +633,8 @@ class ZenohTransport : public Transport {
   }
 
  public:
+  explicit ZenohTransport(DisconnectedTransportTag) {}
+
   template <typename ConfigTransfer>
   explicit ZenohTransport(ConfigTransfer&& config_transfer)
       : open_result_(OpenZenohSession(
@@ -643,16 +653,18 @@ class ZenohTransport : public Transport {
 
   Result<void> Put(std::string_view key, std::span<const std::byte> payload, Encoding encoding,
                    PutOptions /*options*/) override {
-    if (!session_valid_) return Result<void>::Err(MakeError(TransportErrc::kErrDisconnected));
+    if (!session_valid_) {
+      return SemanticTransportError<void>(Status::Disconnected, TransportErrc::kErrDisconnected);
+    }
 
     auto enc = MakeEncoding(encoding);
-    if (!enc.IsOk()) return Result<void>::Err(enc.Error());
+    if (!enc.IsOk()) return Result<void>::ErrFrom(enc);
 
     auto ke = MakeKeyexpr(key);
-    if (!ke.IsOk()) return Result<void>::Err(ke.Error());
+    if (!ke.IsOk()) return Result<void>::ErrFrom(ke);
 
     auto p = MakeBytes(payload);
-    if (!p.IsOk()) return Result<void>::Err(p.Error());
+    if (!p.IsOk()) return Result<void>::ErrFrom(p);
 
     z_put_options_t opts;
     z_put_options_default(&opts);
@@ -665,10 +677,12 @@ class ZenohTransport : public Transport {
   }
 
   Result<void> Delete(std::string_view key, PutOptions /*options*/) override {
-    if (!session_valid_) return Result<void>::Err(MakeError(TransportErrc::kErrDisconnected));
+    if (!session_valid_) {
+      return SemanticTransportError<void>(Status::Disconnected, TransportErrc::kErrDisconnected);
+    }
 
     auto ke = MakeKeyexpr(key);
-    if (!ke.IsOk()) return Result<void>::Err(ke.Error());
+    if (!ke.IsOk()) return Result<void>::ErrFrom(ke);
 
     z_delete_options_t opts;
     z_delete_options_default(&opts);
@@ -681,11 +695,15 @@ class ZenohTransport : public Transport {
 
   Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
                    std::chrono::milliseconds timeout) override {
-    if (!session_valid_) return Result<void>::Err(MakeError(TransportErrc::kErrDisconnected));
-    if (timeout.count() < 0) return Result<void>::Err(MakeError(TransportErrc::kErrInvalidArg));
+    if (!session_valid_) {
+      return SemanticTransportError<void>(Status::Disconnected, TransportErrc::kErrDisconnected);
+    }
+    if (timeout.count() < 0) {
+      return SemanticTransportError<void>(Status::InvalidArgument, TransportErrc::kErrInvalidArg);
+    }
 
     auto ke = MakeKeyexpr(keyexpr);
-    if (!ke.IsOk()) return Result<void>::Err(ke.Error());
+    if (!ke.IsOk()) return Result<void>::ErrFrom(ke);
 
     auto* reply_ctx = new GetReplyCtx(sink);
 
@@ -708,12 +726,16 @@ class ZenohTransport : public Transport {
       std::string_view keyexpr_str,
       std::function<void(const TransportSample&)> callback) override {
     if (!session_valid_) {
-      return Result<Subscription>::Err(MakeError(TransportErrc::kErrDisconnected));
+      return SemanticTransportError<Subscription>(Status::Disconnected,
+                                                  TransportErrc::kErrDisconnected);
     }
-    if (!callback) return Result<Subscription>::Err(MakeError(TransportErrc::kErrInvalidArg));
+    if (!callback) {
+      return SemanticTransportError<Subscription>(Status::InvalidArgument,
+                                                  TransportErrc::kErrInvalidArg);
+    }
 
     auto ke = MakeKeyexpr(keyexpr_str);
-    if (!ke.IsOk()) return Result<Subscription>::Err(ke.Error());
+    if (!ke.IsOk()) return Result<Subscription>::ErrFrom(ke);
     Subscription subscription;
 
     subscription.impl_ = std::make_unique<Subscription::Impl>();
@@ -741,9 +763,13 @@ class ZenohTransport : public Transport {
       std::function<void(TransportQuery&)> callback) override {
     // An empty callback is a programming error; return an error rather than
     // registering a closure that would throw std::bad_function_call (#67).
-    if (!callback) return Result<Queryable>::Err(MakeError(TransportErrc::kErrInvalidArg));
+    if (!callback) {
+      return SemanticTransportError<Queryable>(Status::InvalidArgument,
+                                               TransportErrc::kErrInvalidArg);
+    }
     if (!session_valid_) {
-      return Result<Queryable>::Err(MakeError(TransportErrc::kErrDisconnected));
+      return SemanticTransportError<Queryable>(Status::Disconnected,
+                                               TransportErrc::kErrDisconnected);
     }
     Queryable q;
     q.impl_ = std::make_unique<Queryable::Impl>();
@@ -753,7 +779,7 @@ class ZenohTransport : public Transport {
     auto ke = MakeKeyexpr(keyexpr_str);
     if (!ke.IsOk()) {
       q.Reset();
-      return Result<Queryable>::Err(ke.Error());
+      return Result<Queryable>::ErrFrom(ke);
     }
 
     auto* context = new std::shared_ptr<QueryableState>(q.impl_->state);
@@ -781,6 +807,14 @@ class ZenohTransport : public Transport {
   z_result_t open_result_ = -1;
   bool session_valid_ = false;
 };
+
+namespace transport_test_access {
+
+std::unique_ptr<Transport> MakeDisconnectedTransport() {
+  return std::make_unique<ZenohTransport>(DisconnectedTransportTag{});
+}
+
+}  // namespace transport_test_access
 
 }  // namespace sitos
 

--- a/src/transport/zenoh_transport_test_access.hpp
+++ b/src/transport/zenoh_transport_test_access.hpp
@@ -7,6 +7,7 @@
 #define SITOS_TRANSPORT_ZENOH_TRANSPORT_TEST_ACCESS_HPP
 
 #include <functional>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -23,6 +24,9 @@ Encoding NormalizeWireEncoding(std::string wire_encoding);
 
 /// Verifies allocation failure occurs before a constructor argument transfers ownership.
 bool AllocationFailurePrecedesOwnershipTransfer();
+
+/// Returns a production transport with no opened Zenoh session.
+std::unique_ptr<Transport> MakeDisconnectedTransport();
 
 /// Internal access for Subscription ownership regression tests.
 class SubscriptionTestAccess {

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -295,8 +295,11 @@ class TransportTest : public ::testing::Test {
   std::unique_ptr<sitos::Transport> transport_;
 };
 
-TEST_F(TransportTest, InvalidArgumentsPreserveStatusMessageAndCause) {
-  const auto timeout_result = transport_->Get(
+TEST(ZenohTransportStatusTest, InvalidArgumentsPreserveStatusMessageAndCause) {
+  auto transport = sitos::MakeZenohTransport();
+  ASSERT_NE(transport, nullptr) << "Failed to open zenoh session";
+
+  const auto timeout_result = transport->Get(
       "sitos/test/status/invalid-timeout",
       [](std::string_view, std::span<const std::byte>, const sitos::Encoding&) { return true; },
       std::chrono::milliseconds(-1));
@@ -304,19 +307,22 @@ TEST_F(TransportTest, InvalidArgumentsPreserveStatusMessageAndCause) {
                            -2);
 
   const auto subscriber_result =
-      transport_->DeclareSubscriber("sitos/test/status/empty-subscriber", {});
+      transport->DeclareSubscriber("sitos/test/status/empty-subscriber", {});
   ExpectZenohSemanticError(subscriber_result, sitos::Status::InvalidArgument, "invalid argument",
                            -2);
 
   const auto queryable_result =
-      transport_->DeclareQueryable("sitos/test/status/empty-queryable", {});
+      transport->DeclareQueryable("sitos/test/status/empty-queryable", {});
   ExpectZenohSemanticError(queryable_result, sitos::Status::InvalidArgument, "invalid argument",
                            -2);
 }
 
-TEST_F(TransportTest, NativeKeyExpressionFailureRemainsError) {
+TEST(ZenohTransportStatusTest, NativeKeyExpressionFailureRemainsError) {
+  auto transport = sitos::MakeZenohTransport();
+  ASSERT_NE(transport, nullptr) << "Failed to open zenoh session";
+
   const std::vector<std::byte> payload = {std::byte{0x01}};
-  const auto result = transport_->Put("sitos//invalid", payload,
+  const auto result = transport->Put("sitos//invalid", payload,
                                       {std::string(sitos::Encoding::kSitosV1)}, {});
   ASSERT_FALSE(result.IsOk());
   EXPECT_EQ(result.StatusCode(), sitos::Status::Error);

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -235,6 +235,54 @@ TEST(ZenohEncodingTest, NormalizesCompatibleSitosWireEncodings) {
   EXPECT_EQ(NormalizeWireEncoding("application/json").id, "application/json");
 }
 
+template <typename T>
+void ExpectZenohSemanticError(const sitos::Result<T>& result, sitos::Status status,
+                              std::string_view message, int cause_value) {
+  ASSERT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), status);
+  EXPECT_EQ(result.Message(), message);
+  EXPECT_STREQ(result.Error().category().name(), "sitos.zenoh");
+  EXPECT_EQ(result.Error().value(), cause_value);
+  EXPECT_NE(result.Error().value(), 0);
+}
+
+TEST(ZenohTransportStatusTest, DisconnectedOperationsPreserveStatusMessageAndCause) {
+  auto transport = sitos::transport_test_access::MakeDisconnectedTransport();
+  ASSERT_NE(transport, nullptr);
+  const std::vector<std::byte> payload = {std::byte{0x01}};
+  const sitos::Encoding encoding{std::string(sitos::Encoding::kSitosV1)};
+
+  ExpectZenohSemanticError(
+      transport->Put("sitos/test/status/disconnected", payload, encoding, {}),
+      sitos::Status::Disconnected, "zenoh session is not available", -1);
+  ExpectZenohSemanticError(transport->Delete("sitos/test/status/disconnected", {}),
+                           sitos::Status::Disconnected, "zenoh session is not available", -1);
+  ExpectZenohSemanticError(
+      transport->Get(
+          "sitos/test/status/disconnected",
+          [](std::string_view, std::span<const std::byte>, const sitos::Encoding&) {
+            return true;
+          },
+          std::chrono::milliseconds(1)),
+      sitos::Status::Disconnected, "zenoh session is not available", -1);
+  ExpectZenohSemanticError(
+      transport->DeclareSubscriber("sitos/test/status/disconnected",
+                                   [](const sitos::TransportSample&) {}),
+      sitos::Status::Disconnected, "zenoh session is not available", -1);
+  ExpectZenohSemanticError(
+      transport->DeclareQueryable("sitos/test/status/disconnected",
+                                  [](sitos::TransportQuery&) {}),
+      sitos::Status::Disconnected, "zenoh session is not available", -1);
+}
+
+TEST(ZenohTransportStatusTest, DeadQueryPreservesStatusMessageAndCause) {
+  sitos::TransportQuery query;
+  ExpectZenohSemanticError(query.Reply("sitos/test/status/dead-query", {},
+                                       {std::string(sitos::Encoding::kSitosV1)}),
+                           sitos::Status::Error,
+                           "query is no longer valid (queryable destroyed)", -3);
+}
+
 class TransportTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -246,6 +294,36 @@ class TransportTest : public ::testing::Test {
 
   std::unique_ptr<sitos::Transport> transport_;
 };
+
+TEST_F(TransportTest, InvalidArgumentsPreserveStatusMessageAndCause) {
+  const auto timeout_result = transport_->Get(
+      "sitos/test/status/invalid-timeout",
+      [](std::string_view, std::span<const std::byte>, const sitos::Encoding&) { return true; },
+      std::chrono::milliseconds(-1));
+  ExpectZenohSemanticError(timeout_result, sitos::Status::InvalidArgument, "invalid argument",
+                           -2);
+
+  const auto subscriber_result =
+      transport_->DeclareSubscriber("sitos/test/status/empty-subscriber", {});
+  ExpectZenohSemanticError(subscriber_result, sitos::Status::InvalidArgument, "invalid argument",
+                           -2);
+
+  const auto queryable_result =
+      transport_->DeclareQueryable("sitos/test/status/empty-queryable", {});
+  ExpectZenohSemanticError(queryable_result, sitos::Status::InvalidArgument, "invalid argument",
+                           -2);
+}
+
+TEST_F(TransportTest, NativeKeyExpressionFailureRemainsError) {
+  const std::vector<std::byte> payload = {std::byte{0x01}};
+  const auto result = transport_->Put("sitos//invalid", payload,
+                                      {std::string(sitos::Encoding::kSitosV1)}, {});
+  ASSERT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), sitos::Status::Error);
+  EXPECT_TRUE(result.Message().empty());
+  EXPECT_STREQ(result.Error().category().name(), "sitos.zenoh");
+  EXPECT_NE(result.Error().value(), 0);
+}
 
 TEST_F(TransportTest, PutAndDeleteReturnOk) {
   std::vector<std::byte> payload = {std::byte{0x01}, std::byte{0x02}};

--- a/tests/unit/result_test.cpp
+++ b/tests/unit/result_test.cpp
@@ -128,6 +128,14 @@ TEST(ResultTest, AssignmentFailurePreservesAnObservableErrorState) {
   EXPECT_TRUE(target.Message().empty());
 }
 
+TEST(ResultTest, LegacyStatusCategoryRemainsError) {
+  const auto cause = MakeErrorCode(Status::Disconnected);
+  const auto result = Result<void>::Err(cause);
+  EXPECT_EQ(result.StatusCode(), Status::Error);
+  EXPECT_TRUE(result.Message().empty());
+  EXPECT_EQ(result.Error(), cause);
+}
+
 TEST(ResultTest, UnknownLegacyErrorsRemainErrors) {
   const auto cause = std::make_error_code(std::errc::file_exists);
   auto result = Result<void>::Err(cause);

--- a/tests/unit/storage_node_test.cpp
+++ b/tests/unit/storage_node_test.cpp
@@ -146,6 +146,11 @@ class FakeTransport final : public Transport {
       std::function<void(const TransportSample&)> callback) override {
     subscriber_keyexpr = std::string(keyexpr);
     subscriber_callback = std::move(callback);
+    if (subscriber_failure.has_value()) {
+      subscriber_callback = {};
+      return Result<Subscription>::Err(subscriber_failure->status, subscriber_failure->message,
+                                       subscriber_failure->cause);
+    }
     if (fail_subscriber) {
       subscriber_callback = {};
       return Result<Subscription>::Err(std::make_error_code(std::errc::io_error));
@@ -168,6 +173,11 @@ class FakeTransport final : public Transport {
       std::function<void(TransportQuery&)> callback) override {
     declared_keyexpr = std::string(keyexpr);
     query_callback = std::move(callback);
+    if (queryable_failure.has_value()) {
+      query_callback = {};
+      return Result<Queryable>::Err(queryable_failure->status, queryable_failure->message,
+                                    queryable_failure->cause);
+    }
     if (fail_queryable) {
       query_callback = {};
       return Result<Queryable>::Err(std::make_error_code(std::errc::io_error));
@@ -209,6 +219,8 @@ class FakeTransport final : public Transport {
   std::function<void(const TransportSample&)> subscriber_callback;
   bool fail_queryable = false;
   bool fail_subscriber = false;
+  std::optional<ErrorInfo> queryable_failure;
+  std::optional<ErrorInfo> subscriber_failure;
   bool invoke_queryable_during_declare = false;
   int queryable_declarations = 0;
   int subscriber_declarations = 0;
@@ -302,6 +314,49 @@ TEST(StorageNodeLifecycleTest, QueryableFailureDoesNotDeclareSubscriberAndCanRet
   transport.fail_queryable = false;
   ASSERT_TRUE(node.Start(std::make_shared<InMemoryEngine>(), {}).IsOk());
   node.Stop();
+}
+
+TEST(StorageNodeLifecycleTest, QueryableFailurePreservesErrorInfoAndCanRetry) {
+  FakeTransport transport;
+  const auto cause = MakeErrorCode(Status::Disconnected);
+  transport.queryable_failure = ErrorInfo{Status::Disconnected, "queryable offline", cause};
+  StorageNode node(transport);
+
+  auto result = node.Start(std::make_shared<InMemoryEngine>(), {});
+  ASSERT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), Status::Disconnected);
+  EXPECT_EQ(result.Message(), "queryable offline");
+  EXPECT_EQ(result.Error(), cause);
+  EXPECT_EQ(transport.subscriber_declarations, 0);
+  EXPECT_FALSE(node.IsStarted());
+
+  transport.queryable_failure.reset();
+  ASSERT_TRUE(node.Start(std::make_shared<InMemoryEngine>(), {}).IsOk());
+  EXPECT_TRUE(node.IsStarted());
+  node.Stop();
+}
+
+TEST(StorageNodeLifecycleTest, SubscriberFailurePreservesErrorInfoAndRollsBack) {
+  FakeTransport transport;
+  const auto cause = MakeErrorCode(Status::InvalidArgument);
+  transport.subscriber_failure = ErrorInfo{Status::InvalidArgument, "subscriber rejected", cause};
+  StorageNode node(transport);
+
+  auto result = node.Start(std::make_shared<InMemoryEngine>(), {});
+  ASSERT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), Status::InvalidArgument);
+  EXPECT_EQ(result.Message(), "subscriber rejected");
+  EXPECT_EQ(result.Error(), cause);
+  EXPECT_EQ(transport.queryable_resets, 1);
+  EXPECT_EQ(transport.subscriber_declarations, 0);
+  EXPECT_FALSE(node.IsStarted());
+
+  transport.subscriber_failure.reset();
+  ASSERT_TRUE(node.Start(std::make_shared<InMemoryEngine>(), {}).IsOk());
+  EXPECT_TRUE(node.IsStarted());
+  node.Stop();
+  EXPECT_EQ(transport.queryable_resets, 2);
+  EXPECT_EQ(transport.subscriber_resets, 1);
 }
 
 TEST(StorageNodeLifecycleTest, StagingCallbacksCannotTouchEngine) {


### PR DESCRIPTION
Closes #88

## Summary

- Classify known Zenoh adapter sentinels with explicit Status, message, and native cause.
- Preserve ErrorInfo through transport preparation and StorageNode declaration forwarding.
- Add deterministic semantic-status and rollback/retry regression coverage.

## Acceptance Criteria Verification

- [x] Disconnected Zenoh operations return `Status::Disconnected` with the original Zenoh cause.
- [x] Invalid adapter arguments return `Status::InvalidArgument` before native preparation.
- [x] Generic native failures remain `Status::Error`.
- [x] Type-changing forwarding preserves Status, Message, and Error through `ErrFrom`.
- [x] StorageNode queryable/subscriber failures preserve details while retaining rollback, stopped state, and retry.
- [x] Legacy `Err(std::error_code)` mapping and `Error()` compatibility remain unchanged.
- [x] Zenoh-enabled and Zenoh-disabled suites pass locally; CI will validate Linux, sanitizers, Windows, isolation, and static analysis.

## RED-phase Confirmation

Before the StorageNode implementation, the two new lifecycle tests failed correctly on the prior implementation:

```text
Expected: result.StatusCode() == Status::Disconnected
Actual:   Status::Error
Expected: result.Message() == "queryable offline"
Actual:   ""

Expected: result.StatusCode() == Status::InvalidArgument
Actual:   Status::Error
Expected: result.Message() == "subscriber rejected"
Actual:   ""
```

Before the Zenoh seam implementation, the new disconnected-operation test failed to link at test-only commit `4352869` because `MakeDisconnectedTransport()` was intentionally declared but not yet defined. Reproducing command:

```powershell
cmake --build build-85-on --target sitos_transport_test
```

Captured failure:

```text
transport_test.cpp.obj : error LNK2019: unresolved external symbol "std::unique_ptr<sitos::Transport> sitos::transport_test_access::MakeDisconnectedTransport(void)" referenced in ZenohTransportStatusTest_DisconnectedOperationsPreserveStatusMessageAndCause_Test::TestBody
tests\\sitos_transport_test.exe : fatal error LNK1120: 1 unresolved externals
```

## Validation

- Focused Result and StorageNode tests: 3/3 passed.
- Focused Zenoh semantic-status tests: 4/4 passed.
- Zenoh semantic-status tests repeated ten times: passed with `ctest --test-dir build-85-on --output-on-failure --repeat until-fail:10 -R 'ZenohTransportStatusTest|TransportTest.(InvalidArgumentsPreserveStatusMessageAndCause|NativeKeyExpressionFailureRemainsError)'` (all four semantic-status tests, including the two live-session tests).
- Full Zenoh OFF suite: 178/178 passed.
- Full Zenoh ON suite: 213/213 passed.
- `git diff --check`, lossless-forwarding audit, sentinel-construction audit, and secret scan passed.
- Local Linux sanitizer execution was unavailable because the installed WSL distribution has no CMake; required sanitizer validation remains a CI gate.

## ADR Needed

No. This applies ADR-0019's accepted Result error contract without changing public APIs, wire format, or the Get completion/thread model owned by ADR-0020 and #86.

## Scope

#86 synchronous Get completion, callback lifetime, timeout-zero behavior, callback serialization, and reply deduplication are intentionally not implemented here.
