### PR TITLE
fix(transport): separate adapter and zenoh error causes (#90)

### DIFF
--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -48,10 +48,12 @@ to `nullptr`. Configuration text is never retained or included in diagnostics.
 
 Client-facing status classification and `ClientConfig` validation are dependency-free and
 live in `status.hpp`, `result.hpp`, and `client_config.hpp`. The adapter explicitly classifies
-known disconnected and invalid-argument conditions with synthesized adapter causes through
-`Result::Error()`. Native Zenoh failures retain their original causes. Type-changing internal
-propagation uses `Result::ErrFrom` to retain Status, message, and cause; native Zenoh failures
-without a reliable semantic classification remain `Status::Error`.
+known disconnected and invalid-argument conditions with synthesized `sitos.transport` causes
+through `Result::Error()`. Native Zenoh failures retain `sitos.zenoh` causes. Distinct strongly
+typed construction paths and error categories prevent equal numeric values from crossing these
+diagnostic namespaces. Type-changing internal propagation uses `Result::ErrFrom` to retain
+Status, message, and cause; native Zenoh failures without a reliable semantic classification
+remain `Status::Error`.
 
 Higher-level components see only the following abstract API.
 

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -47,13 +47,14 @@ cause. `MakeZenohTransport()` remains the compatibility wrapper that converts an
 to `nullptr`. Configuration text is never retained or included in diagnostics.
 
 Client-facing status classification and `ClientConfig` validation are dependency-free and
-live in `status.hpp`, `result.hpp`, and `client_config.hpp`. The adapter explicitly classifies
-known disconnected and invalid-argument conditions with synthesized `sitos.transport` causes
-through `Result::Error()`. Native Zenoh failures retain `sitos.zenoh` causes. Distinct strongly
-typed construction paths and error categories prevent equal numeric values from crossing these
-diagnostic namespaces. Type-changing internal propagation uses `Result::ErrFrom` to retain
-Status, message, and cause; native Zenoh failures without a reliable semantic classification
-remain `Status::Error`.
+live in `status.hpp`, `result.hpp`, and `client_config.hpp`. The adapter creates synthesized
+`sitos.transport` causes for disconnected-session, invalid-operation-argument, and dead-query
+failures; callers observe these causes through `Result::Error()`. Pure input-validation failures
+may instead carry the corresponding `sitos.status` cause. Native Zenoh failures retain
+`sitos.zenoh` causes. Distinct strongly typed construction paths and error categories prevent
+equal numeric values from crossing these diagnostic namespaces. Type-changing internal
+propagation uses `Result::ErrFrom` to retain Status, message, and cause; native Zenoh failures
+without a reliable semantic classification remain `Status::Error`.
 
 Higher-level components see only the following abstract API.
 

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -21,6 +21,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <type_traits>
 
 #include "sitos/transport.hpp"
 
@@ -45,11 +46,24 @@ enum class TransportErrc {
   kErrNoQuery = -3,       // queryable destroyed or query unavailable
 };
 
-// A custom error_category so std::error_code::message() produces meaningful
-// text instead of the platform-dependent generic_category() strings.
+static_assert(!std::is_convertible_v<TransportErrc, z_result_t>);
+static_assert(!std::is_convertible_v<z_result_t, TransportErrc>);
+
+// Separate categories keep adapter-generated diagnostics distinct from native
+// zenoh-c results even when their numeric values are identical.
 class ZenohErrorCategory : public std::error_category {
  public:
   const char* name() const noexcept override { return "sitos.zenoh"; }
+
+  std::string message(int ev) const override {
+    if (ev == Z_OK) return "ok";
+    return "zenoh error code " + std::to_string(ev);
+  }
+};
+
+class TransportErrorCategory : public std::error_category {
+ public:
+  const char* name() const noexcept override { return "sitos.transport"; }
 
   std::string message(int ev) const override {
     using enum TransportErrc;
@@ -61,8 +75,7 @@ class ZenohErrorCategory : public std::error_category {
       case kErrNoQuery:
         return "query is no longer valid (queryable destroyed)";
       default:
-        if (ev == Z_OK) return "ok";
-        return "zenoh error code " + std::to_string(ev);
+        return "transport error code " + std::to_string(ev);
     }
   }
 };
@@ -72,16 +85,23 @@ const std::error_category& ZenohCategory() {
   return kCategory;
 }
 
-std::error_code MakeError(z_result_t rc) {
+const std::error_category& TransportCategory() {
+  static const TransportErrorCategory kCategory;
+  return kCategory;
+}
+
+std::error_code MakeZenohError(z_result_t rc) {
   if (rc == Z_OK) return {};
   return {static_cast<int>(rc), ZenohCategory()};
 }
 
-std::error_code MakeError(TransportErrc ec) { return {static_cast<int>(ec), ZenohCategory()}; }
+std::error_code MakeTransportError(TransportErrc ec) {
+  return {static_cast<int>(ec), TransportCategory()};
+}
 
 template <typename T>
 Result<T> SemanticTransportError(Status status, TransportErrc code) {
-  const auto cause = MakeError(code);
+  const auto cause = MakeTransportError(code);
   return Result<T>::Err(status, cause.message(), cause);
 }
 
@@ -164,7 +184,7 @@ class AllocationFailureProbe {
 Result<ZenohOwned<z_owned_keyexpr_t>> MakeKeyexpr(std::string_view key) {
   ZenohOwned<z_owned_keyexpr_t> ke;
   z_result_t rc = z_keyexpr_from_str(ke.get(), std::string(key).c_str());
-  if (rc != Z_OK) return Result<ZenohOwned<z_owned_keyexpr_t>>::Err(MakeError(rc));
+  if (rc != Z_OK) return Result<ZenohOwned<z_owned_keyexpr_t>>::Err(MakeZenohError(rc));
   ke.mark_valid();  // ownership acquired
   return Result<ZenohOwned<z_owned_keyexpr_t>>::Ok(std::move(ke));
 }
@@ -194,14 +214,14 @@ Result<ZenohOwned<z_owned_encoding_t>> MakeEncoding(const Encoding& enc) {
     z_result_t rc = z_encoding_set_schema_from_substr(z_enc.loan_mut(), schema->data(),
                                                        schema->size());
     if (rc != Z_OK) {
-      return Result<ZenohOwned<z_owned_encoding_t>>::Err(MakeError(rc));
+      return Result<ZenohOwned<z_owned_encoding_t>>::Err(MakeZenohError(rc));
     }
     return Result<ZenohOwned<z_owned_encoding_t>>::Ok(std::move(z_enc));
   }
 
   z_result_t rc = z_encoding_from_substr(z_enc.get(), enc.id.data(), enc.id.size());
   if (rc != Z_OK) {
-    return Result<ZenohOwned<z_owned_encoding_t>>::Err(MakeError(rc));
+    return Result<ZenohOwned<z_owned_encoding_t>>::Err(MakeZenohError(rc));
   }
   z_enc.mark_valid();
   return Result<ZenohOwned<z_owned_encoding_t>>::Ok(std::move(z_enc));
@@ -228,7 +248,7 @@ Result<ZenohOwned<z_owned_bytes_t>> MakeBytes(std::span<const std::byte> payload
   z_result_t rc = z_bytes_copy_from_buf(p.get(), reinterpret_cast<const uint8_t*>(payload.data()),
                                         payload.size());
   if (rc != Z_OK) {
-    return Result<ZenohOwned<z_owned_bytes_t>>::Err(MakeError(rc));
+    return Result<ZenohOwned<z_owned_bytes_t>>::Err(MakeZenohError(rc));
   }
   p.mark_valid();
   return Result<ZenohOwned<z_owned_bytes_t>>::Ok(std::move(p));
@@ -291,6 +311,10 @@ std::optional<std::string> BuildWireEncoding(const Encoding& encoding) {
 
 Encoding NormalizeWireEncoding(std::string wire_encoding) {
   return NormalizeEncoding(std::move(wire_encoding));
+}
+
+std::error_code MakeNativeError(std::int8_t code) {
+  return MakeZenohError(static_cast<z_result_t>(code));
 }
 
 bool AllocationFailurePrecedesOwnershipTransfer() {
@@ -370,7 +394,7 @@ Result<void> TransportQuery::Reply(std::string_view key, std::span<const std::by
 
   z_result_t rc = z_query_reply(callback_state->query, ke.Value().loan(), p.Value().moved(), &opts);
 
-  if (rc != Z_OK) return Result<void>::Err(MakeError(rc));
+  if (rc != Z_OK) return Result<void>::Err(MakeZenohError(rc));
   return Result<void>::Ok();
 }
 
@@ -669,7 +693,7 @@ class ZenohTransport : public Transport {
 
     z_result_t rc = z_put(z_session_loan(&session_), ke.Value().loan(), p.Value().moved(), &opts);
 
-    if (rc != Z_OK) return Result<void>::Err(MakeError(rc));
+    if (rc != Z_OK) return Result<void>::Err(MakeZenohError(rc));
     return Result<void>::Ok();
   }
 
@@ -686,7 +710,7 @@ class ZenohTransport : public Transport {
 
     z_result_t rc = z_delete(z_session_loan(&session_), ke.Value().loan(), &opts);
 
-    if (rc != Z_OK) return Result<void>::Err(MakeError(rc));
+    if (rc != Z_OK) return Result<void>::Err(MakeZenohError(rc));
     return Result<void>::Ok();
   }
 
@@ -715,7 +739,7 @@ class ZenohTransport : public Transport {
 
     z_result_t rc = z_get(z_session_loan(&session_), ke.Value().loan(), "", z_move(closure), &opts);
 
-    if (rc != Z_OK) return Result<void>::Err(MakeError(rc));
+    if (rc != Z_OK) return Result<void>::Err(MakeZenohError(rc));
     return Result<void>::Ok();
   }
 
@@ -750,7 +774,7 @@ class ZenohTransport : public Transport {
         z_move(closure), &options);
     if (decl_rc != Z_OK) {
       subscription.Reset();
-      return Result<Subscription>::Err(MakeError(decl_rc));
+      return Result<Subscription>::Err(MakeZenohError(decl_rc));
     }
     return Result<Subscription>::Ok(std::move(subscription));
   }
@@ -794,7 +818,7 @@ class ZenohTransport : public Transport {
 
     if (decl_rc != Z_OK) {
       q.Reset();
-      return Result<Queryable>::Err(MakeError(decl_rc));
+      return Result<Queryable>::Err(MakeZenohError(decl_rc));
     }
     return Result<Queryable>::Ok(std::move(q));
   }
@@ -835,16 +859,17 @@ sitos::Result<std::unique_ptr<sitos::Transport>> sitos::OpenZenohTransport(
     const auto status = transport_detail::ConfigFailureStatus(user_config_provided);
     const char* message = user_config_provided ? "invalid zenoh configuration"
                                                : "failed to create default zenoh configuration";
-    return Result<std::unique_ptr<Transport>>::Err(status, message, MakeError(config_result));
+    return Result<std::unique_ptr<Transport>>::Err(status, message,
+                                                   MakeZenohError(config_result));
   }
 
   config.mark_valid();
   auto transport = MakeUniqueWithDeferredTransfer<sitos::ZenohTransport>(
       [&config] { return config.moved(); });
   if (!transport->IsSessionValid()) {
-    return Result<std::unique_ptr<Transport>>::Err(Status::Error,
-                                                   "failed to open zenoh session",
-                                                   MakeError(transport->OpenResult()));
+    return Result<std::unique_ptr<Transport>>::Err(
+        Status::Error, "failed to open zenoh session",
+        MakeZenohError(transport->OpenResult()));
   }
   return Result<std::unique_ptr<Transport>>::Ok(std::move(transport));
 }

--- a/src/transport/zenoh_transport_test_access.hpp
+++ b/src/transport/zenoh_transport_test_access.hpp
@@ -6,11 +6,13 @@
 #ifndef SITOS_TRANSPORT_ZENOH_TRANSPORT_TEST_ACCESS_HPP
 #define SITOS_TRANSPORT_ZENOH_TRANSPORT_TEST_ACCESS_HPP
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <system_error>
 
 #include "sitos/transport.hpp"
 
@@ -21,6 +23,9 @@ std::optional<std::string> BuildWireEncoding(const Encoding& encoding);
 
 /// Applies the production receive-side normalization to a wire Encoding string.
 Encoding NormalizeWireEncoding(std::string wire_encoding);
+
+/// Returns the production diagnostic for a native zenoh-c result value.
+std::error_code MakeNativeError(std::int8_t code);
 
 /// Verifies allocation failure occurs before a constructor argument transfers ownership.
 bool AllocationFailurePrecedesOwnershipTransfer();

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -9,10 +9,12 @@
 
 #include "src/transport/zenoh_transport_test_access.hpp"
 
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <cstddef>
+#include <cstdint>
 #include <mutex>
 #include <stdexcept>
 #include <string>
@@ -235,13 +237,23 @@ TEST(ZenohEncodingTest, NormalizesCompatibleSitosWireEncodings) {
   EXPECT_EQ(NormalizeWireEncoding("application/json").id, "application/json");
 }
 
+TEST(ZenohTransportStatusTest, NativeCodesNeverUseAdapterDiagnostics) {
+  constexpr std::array<std::int8_t, 3> kCollidingCodes = {-1, -2, -3};
+  for (const auto code : kCollidingCodes) {
+    const auto error = sitos::transport_test_access::MakeNativeError(code);
+    EXPECT_STREQ(error.category().name(), "sitos.zenoh");
+    EXPECT_EQ(error.value(), code);
+    EXPECT_EQ(error.message(), "zenoh error code " + std::to_string(code));
+  }
+}
+
 template <typename T>
 void ExpectZenohSemanticError(const sitos::Result<T>& result, sitos::Status status,
                               std::string_view message, int cause_value) {
   ASSERT_FALSE(result.IsOk());
   EXPECT_EQ(result.StatusCode(), status);
   EXPECT_EQ(result.Message(), message);
-  EXPECT_STREQ(result.Error().category().name(), "sitos.zenoh");
+  EXPECT_STREQ(result.Error().category().name(), "sitos.transport");
   EXPECT_EQ(result.Error().value(), cause_value);
   EXPECT_NE(result.Error().value(), 0);
 }
@@ -328,7 +340,8 @@ TEST(ZenohTransportStatusTest, NativeKeyExpressionFailureRemainsError) {
   EXPECT_EQ(result.StatusCode(), sitos::Status::Error);
   EXPECT_TRUE(result.Message().empty());
   EXPECT_STREQ(result.Error().category().name(), "sitos.zenoh");
-  EXPECT_NE(result.Error().value(), 0);
+  EXPECT_EQ(result.Error().value(), -1);
+  EXPECT_EQ(result.Error().message(), "zenoh error code -1");
 }
 
 TEST_F(TransportTest, PutAndDeleteReturnOk) {


### PR DESCRIPTION
## Summary

- Separate adapter-generated semantic causes into the `sitos.transport` error category.
- Keep native zenoh-c return causes in `sitos.zenoh`, even when numeric values overlap.
- Use distinct strongly typed construction paths so native and adapter diagnostics cannot be mixed implicitly.
- Add regression coverage for native `-1`, `-2`, and `-3` plus the real invalid-key path.

Closes #90

## Scope checklist

- [x] Separate adapter sentinel diagnostics from every representable native `z_result_t` namespace.
- [x] Add compile-time type-separation guards.
- [x] Preserve public `Status`, `Result`, and native error behavior except for correcting diagnostics.
- [x] Update tests and dependency documentation.
- [x] Verify the pinned zenoh-c configuration locally.
- [x] Verify the dependency-upgrade minimum/latest configurations in GitHub Actions.

## TDD RED evidence

The four existing semantic-status paths failed before the implementation:

```text
ZenohTransportStatusTest.DisconnectedOperationsPreserveStatusMessageAndCause
Expected: "sitos.transport"
Actual:   "sitos.zenoh"

ZenohTransportStatusTest.DeadQueryPreservesStatusMessageAndCause
Expected: "sitos.transport"
Actual:   "sitos.zenoh"

ZenohTransportStatusTest.InvalidArgumentsPreserveStatusMessageAndCause
Expected: "sitos.transport"
Actual:   "sitos.zenoh"

ZenohTransportStatusTest.NativeKeyExpressionFailureRemainsError
Expected: "zenoh error code -1"
Actual:   "zenoh session is not available"
```

This directly reproduced the native `Z_EINVAL (-1)` misdiagnosis reported by Issue #90.

## Validation

- Zenoh ON: **214/214 passed**
- Zenoh OFF: **178/178 passed**
- `ZenohTransportStatusTest.*`: **5/5 passed**, repeated ten times
- `git diff --check`: passed
- Secret scan: passed
- Literal `\\n` commit-message scan: passed
- Dependency Upgrade workflow: minimum-supported and latest-stable matrix passed ([run 29505213456](https://github.com/tetsuh/sitos/actions/runs/29505213456)); both currently resolve to zenoh-c 1.9.0

## ADR judgment

No ADR is required. The PR changes neither public API nor wire protocol nor thread/consistency model; it corrects internal diagnostic namespace separation only.

## Out of scope

- `Transport::Get` completion, timeout, callback, and reply-cardinality changes (#86)
- ParamStore and acknowledgement behavior
