### PR TITLE
[ADR] feat(transport): synchronously complete Get requests (#86)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           UBSAN_OPTIONS: halt_on_error=1
         run: >-
           ctest --test-dir build/sanitizer-${{ matrix.name }}
-          --output-on-failure -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest'
+          --output-on-failure -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|TransportGetCompletionTest'
 
   build-windows:
     runs-on: windows-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(sitos STATIC
   src/in_memory_engine.cpp
   src/logging.cpp
   src/storage_node.cpp
+  src/transport/get_completion.cpp
   src/transport/declaration_handle_lifecycle.cpp
 )
 add_library(sitos::sitos ALIAS sitos)

--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -330,6 +330,7 @@ External client        Controller(StorageNode)          Calc(ParamCache)
 | Component | Threads |
 |---|---|
 | zenoh callbacks (queryable/subscriber) | zenoh internal thread pool. sitos callbacks return quickly (engine I/O is allowed; blocking waits are prohibited) |
+| Transport Get sink | zenoh reply callback. Sinks are serialized per request, must return quickly, and must not recursively call blocking Get on the same Transport (ADR-0020) |
 | ParamCache delta application | zenoh subscriber thread. The writer lock is held only briefly for replacement |
 | ParamCache Get | Any application thread (shared lock) [N07] |
 | Python callbacks | Dedicated dispatch thread + queue (the GIL is not acquired on zenoh threads) [P04] |

--- a/docs/04_api_cpp.md
+++ b/docs/04_api_cpp.md
@@ -115,8 +115,10 @@ Key arguments are `std::string_view` in all APIs. Invalid keys ([03] §1.2) prod
 `Status::InvalidKey`.
 
 The `Transport` abstraction (a zenoh adapter that provides put/get/queryable/subscriber) is
-defined in [09_dependency_policy.md](09_dependency_policy.md) §3.
-`ParamStore`/`ParamCache`/`StorageNode` do not expose raw zenoh-cpp types in the public API.
+defined in [09_dependency_policy.md](09_dependency_policy.md) §3. Its Get timeout must be
+strictly positive; successful Get returns after terminal reply completion with no subsequent
+sink callback (ADR-0020). `ParamStore`/`ParamCache`/`StorageNode` do not expose raw zenoh-cpp
+types in the public API.
 zenoh session injection [X04] is performed by converting the session to
 `std::shared_ptr<Transport>` with the `ZenohTransport::From(session)` factory before passing it in.
 

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -106,6 +106,14 @@ public:
 } // namespace sitos
 ```
 
+`Get` requires a strictly positive timeout and returns only after terminal
+reply-closure completion and callback quiescence. Terminal zero replies are
+successful transport completion. Sinks are serialized within one request and
+are never invoked after Get returns; a false result suppresses later delivery
+but does not bypass the completion wait. Distinct requests may invoke sinks
+concurrently. Low-level Get sinks must not recursively call blocking Get on the
+same Transport, but may call nonblocking Put or Delete. See ADR-0020.
+
 This abstraction is limited to **only the zenoh features that sitos needs**:
 
 | Feature | Purpose |

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -112,7 +112,9 @@ successful transport completion. Sinks are serialized within one request and
 are never invoked after Get returns; a false result suppresses later delivery
 but does not bypass the completion wait. Distinct requests may invoke sinks
 concurrently. Low-level Get sinks must not recursively call blocking Get on the
-same Transport, but may call nonblocking Put or Delete. See ADR-0020.
+same Transport, but may call nonblocking Put or Delete. An `Error` result does
+not imply the sink was never invoked: a reply-processing failure can follow the
+delivery of earlier concrete keys. See ADR-0020.
 
 This abstraction is limited to **only the zenoh features that sitos needs**:
 

--- a/docs/adr/0020-synchronously-complete-transport-get.md
+++ b/docs/adr/0020-synchronously-complete-transport-get.md
@@ -1,0 +1,54 @@
+# ADR-0020: Synchronously complete Transport Get requests
+
+## Status
+
+Proposed — 2026-07-16
+
+## Context
+
+`Transport::Get` is the low-level read primitive for future synchronous
+ParamStore and ParamCache operations. Returning after Zenoh query submission
+left reply callbacks active after the caller returned, so callers could not
+safely retain local collection state or distinguish terminal zero replies from
+an in-progress query. The transport must retain its backend isolation while
+providing a completion boundary that works in Zenoh-enabled and disabled builds.
+
+## Decision
+
+We will make a successful `Transport::Get` return only after Zenoh drops its
+reply closure and all C reply callbacks that entered for the request have
+finished. A strictly positive timeout bounds the Zenoh query collection window;
+terminal zero replies are successful transport completion. The adapter uses
+`LATEST` consolidation and a per-request first-observed-key fallback, serializes
+one request's sinks without serializing other requests, and suppresses later
+delivery after sink false or the first recorded failure.
+
+## Consequences
+
+* Good: callers can copy reply data during a sink and use it safely after Get
+  returns, without callbacks accessing caller state afterward.
+* Good: sink exceptions and native reply-processing errors are contained at the
+  C ABI boundary, reported as Error after quiescence, and cannot become false
+  zero-reply success.
+* Good: independent Get, Put, and Delete requests remain concurrently usable.
+* Bad: Get blocks through normal terminal closure even after a sink returns
+  false, so low-level sinks must remain short.
+* Bad: recursively calling blocking Get from its own low-level sink is
+  unsupported; nonblocking Put and Delete remain permitted.
+* Neutral: a zero-reply terminal completion is not Timeout. Higher-level
+  ParamStore semantics decide whether it means NotFound or an empty List.
+
+## Options Considered
+
+* **Return after query submission** — rejected because callbacks can outlive
+  caller-owned collection state and make synchronous clients unsafe.
+* **Expose a future or waitable handle** — rejected for v0.2 because the
+  existing Get signature can provide the required completion boundary directly.
+* **Serialize all requests with a session mutex** — rejected because unrelated
+  Gets and nonblocking writes must make independent progress.
+
+## References
+
+* Issue #86
+* ADR-0019
+* `include/sitos/transport.hpp`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,3 +24,4 @@ See [docs/10_adr_process.md](../10_adr_process.md) for the process.
 | [0017](0017-atomic-storage-node-lifecycle.md) | Use atomic, quiescent StorageNode lifecycle transitions |
 | [0018](0018-use-zenoh-valid-batch-key-segment.md) | Use a zenoh-valid batch key segment |
 | [0019](0019-client-result-status-configuration.md) | Additive client result and configuration foundation |
+| [0020](0020-synchronously-complete-transport-get.md) | Synchronously complete Transport Get requests |

--- a/include/sitos/transport.hpp
+++ b/include/sitos/transport.hpp
@@ -153,8 +153,15 @@ class Transport {
   virtual Result<void> Delete(std::string_view key, PutOptions options) = 0;
 
   /// Query results for the given key expression.
-  /// The sink is called once per matching key. Return false from the sink to
-  /// stop early.
+  ///
+  /// `timeout` must be strictly positive. Success returns only after the
+  /// native reply closure has dropped and every sink invocation for this
+  /// request has finished; no sink runs after this method returns. Zero replies
+  /// are successful transport completion. The sink is serialized per request,
+  /// receives each concrete key at most once, and may return false to suppress
+  /// later delivery while the method still waits for completion. Sink views are
+  /// valid only for the callback. A sink must not recursively call blocking
+  /// Get on the same Transport, but may call nonblocking Put or Delete.
   using QueryResultSink =
       std::function<bool(std::string_view key, std::span<const std::byte> payload,
                          Encoding encoding)>;

--- a/include/sitos/transport.hpp
+++ b/include/sitos/transport.hpp
@@ -162,6 +162,9 @@ class Transport {
   /// later delivery while the method still waits for completion. Sink views are
   /// valid only for the callback. A sink must not recursively call blocking
   /// Get on the same Transport, but may call nonblocking Put or Delete.
+  /// An Error result does not imply the sink was never invoked: a reply-
+  /// processing failure can occur after earlier concrete keys were already
+  /// delivered, so callers must not treat Error as "no data was seen".
   using QueryResultSink =
       std::function<bool(std::string_view key, std::span<const std::byte> payload,
                          Encoding encoding)>;

--- a/src/transport/get_completion.cpp
+++ b/src/transport/get_completion.cpp
@@ -37,12 +37,12 @@ void GetCompletion::CallbackLease::Release() noexcept {
 GetCompletion::GetCompletion(Transport::QueryResultSink sink) : sink_(std::move(sink)) {}
 
 GetCompletion::CallbackLease GetCompletion::AcquireCallbackLease(
-    const std::shared_ptr<GetCompletion>* completion_context) noexcept {
+    const std::shared_ptr<GetCompletion>& completion_owner) noexcept {
   std::shared_ptr<GetCompletion> completion;
   bool enrolled = false;
   {
     std::lock_guard<std::mutex> lock(state_mutex_);
-    completion = *completion_context;
+    completion = completion_owner;
     if (!dropped_) {
       ++in_flight_;
       enrolled = true;

--- a/src/transport/get_completion.cpp
+++ b/src/transport/get_completion.cpp
@@ -9,13 +9,17 @@
 namespace sitos::transport_internal {
 
 GetCompletion::CallbackLease::CallbackLease(CallbackLease&& other) noexcept
-    : completion_(std::move(other.completion_)) {}
+    : completion_(std::move(other.completion_)), enrolled_(other.enrolled_) {
+  other.enrolled_ = false;
+}
 
 GetCompletion::CallbackLease& GetCompletion::CallbackLease::operator=(
     CallbackLease&& other) noexcept {
   if (this != &other) {
     Release();
     completion_ = std::move(other.completion_);
+    enrolled_ = other.enrolled_;
+    other.enrolled_ = false;
   }
   return *this;
 }
@@ -23,21 +27,28 @@ GetCompletion::CallbackLease& GetCompletion::CallbackLease::operator=(
 GetCompletion::CallbackLease::~CallbackLease() { Release(); }
 
 void GetCompletion::CallbackLease::Release() noexcept {
-  if (completion_) {
+  if (completion_ && enrolled_) {
     completion_->ReleaseCallback();
-    completion_.reset();
   }
+  enrolled_ = false;
+  completion_.reset();
 }
 
 GetCompletion::GetCompletion(Transport::QueryResultSink sink) : sink_(std::move(sink)) {}
 
-GetCompletion::CallbackLease GetCompletion::AcquireCallbackLease() {
-  auto completion = shared_from_this();
+GetCompletion::CallbackLease GetCompletion::AcquireCallbackLease(
+    const std::shared_ptr<GetCompletion>* completion_context) noexcept {
+  std::shared_ptr<GetCompletion> completion;
+  bool enrolled = false;
   {
     std::lock_guard<std::mutex> lock(state_mutex_);
-    ++in_flight_;
+    completion = *completion_context;
+    if (!dropped_) {
+      ++in_flight_;
+      enrolled = true;
+    }
   }
-  return CallbackLease(std::move(completion));
+  return CallbackLease(std::move(completion), enrolled);
 }
 
 void GetCompletion::MarkDropped() noexcept {

--- a/src/transport/get_completion.cpp
+++ b/src/transport/get_completion.cpp
@@ -47,8 +47,7 @@ void GetCompletion::ProcessReply(const ReplyConverter& converter) noexcept {
   try {
     auto converted = converter();
     if (!converted.IsOk()) {
-      RecordFailure(
-          ErrorInfo{converted.StatusCode(), std::string(converted.Message()), converted.Error()});
+      RecordFailure(converted.StatusCode(), converted.Error(), FailureKind::kReplyConversion);
       return;
     }
 
@@ -83,8 +82,11 @@ void GetCompletion::RecordCallbackFailure() noexcept { RecordUnexpectedFailure()
 Result<void> GetCompletion::WaitForResult() {
   std::unique_lock<std::mutex> lock(state_mutex_);
   state_condition_.wait(lock, [this] { return dropped_ && in_flight_ == 0; });
-  if (failure_.has_value()) {
-    return Result<void>::Err(failure_->status, failure_->message, failure_->cause);
+  if (delivery_state_ == DeliveryState::kFailed) {
+    const char* message = failure_kind_ == FailureKind::kReplyConversion
+                              ? "failed to process zenoh get reply"
+                              : "get reply callback failed";
+    return Result<void>::Err(failure_status_, message, failure_cause_);
   }
   return Result<void>::Ok();
 }
@@ -98,17 +100,18 @@ void GetCompletion::ReleaseCallback() noexcept {
   state_condition_.notify_all();
 }
 
-void GetCompletion::RecordFailure(const ErrorInfo& error) noexcept {
+void GetCompletion::RecordFailure(Status status, std::error_code cause, FailureKind kind) noexcept {
   std::lock_guard<std::mutex> lock(state_mutex_);
   if (delivery_state_ == DeliveryState::kActive) {
     delivery_state_ = DeliveryState::kFailed;
-    failure_ = error;
+    failure_kind_ = kind;
+    failure_status_ = status;
+    failure_cause_ = cause ? cause : MakeErrorCode(status);
   }
 }
 
 void GetCompletion::RecordUnexpectedFailure() noexcept {
-  RecordFailure(
-      ErrorInfo{Status::Error, "get reply callback failed", MakeErrorCode(Status::Error)});
+  RecordFailure(Status::Error, MakeErrorCode(Status::Error), FailureKind::kCallbackException);
 }
 
 bool GetCompletion::IsActive() const {

--- a/src/transport/get_completion.cpp
+++ b/src/transport/get_completion.cpp
@@ -36,13 +36,11 @@ void GetCompletion::CallbackLease::Release() noexcept {
 
 GetCompletion::GetCompletion(Transport::QueryResultSink sink) : sink_(std::move(sink)) {}
 
-GetCompletion::CallbackLease GetCompletion::AcquireCallbackLease(
-    const std::shared_ptr<GetCompletion>& completion_owner) noexcept {
-  std::shared_ptr<GetCompletion> completion;
+GetCompletion::CallbackLease GetCompletion::AcquireCallbackLease() noexcept {
+  std::shared_ptr<GetCompletion> completion = shared_from_this();
   bool enrolled = false;
   {
     std::lock_guard<std::mutex> lock(state_mutex_);
-    completion = completion_owner;
     if (!dropped_) {
       ++in_flight_;
       enrolled = true;

--- a/src/transport/get_completion.cpp
+++ b/src/transport/get_completion.cpp
@@ -1,0 +1,119 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "get_completion.hpp"
+
+#include <cassert>
+#include <utility>
+
+namespace sitos::transport_internal {
+
+GetCompletion::CallbackLease::CallbackLease(CallbackLease&& other) noexcept
+    : completion_(std::move(other.completion_)) {}
+
+GetCompletion::CallbackLease& GetCompletion::CallbackLease::operator=(
+    CallbackLease&& other) noexcept {
+  if (this != &other) {
+    Release();
+    completion_ = std::move(other.completion_);
+  }
+  return *this;
+}
+
+GetCompletion::CallbackLease::~CallbackLease() { Release(); }
+
+void GetCompletion::CallbackLease::Release() noexcept {
+  if (completion_) {
+    completion_->ReleaseCallback();
+    completion_.reset();
+  }
+}
+
+GetCompletion::GetCompletion(Transport::QueryResultSink sink) : sink_(std::move(sink)) {}
+
+GetCompletion::CallbackLease GetCompletion::AcquireCallbackLease() {
+  auto completion = shared_from_this();
+  {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    ++in_flight_;
+  }
+  return CallbackLease(std::move(completion));
+}
+
+void GetCompletion::ProcessReply(const ReplyConverter& converter) noexcept {
+  std::unique_lock<std::mutex> delivery_lock(delivery_mutex_);
+  if (!IsActive()) return;
+
+  try {
+    auto converted = converter();
+    if (!converted.IsOk()) {
+      RecordFailure(
+          ErrorInfo{converted.StatusCode(), std::string(converted.Message()), converted.Error()});
+      return;
+    }
+
+    QueryReply reply = std::move(converted).Value();
+    {
+      std::lock_guard<std::mutex> lock(state_mutex_);
+      if (delivery_state_ != DeliveryState::kActive) return;
+      if (!delivered_keys_.insert(reply.key).second) return;
+    }
+
+    if (sink_ && !sink_(reply.key, reply.payload, reply.encoding)) {
+      std::lock_guard<std::mutex> lock(state_mutex_);
+      if (delivery_state_ == DeliveryState::kActive) {
+        delivery_state_ = DeliveryState::kStoppedBySink;
+      }
+    }
+  } catch (...) {
+    RecordUnexpectedFailure();
+  }
+}
+
+void GetCompletion::MarkDropped() noexcept {
+  {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    dropped_ = true;
+  }
+  state_condition_.notify_all();
+}
+
+void GetCompletion::RecordCallbackFailure() noexcept { RecordUnexpectedFailure(); }
+
+Result<void> GetCompletion::WaitForResult() {
+  std::unique_lock<std::mutex> lock(state_mutex_);
+  state_condition_.wait(lock, [this] { return dropped_ && in_flight_ == 0; });
+  if (failure_.has_value()) {
+    return Result<void>::Err(failure_->status, failure_->message, failure_->cause);
+  }
+  return Result<void>::Ok();
+}
+
+void GetCompletion::ReleaseCallback() noexcept {
+  {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    assert(in_flight_ > 0);
+    if (in_flight_ > 0) --in_flight_;
+  }
+  state_condition_.notify_all();
+}
+
+void GetCompletion::RecordFailure(const ErrorInfo& error) noexcept {
+  std::lock_guard<std::mutex> lock(state_mutex_);
+  if (delivery_state_ == DeliveryState::kActive) {
+    delivery_state_ = DeliveryState::kFailed;
+    failure_ = error;
+  }
+}
+
+void GetCompletion::RecordUnexpectedFailure() noexcept {
+  RecordFailure(
+      ErrorInfo{Status::Error, "get reply callback failed", MakeErrorCode(Status::Error)});
+}
+
+bool GetCompletion::IsActive() const {
+  std::lock_guard<std::mutex> lock(state_mutex_);
+  return delivery_state_ == DeliveryState::kActive;
+}
+
+}  // namespace sitos::transport_internal

--- a/src/transport/get_completion.cpp
+++ b/src/transport/get_completion.cpp
@@ -40,35 +40,6 @@ GetCompletion::CallbackLease GetCompletion::AcquireCallbackLease() {
   return CallbackLease(std::move(completion));
 }
 
-void GetCompletion::ProcessReply(const ReplyConverter& converter) noexcept {
-  std::unique_lock<std::mutex> delivery_lock(delivery_mutex_);
-  if (!IsActive()) return;
-
-  try {
-    auto converted = converter();
-    if (!converted.IsOk()) {
-      RecordFailure(converted.StatusCode(), converted.Error(), FailureKind::kReplyConversion);
-      return;
-    }
-
-    QueryReply reply = std::move(converted).Value();
-    {
-      std::lock_guard<std::mutex> lock(state_mutex_);
-      if (delivery_state_ != DeliveryState::kActive) return;
-      if (!delivered_keys_.insert(reply.key).second) return;
-    }
-
-    if (sink_ && !sink_(reply.key, reply.payload, reply.encoding)) {
-      std::lock_guard<std::mutex> lock(state_mutex_);
-      if (delivery_state_ == DeliveryState::kActive) {
-        delivery_state_ = DeliveryState::kStoppedBySink;
-      }
-    }
-  } catch (...) {
-    RecordUnexpectedFailure();
-  }
-}
-
 void GetCompletion::MarkDropped() noexcept {
   {
     std::lock_guard<std::mutex> lock(state_mutex_);

--- a/src/transport/get_completion.hpp
+++ b/src/transport/get_completion.hpp
@@ -60,9 +60,9 @@ class GetCompletion : public std::enable_shared_from_this<GetCompletion> {
   explicit GetCompletion(Transport::QueryResultSink sink);
 
   /// Enrolls the complete C callback before reply inspection or delivery waits.
-  /// The caller supplies a local owner copied from the native closure context.
-  CallbackLease AcquireCallbackLease(
-      const std::shared_ptr<GetCompletion>& completion_owner) noexcept;
+  /// The lease keeps this completion alive via shared_from_this(), so callers
+  /// must hold a live owning reference for the duration of the call.
+  CallbackLease AcquireCallbackLease() noexcept;
 
   /// Runs conversion and, if successful, delivery under the per-request gate.
   /// Conversion and sink failures become a terminal request error.

--- a/src/transport/get_completion.hpp
+++ b/src/transport/get_completion.hpp
@@ -43,20 +43,27 @@ class GetCompletion : public std::enable_shared_from_this<GetCompletion> {
     CallbackLease(const CallbackLease&) = delete;
     CallbackLease& operator=(const CallbackLease&) = delete;
 
+    GetCompletion& Completion() const noexcept { return *completion_; }
+    bool IsEnrolled() const noexcept { return enrolled_; }
+
    private:
     friend class GetCompletion;
-    explicit CallbackLease(std::shared_ptr<GetCompletion> completion)
-        : completion_(std::move(completion)) {}
+    explicit CallbackLease(std::shared_ptr<GetCompletion> completion, bool enrolled)
+        : completion_(std::move(completion)), enrolled_(enrolled) {}
 
     void Release() noexcept;
 
     std::shared_ptr<GetCompletion> completion_;
+    bool enrolled_ = false;
   };
 
   explicit GetCompletion(Transport::QueryResultSink sink);
 
   /// Enrolls the complete C callback before reply inspection or delivery waits.
-  CallbackLease AcquireCallbackLease();
+  /// The context owner is copied while the completion mutex is held so native
+  /// closure drop cannot race callback registration.
+  CallbackLease AcquireCallbackLease(
+      const std::shared_ptr<GetCompletion>* completion_context) noexcept;
 
   /// Runs conversion and, if successful, delivery under the per-request gate.
   /// Conversion and sink failures become a terminal request error.

--- a/src/transport/get_completion.hpp
+++ b/src/transport/get_completion.hpp
@@ -1,0 +1,94 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Per-request completion state shared by Transport::Get implementations.
+
+#ifndef SITOS_TRANSPORT_GET_COMPLETION_HPP
+#define SITOS_TRANSPORT_GET_COMPLETION_HPP
+
+#include <condition_variable>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <span>
+#include <string>
+#include <unordered_set>
+
+#include "sitos/transport.hpp"
+
+namespace sitos::transport_internal {
+
+/// A converted reply whose views remain valid only for ProcessReply().
+struct QueryReply {
+  std::string key;
+  std::span<const std::byte> payload;
+  Encoding encoding;
+  std::shared_ptr<void> payload_keepalive;
+};
+
+/// Shared completion and delivery state for exactly one Transport::Get request.
+class GetCompletion : public std::enable_shared_from_this<GetCompletion> {
+ public:
+  using ReplyConverter = std::function<Result<QueryReply>()>;
+
+  class CallbackLease {
+   public:
+    CallbackLease(CallbackLease&& other) noexcept;
+    CallbackLease& operator=(CallbackLease&& other) noexcept;
+    ~CallbackLease();
+
+    CallbackLease(const CallbackLease&) = delete;
+    CallbackLease& operator=(const CallbackLease&) = delete;
+
+   private:
+    friend class GetCompletion;
+    explicit CallbackLease(std::shared_ptr<GetCompletion> completion)
+        : completion_(std::move(completion)) {}
+
+    void Release() noexcept;
+
+    std::shared_ptr<GetCompletion> completion_;
+  };
+
+  explicit GetCompletion(Transport::QueryResultSink sink);
+
+  /// Enrolls the complete C callback before reply inspection or delivery waits.
+  CallbackLease AcquireCallbackLease();
+
+  /// Runs conversion and, if successful, delivery under the per-request gate.
+  /// Conversion and sink failures become a terminal request error.
+  void ProcessReply(const ReplyConverter& converter) noexcept;
+
+  /// Marks native reply-closure drop. It is idempotent for submission failures.
+  void MarkDropped() noexcept;
+
+  /// Records an exception that escaped work surrounding ProcessReply().
+  void RecordCallbackFailure() noexcept;
+
+  /// Waits for terminal closure drop and every callback that already entered.
+  Result<void> WaitForResult();
+
+ private:
+  enum class DeliveryState { kActive, kStoppedBySink, kFailed };
+
+  void ReleaseCallback() noexcept;
+  void RecordFailure(const ErrorInfo& error) noexcept;
+  void RecordUnexpectedFailure() noexcept;
+  bool IsActive() const;
+
+  Transport::QueryResultSink sink_;
+  mutable std::mutex state_mutex_;
+  std::condition_variable state_condition_;
+  bool dropped_ = false;
+  std::size_t in_flight_ = 0;
+  DeliveryState delivery_state_ = DeliveryState::kActive;
+  std::optional<ErrorInfo> failure_;
+  std::unordered_set<std::string> delivered_keys_;
+  std::mutex delivery_mutex_;
+};
+
+}  // namespace sitos::transport_internal
+
+#endif  // SITOS_TRANSPORT_GET_COMPLETION_HPP

--- a/src/transport/get_completion.hpp
+++ b/src/transport/get_completion.hpp
@@ -8,12 +8,12 @@
 
 #include <condition_variable>
 #include <cstddef>
-#include <functional>
 #include <memory>
 #include <mutex>
 #include <span>
 #include <string>
 #include <unordered_set>
+#include <utility>
 
 #include "sitos/transport.hpp"
 
@@ -29,9 +29,11 @@ struct QueryReply {
 
 /// Shared completion and delivery state for exactly one Transport::Get request.
 class GetCompletion : public std::enable_shared_from_this<GetCompletion> {
- public:
-  using ReplyConverter = std::function<Result<QueryReply>()>;
+ private:
+  enum class DeliveryState { kActive, kStoppedBySink, kFailed };
+  enum class FailureKind { kNone, kReplyConversion, kCallbackException };
 
+ public:
   class CallbackLease {
    public:
     CallbackLease(CallbackLease&& other) noexcept;
@@ -58,7 +60,35 @@ class GetCompletion : public std::enable_shared_from_this<GetCompletion> {
 
   /// Runs conversion and, if successful, delivery under the per-request gate.
   /// Conversion and sink failures become a terminal request error.
-  void ProcessReply(const ReplyConverter& converter) noexcept;
+  template <typename Converter>
+  void ProcessReply(Converter&& converter) noexcept {
+    std::unique_lock<std::mutex> delivery_lock(delivery_mutex_);
+    if (!IsActive()) return;
+
+    try {
+      auto converted = std::forward<Converter>(converter)();
+      if (!converted.IsOk()) {
+        RecordFailure(converted.StatusCode(), converted.Error(), FailureKind::kReplyConversion);
+        return;
+      }
+
+      QueryReply reply = std::move(converted).Value();
+      {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        if (delivery_state_ != DeliveryState::kActive) return;
+        if (!delivered_keys_.insert(reply.key).second) return;
+      }
+
+      if (sink_ && !sink_(reply.key, reply.payload, reply.encoding)) {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        if (delivery_state_ == DeliveryState::kActive) {
+          delivery_state_ = DeliveryState::kStoppedBySink;
+        }
+      }
+    } catch (...) {
+      RecordUnexpectedFailure();
+    }
+  }
 
   /// Marks native reply-closure drop. It is idempotent for submission failures.
   void MarkDropped() noexcept;
@@ -70,9 +100,6 @@ class GetCompletion : public std::enable_shared_from_this<GetCompletion> {
   Result<void> WaitForResult();
 
  private:
-  enum class DeliveryState { kActive, kStoppedBySink, kFailed };
-  enum class FailureKind { kNone, kReplyConversion, kCallbackException };
-
   void ReleaseCallback() noexcept;
   void RecordFailure(Status status, std::error_code cause, FailureKind kind) noexcept;
   void RecordUnexpectedFailure() noexcept;

--- a/src/transport/get_completion.hpp
+++ b/src/transport/get_completion.hpp
@@ -74,7 +74,7 @@ class GetCompletion : public std::enable_shared_from_this<GetCompletion> {
     try {
       auto converted = std::forward<Converter>(converter)();
       if (!converted.IsOk()) {
-        RecordFailure(converted.StatusCode(), converted.Error(), FailureKind::kReplyConversion);
+        RecordFailure(Status::Error, converted.Error(), FailureKind::kReplyConversion);
         return;
       }
 

--- a/src/transport/get_completion.hpp
+++ b/src/transport/get_completion.hpp
@@ -60,10 +60,9 @@ class GetCompletion : public std::enable_shared_from_this<GetCompletion> {
   explicit GetCompletion(Transport::QueryResultSink sink);
 
   /// Enrolls the complete C callback before reply inspection or delivery waits.
-  /// The context owner is copied while the completion mutex is held so native
-  /// closure drop cannot race callback registration.
+  /// The caller supplies a local owner copied from the native closure context.
   CallbackLease AcquireCallbackLease(
-      const std::shared_ptr<GetCompletion>* completion_context) noexcept;
+      const std::shared_ptr<GetCompletion>& completion_owner) noexcept;
 
   /// Runs conversion and, if successful, delivery under the per-request gate.
   /// Conversion and sink failures become a terminal request error.

--- a/src/transport/get_completion.hpp
+++ b/src/transport/get_completion.hpp
@@ -11,7 +11,6 @@
 #include <functional>
 #include <memory>
 #include <mutex>
-#include <optional>
 #include <span>
 #include <string>
 #include <unordered_set>
@@ -72,9 +71,10 @@ class GetCompletion : public std::enable_shared_from_this<GetCompletion> {
 
  private:
   enum class DeliveryState { kActive, kStoppedBySink, kFailed };
+  enum class FailureKind { kNone, kReplyConversion, kCallbackException };
 
   void ReleaseCallback() noexcept;
-  void RecordFailure(const ErrorInfo& error) noexcept;
+  void RecordFailure(Status status, std::error_code cause, FailureKind kind) noexcept;
   void RecordUnexpectedFailure() noexcept;
   bool IsActive() const;
 
@@ -84,7 +84,9 @@ class GetCompletion : public std::enable_shared_from_this<GetCompletion> {
   bool dropped_ = false;
   std::size_t in_flight_ = 0;
   DeliveryState delivery_state_ = DeliveryState::kActive;
-  std::optional<ErrorInfo> failure_;
+  FailureKind failure_kind_ = FailureKind::kNone;
+  Status failure_status_ = Status::Error;
+  std::error_code failure_cause_;
   std::unordered_set<std::string> delivered_keys_;
   std::mutex delivery_mutex_;
 };

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -310,7 +310,7 @@ void OnGetReply(z_loaned_reply_t* reply, void* context) noexcept {
     }
     if (!completion) return;
 
-    auto lease = completion->AcquireCallbackLease(completion);
+    auto lease = completion->AcquireCallbackLease();
     if (!lease.IsEnrolled()) return;
     lease.Completion().ProcessReply([reply] { return ConvertGetReply(reply); });
   } catch (...) {
@@ -320,8 +320,12 @@ void OnGetReply(z_loaned_reply_t* reply, void* context) noexcept {
 }
 
 void DropGetReplyContext(void* context) noexcept {
-  // zenoh never invokes a closure after its drop callback. The context mutex
-  // synchronizes a reply callback that began before terminal closure drop.
+  // Lifetime safety here rests on the zenoh-c contract: for one get, zenoh
+  // invokes the reply callback and this drop callback from the same query task,
+  // so they never overlap and drop runs only after the last reply returns. The
+  // mutex therefore does not (and cannot) protect this context's lifetime; it
+  // only guards the shared-owner handoff so the read in OnGetReply and the move
+  // below are not a data race under that ordering.
   std::unique_ptr<GetReplyContext> reply_context(static_cast<GetReplyContext*>(context));
   std::shared_ptr<transport_internal::GetCompletion> completion;
   {

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -293,10 +293,13 @@ Result<transport_internal::QueryReply> ConvertGetReply(z_loaned_reply_t* reply) 
 }
 
 void OnGetReply(z_loaned_reply_t* reply, void* context) noexcept {
-  std::shared_ptr<transport_internal::GetCompletion> completion;
+  transport_internal::GetCompletion* completion = nullptr;
   try {
-    completion = *static_cast<std::shared_ptr<transport_internal::GetCompletion>*>(context);
-    auto lease = completion->AcquireCallbackLease();
+    auto* completion_context =
+        static_cast<std::shared_ptr<transport_internal::GetCompletion>*>(context);
+    auto lease = (*completion_context)->AcquireCallbackLease(completion_context);
+    if (!lease.IsEnrolled()) return;
+    completion = &lease.Completion();
     completion->ProcessReply([reply] { return ConvertGetReply(reply); });
   } catch (...) {
     // Contain all C++ exceptions at the zenoh-c callback boundary (#67).

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -769,6 +769,7 @@ class ZenohTransport : public Transport {
       // z_get consumes the moved closure. Marking completion here is idempotent
       // if zenoh already invoked the drop callback while reporting the failure.
       completion->MarkDropped();
+      static_cast<void>(completion->WaitForResult());
       return Result<void>::Err(MakeZenohError(result));
     }
     return completion->WaitForResult();

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -292,15 +292,27 @@ Result<transport_internal::QueryReply> ConvertGetReply(z_loaned_reply_t* reply) 
                                      ReadEncoding(sample), std::move(slice)});
 }
 
+struct GetReplyContext {
+  explicit GetReplyContext(std::shared_ptr<transport_internal::GetCompletion> completion)
+      : completion(std::move(completion)) {}
+
+  std::mutex mutex;
+  std::shared_ptr<transport_internal::GetCompletion> completion;
+};
+
 void OnGetReply(z_loaned_reply_t* reply, void* context) noexcept {
-  transport_internal::GetCompletion* completion = nullptr;
+  std::shared_ptr<transport_internal::GetCompletion> completion;
   try {
-    auto* completion_context =
-        static_cast<std::shared_ptr<transport_internal::GetCompletion>*>(context);
-    auto lease = (*completion_context)->AcquireCallbackLease(completion_context);
+    auto* reply_context = static_cast<GetReplyContext*>(context);
+    {
+      std::lock_guard<std::mutex> lock(reply_context->mutex);
+      completion = reply_context->completion;
+    }
+    if (!completion) return;
+
+    auto lease = completion->AcquireCallbackLease(completion);
     if (!lease.IsEnrolled()) return;
-    completion = &lease.Completion();
-    completion->ProcessReply([reply] { return ConvertGetReply(reply); });
+    lease.Completion().ProcessReply([reply] { return ConvertGetReply(reply); });
   } catch (...) {
     // Contain all C++ exceptions at the zenoh-c callback boundary (#67).
     if (completion) completion->RecordCallbackFailure();
@@ -308,9 +320,14 @@ void OnGetReply(z_loaned_reply_t* reply, void* context) noexcept {
 }
 
 void DropGetReplyContext(void* context) noexcept {
-  std::unique_ptr<std::shared_ptr<transport_internal::GetCompletion>> completion_context(
-      static_cast<std::shared_ptr<transport_internal::GetCompletion>*>(context));
-  auto completion = std::move(*completion_context);
+  // zenoh never invokes a closure after its drop callback. The context mutex
+  // synchronizes a reply callback that began before terminal closure drop.
+  std::unique_ptr<GetReplyContext> reply_context(static_cast<GetReplyContext*>(context));
+  std::shared_ptr<transport_internal::GetCompletion> completion;
+  {
+    std::lock_guard<std::mutex> lock(reply_context->mutex);
+    completion = std::move(reply_context->completion);
+  }
   if (completion) completion->MarkDropped();
 }
 
@@ -759,7 +776,7 @@ class ZenohTransport : public Transport {
     if (!ke.IsOk()) return Result<void>::ErrFrom(ke);
 
     auto completion = std::make_shared<transport_internal::GetCompletion>(sink);
-    auto* context = new std::shared_ptr<transport_internal::GetCompletion>(completion);
+    auto* context = new GetReplyContext(completion);
     z_owned_closure_reply_t closure;
     z_closure_reply(&closure, OnGetReply, DropGetReplyContext, context);
 

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -27,6 +27,7 @@
 
 #include "config_failure.hpp"
 #include "declaration_handle_lifecycle.hpp"
+#include "get_completion.hpp"
 #include "zenoh_transport_test_access.hpp"
 
 namespace sitos {
@@ -254,44 +255,66 @@ Result<ZenohOwned<z_owned_bytes_t>> MakeBytes(std::span<const std::byte> payload
   return Result<ZenohOwned<z_owned_bytes_t>>::Ok(std::move(p));
 }
 
-struct GetReplyCtx {
-  explicit GetReplyCtx(const Transport::QueryResultSink& result_sink) : sink(result_sink) {}
+Result<transport_internal::QueryReply> ConvertGetReply(z_loaned_reply_t* reply) {
+  if (!z_reply_is_ok(reply)) {
+    return Result<transport_internal::QueryReply>::Err(
+        Status::Error, "zenoh get reply reported an error", MakeErrorCode(Status::Error));
+  }
 
-  Transport::QueryResultSink sink;
-  std::atomic<bool> stop{false};
-};
+  const z_loaned_sample_t* sample = z_reply_ok(reply);
+  if (sample == nullptr) {
+    return Result<transport_internal::QueryReply>::Err(
+        Status::Error, "zenoh get reply did not contain a sample", MakeErrorCode(Status::Error));
+  }
 
-void OnGetReply(z_loaned_reply_t* reply, void* context) {
-  auto* c = static_cast<GetReplyCtx*>(context);
+  const z_loaned_bytes_t* payload = z_sample_payload(sample);
+  if (payload == nullptr) {
+    return Result<transport_internal::QueryReply>::Err(
+        Status::Error, "zenoh get reply did not contain a payload", MakeErrorCode(Status::Error));
+  }
+  auto slice = std::make_shared<ZenohOwned<z_owned_slice_t>>();
+  const z_result_t slice_result = z_bytes_to_slice(payload, slice->get());
+  if (slice_result != Z_OK) {
+    return Result<transport_internal::QueryReply>::Err(
+        Status::Error, "failed to read zenoh get reply payload", MakeZenohError(slice_result));
+  }
+  slice->mark_valid();
+
+  z_view_string_t key_view;
+  z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_view);
+  std::string key(z_string_data(z_view_string_loan(&key_view)),
+                  z_string_len(z_view_string_loan(&key_view)));
+  const auto* data = reinterpret_cast<const std::byte*>(z_slice_data(slice->loan()));
+  const auto length = z_slice_len(slice->loan());
+
+  return Result<transport_internal::QueryReply>::Ok(
+      transport_internal::QueryReply{std::move(key), std::span<const std::byte>(data, length),
+                                     ReadEncoding(sample), std::move(slice)});
+}
+
+void OnGetReply(z_loaned_reply_t* reply, void* context) noexcept {
+  std::shared_ptr<transport_internal::GetCompletion> completion;
   try {
-    if (c->stop.load(std::memory_order_relaxed)) return;
-
-    const z_loaned_sample_t* sample = z_reply_ok(reply);
-    if (!sample) return;
-
-    const z_loaned_bytes_t* payload = z_sample_payload(sample);
-    ZenohOwned<z_owned_slice_t> slice;
-    if (z_bytes_to_slice(payload, slice.get()) != Z_OK) return;
-    slice.mark_valid();
-
-    const auto* data = reinterpret_cast<const std::byte*>(z_slice_data(slice.loan()));
-    auto len = z_slice_len(slice.loan());
-
-    z_view_string_t ks;
-    z_keyexpr_as_view_string(z_sample_keyexpr(sample), &ks);
-    std::string key_str(z_string_data(z_view_string_loan(&ks)),
-                        z_string_len(z_view_string_loan(&ks)));
-
-    Encoding enc = ReadEncoding(sample);
-
-    if (c->sink && !c->sink(key_str, std::span<const std::byte>(data, len), enc)) {
-      c->stop.store(true, std::memory_order_relaxed);
-    }
+    completion = *static_cast<std::shared_ptr<transport_internal::GetCompletion>*>(context);
+    auto lease = completion->AcquireCallbackLease();
+    completion->ProcessReply([reply] { return ConvertGetReply(reply); });
   } catch (...) {
     // Contain all C++ exceptions at the zenoh-c callback boundary (#67).
-    // The RAII slice owner drops a successfully-created slice while unwinding.
-    c->stop.store(true, std::memory_order_relaxed);
+    if (completion) completion->RecordCallbackFailure();
   }
+}
+
+void DropGetReplyContext(void* context) noexcept {
+  std::unique_ptr<std::shared_ptr<transport_internal::GetCompletion>> completion_context(
+      static_cast<std::shared_ptr<transport_internal::GetCompletion>*>(context));
+  auto completion = std::move(*completion_context);
+  if (completion) completion->MarkDropped();
+}
+
+void ConfigureGetOptions(z_get_options_t* options, std::chrono::milliseconds timeout) {
+  z_get_options_default(options);
+  options->consolidation.mode = Z_CONSOLIDATION_MODE_LATEST;
+  options->timeout_ms = static_cast<uint64_t>(timeout.count());
 }
 
 }  // namespace
@@ -326,6 +349,12 @@ bool AllocationFailurePrecedesOwnershipTransfer() {
     return !ownership_transferred;
   }
   return false;
+}
+
+bool UsesLatestGetConsolidation() {
+  z_get_options_t options;
+  ConfigureGetOptions(&options, std::chrono::milliseconds(1));
+  return options.consolidation.mode == Z_CONSOLIDATION_MODE_LATEST;
 }
 
 }  // namespace transport_test_access
@@ -716,31 +745,33 @@ class ZenohTransport : public Transport {
 
   Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
                    std::chrono::milliseconds timeout) override {
+    if (timeout.count() <= 0) {
+      return SemanticTransportError<void>(Status::InvalidArgument, TransportErrc::kErrInvalidArg);
+    }
     if (!session_valid_) {
       return SemanticTransportError<void>(Status::Disconnected, TransportErrc::kErrDisconnected);
-    }
-    if (timeout.count() < 0) {
-      return SemanticTransportError<void>(Status::InvalidArgument, TransportErrc::kErrInvalidArg);
     }
 
     auto ke = MakeKeyexpr(keyexpr);
     if (!ke.IsOk()) return Result<void>::ErrFrom(ke);
 
-    auto* reply_ctx = new GetReplyCtx(sink);
-
+    auto completion = std::make_shared<transport_internal::GetCompletion>(sink);
+    auto* context = new std::shared_ptr<transport_internal::GetCompletion>(completion);
     z_owned_closure_reply_t closure;
-    z_closure_reply(
-        &closure, OnGetReply, +[](void* context) { delete static_cast<GetReplyCtx*>(context); },
-        reply_ctx);
+    z_closure_reply(&closure, OnGetReply, DropGetReplyContext, context);
 
     z_get_options_t opts;
-    z_get_options_default(&opts);
-    opts.timeout_ms = static_cast<uint64_t>(timeout.count());
+    ConfigureGetOptions(&opts, timeout);
 
-    z_result_t rc = z_get(z_session_loan(&session_), ke.Value().loan(), "", z_move(closure), &opts);
-
-    if (rc != Z_OK) return Result<void>::Err(MakeZenohError(rc));
-    return Result<void>::Ok();
+    const z_result_t result =
+        z_get(z_session_loan(&session_), ke.Value().loan(), "", z_move(closure), &opts);
+    if (result != Z_OK) {
+      // z_get consumes the moved closure. Marking completion here is idempotent
+      // if zenoh already invoked the drop callback while reporting the failure.
+      completion->MarkDropped();
+      return Result<void>::Err(MakeZenohError(result));
+    }
+    return completion->WaitForResult();
   }
 
   Result<Subscription> DeclareSubscriber(

--- a/src/transport/zenoh_transport_test_access.hpp
+++ b/src/transport/zenoh_transport_test_access.hpp
@@ -30,6 +30,9 @@ std::error_code MakeNativeError(std::int8_t code);
 /// Verifies allocation failure occurs before a constructor argument transfers ownership.
 bool AllocationFailurePrecedesOwnershipTransfer();
 
+/// Verifies the production Get options select native LATEST consolidation.
+bool UsesLatestGetConsolidation();
+
 /// Returns a production transport with no opened Zenoh session.
 std::unique_ptr<Transport> MakeDisconnectedTransport();
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,7 +92,11 @@ target_link_libraries(sitos_transport_get_completion_test
   PRIVATE GTest::gtest_main sitos::sitos)
 target_include_directories(sitos_transport_get_completion_test PRIVATE ${PROJECT_SOURCE_DIR}/src)
 sitos_enable_warnings(sitos_transport_get_completion_test)
-gtest_discover_tests(sitos_transport_get_completion_test)
+# Use configure-time source discovery to avoid CMake 4.4 JSON discovery failures
+# for this zenoh-independent completion test on the Windows runner.
+gtest_add_tests(
+  TARGET sitos_transport_get_completion_test
+  SOURCES unit/transport_get_completion_test.cpp)
 
 add_executable(sitos_storage_node_test
   unit/storage_node_test.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -86,6 +86,14 @@ target_link_libraries(sitos_logging_test
 sitos_enable_warnings(sitos_logging_test)
 gtest_discover_tests(sitos_logging_test)
 
+add_executable(sitos_transport_get_completion_test
+  unit/transport_get_completion_test.cpp)
+target_link_libraries(sitos_transport_get_completion_test
+  PRIVATE GTest::gtest_main sitos::sitos)
+target_include_directories(sitos_transport_get_completion_test PRIVATE ${PROJECT_SOURCE_DIR}/src)
+sitos_enable_warnings(sitos_transport_get_completion_test)
+gtest_discover_tests(sitos_transport_get_completion_test)
+
 add_executable(sitos_storage_node_test
   unit/storage_node_test.cpp)
 target_link_libraries(sitos_storage_node_test

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -452,7 +452,9 @@ TEST_F(TransportTest, GetWaitsForTerminalCompletion) {
           sink_called = std::vector<std::byte>(payload.begin(), payload.end()) == kPayload;
           return true;
         },
-        std::chrono::milliseconds(2000));
+        // Generous relative to the 3s orchestration waits below so a loaded
+        // runner cannot let Get time out before the test releases the query.
+        std::chrono::milliseconds(10000));
     {
       std::lock_guard<std::mutex> lock(mutex);
       get_result = std::move(result);

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -238,6 +238,10 @@ TEST(ZenohEncodingTest, NormalizesCompatibleSitosWireEncodings) {
   EXPECT_EQ(NormalizeWireEncoding("application/json").id, "application/json");
 }
 
+TEST(ZenohTransportStatusTest, GetUsesLatestConsolidation) {
+  EXPECT_TRUE(sitos::transport_test_access::UsesLatestGetConsolidation());
+}
+
 TEST(ZenohTransportStatusTest, NativeCodesNeverUseAdapterDiagnostics) {
   constexpr std::array<std::int8_t, 3> kCollidingCodes = {-1, -2, -3};
   for (const auto code : kCollidingCodes) {

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -18,6 +18,7 @@
 #include <mutex>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <type_traits>
 #include <vector>
 
@@ -307,9 +308,28 @@ class TransportTest : public ::testing::Test {
   std::unique_ptr<sitos::Transport> transport_;
 };
 
+TEST(ZenohTransportStatusTest, ZeroTimeoutPrecedesDisconnectedSession) {
+  auto transport = sitos::transport_test_access::MakeDisconnectedTransport();
+  ASSERT_NE(transport, nullptr);
+
+  const auto result = transport->Get(
+      "sitos/test/status/zero-timeout-disconnected",
+      [](std::string_view, std::span<const std::byte>, const sitos::Encoding&) { return true; },
+      std::chrono::milliseconds::zero());
+
+  ExpectZenohSemanticError(result, sitos::Status::InvalidArgument, "invalid argument", -2);
+}
+
 TEST(ZenohTransportStatusTest, InvalidArgumentsPreserveStatusMessageAndCause) {
   auto transport = sitos::MakeZenohTransport();
   ASSERT_NE(transport, nullptr) << "Failed to open zenoh session";
+
+  const auto zero_timeout_result = transport->Get(
+      "sitos/test/status/zero-timeout",
+      [](std::string_view, std::span<const std::byte>, const sitos::Encoding&) { return true; },
+      std::chrono::milliseconds::zero());
+  ExpectZenohSemanticError(zero_timeout_result, sitos::Status::InvalidArgument, "invalid argument",
+                           -2);
 
   const auto timeout_result = transport->Get(
       "sitos/test/status/invalid-timeout",
@@ -372,6 +392,86 @@ TEST_F(TransportTest, GetWithoutQueryableDoesNotInvokeSink) {
   EXPECT_TRUE(result.IsOk());
   EXPECT_FALSE(callback_called)
       << "No queryable is registered, so the sink should not be invoked";
+}
+
+TEST_F(TransportTest, SinkFalseSuppressesLaterReplies) {
+  const std::string kSelector = "sitos/test/query/sink-false/**";
+  const std::vector<std::byte> kPayload = {std::byte{0x01}};
+  const sitos::Encoding kEncoding{std::string(sitos::Encoding::kSitosV1)};
+  int sink_calls = 0;
+
+  auto queryable = transport_->DeclareQueryable(kSelector, [&](sitos::TransportQuery& query) {
+    EXPECT_TRUE(query.Reply("sitos/test/query/sink-false/one", kPayload, kEncoding).IsOk());
+    EXPECT_TRUE(query.Reply("sitos/test/query/sink-false/two", kPayload, kEncoding).IsOk());
+  });
+  ASSERT_TRUE(queryable.IsOk()) << queryable.Error().message();
+
+  const auto result = transport_->Get(
+      kSelector,
+      [&](std::string_view, std::span<const std::byte>, const sitos::Encoding&) {
+        ++sink_calls;
+        return false;
+      },
+      std::chrono::milliseconds(1000));
+
+  EXPECT_TRUE(result.IsOk()) << result.Error().message();
+  EXPECT_EQ(sink_calls, 1);
+}
+
+TEST_F(TransportTest, GetWaitsForTerminalCompletion) {
+  const std::string kQueryKey = "sitos/test/query/terminal-completion";
+  const std::vector<std::byte> kPayload = {std::byte{0x01}};
+  const sitos::Encoding kEncoding{std::string(sitos::Encoding::kSitosV1)};
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool query_entered = false;
+  bool release_query = false;
+  bool get_returned = false;
+  bool sink_called = false;
+  sitos::Result<void> get_result = sitos::Result<void>::Err(sitos::Status::Error);
+
+  auto queryable = transport_->DeclareQueryable(kQueryKey, [&](sitos::TransportQuery& query) {
+    std::unique_lock<std::mutex> lock(mutex);
+    query_entered = true;
+    condition.notify_all();
+    condition.wait(lock, [&] { return release_query; });
+    lock.unlock();
+    EXPECT_TRUE(query.Reply(kQueryKey, kPayload, kEncoding).IsOk());
+  });
+  ASSERT_TRUE(queryable.IsOk()) << queryable.Error().message();
+
+  std::thread get_thread([&] {
+    auto result = transport_->Get(
+        kQueryKey,
+        [&](std::string_view, std::span<const std::byte> payload, const sitos::Encoding&) {
+          std::lock_guard<std::mutex> lock(mutex);
+          sink_called = std::vector<std::byte>(payload.begin(), payload.end()) == kPayload;
+          return true;
+        },
+        std::chrono::milliseconds(2000));
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      get_result = std::move(result);
+      get_returned = true;
+    }
+    condition.notify_all();
+  });
+
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(3), [&] { return query_entered; }));
+    EXPECT_FALSE(get_returned);
+    release_query = true;
+  }
+  condition.notify_all();
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(3), [&] { return get_returned; }));
+  }
+  get_thread.join();
+
+  EXPECT_TRUE(get_result.IsOk()) << get_result.Error().message();
+  EXPECT_TRUE(sink_called);
 }
 
 TEST_F(TransportTest, QueryableRoundTrip) {
@@ -585,7 +685,8 @@ TEST_F(TransportTest, GetSinkExceptionIsContained) {
       },
       std::chrono::milliseconds(2000));
 
-  EXPECT_TRUE(result.IsOk());
+  EXPECT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), sitos::Status::Error);
   {
     std::unique_lock<std::mutex> lock(sink_mutex);
     EXPECT_TRUE(sink_cv.wait_for(lock, std::chrono::seconds(3),

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -461,16 +461,22 @@ TEST_F(TransportTest, GetWaitsForTerminalCompletion) {
     condition.notify_all();
   });
 
+  bool entered_before_release = false;
   {
     std::unique_lock<std::mutex> lock(mutex);
-    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(3), [&] { return query_entered; }));
+    entered_before_release =
+        condition.wait_for(lock, std::chrono::seconds(3), [&] { return query_entered; });
+    EXPECT_TRUE(entered_before_release);
     EXPECT_FALSE(get_returned);
     release_query = true;
   }
   condition.notify_all();
+  bool returned_after_release = false;
   {
     std::unique_lock<std::mutex> lock(mutex);
-    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(3), [&] { return get_returned; }));
+    returned_after_release =
+        condition.wait_for(lock, std::chrono::seconds(3), [&] { return get_returned; });
+    EXPECT_TRUE(returned_after_release);
   }
   get_thread.join();
 

--- a/tests/unit/transport_get_completion_test.cpp
+++ b/tests/unit/transport_get_completion_test.cpp
@@ -168,20 +168,39 @@ TEST(TransportGetCompletionTest, FalseStillWaitsForTerminalDrop) {
 TEST(TransportGetCompletionTest, ExceptionSuppressesQueuedCallbacksAndReturnsError) {
   std::vector<std::byte> payload = {std::byte{0x01}};
   CallbackEntered second_entered;
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool first_sink_entered = false;
+  bool release_first_sink = false;
   int first_calls = 0;
   int second_converter_calls = 0;
   auto completion = std::make_shared<GetCompletion>(
       [&](std::string_view, std::span<const std::byte>, const Encoding&) -> bool {
-        ++first_calls;
+        {
+          std::unique_lock<std::mutex> lock(mutex);
+          ++first_calls;
+          first_sink_entered = true;
+          condition.notify_all();
+          condition.wait(lock, [&] { return release_first_sink; });
+        }
         throw std::runtime_error("sink failure");
       });
 
   auto first = StartReply(completion, nullptr, [&] { return Reply("sitos/test/first", payload); });
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(condition.wait_for(lock, 3s, [&] { return first_sink_entered; }));
+  }
   auto second = StartReply(completion, &second_entered, [&] {
     ++second_converter_calls;
     return Reply("sitos/test/second", payload);
   });
   second_entered.Wait();
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    release_first_sink = true;
+  }
+  condition.notify_all();
 
   first.get();
   second.get();
@@ -222,7 +241,8 @@ TEST(TransportGetCompletionTest, PreservesFirstConversionFailure) {
   {
     auto lease = completion->AcquireCallbackLease(completion);
     completion->ProcessReply([&] {
-      return Result<QueryReply>::Err(Status::Error, "first conversion failure", first_cause);
+      return Result<QueryReply>::Err(Status::InvalidArgument, "first conversion failure",
+                                     first_cause);
     });
   }
   {
@@ -235,6 +255,7 @@ TEST(TransportGetCompletionTest, PreservesFirstConversionFailure) {
 
   const auto result = completion->WaitForResult();
   ASSERT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), Status::Error);
   EXPECT_EQ(result.Error(), first_cause);
   EXPECT_EQ(result.Message(), "failed to process zenoh get reply");
 }

--- a/tests/unit/transport_get_completion_test.cpp
+++ b/tests/unit/transport_get_completion_test.cpp
@@ -1,0 +1,259 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <future>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "transport/get_completion.hpp"
+
+namespace {
+
+using namespace std::chrono_literals;
+using sitos::Encoding;
+using sitos::Result;
+using sitos::Status;
+using sitos::transport_internal::GetCompletion;
+using sitos::transport_internal::QueryReply;
+
+class BlockingSink {
+ public:
+  explicit BlockingSink(bool result = true) : result_(result) {}
+
+  bool operator()(std::string_view, std::span<const std::byte>, const Encoding&) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    entered_ = true;
+    condition_.notify_all();
+    condition_.wait(lock, [this] { return released_; });
+    return result_;
+  }
+
+  void WaitUntilEntered() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    ASSERT_TRUE(condition_.wait_for(lock, 3s, [this] { return entered_; }));
+  }
+
+  void Release() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    released_ = true;
+    condition_.notify_all();
+  }
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable condition_;
+  bool entered_ = false;
+  bool released_ = false;
+  bool result_;
+};
+
+class CallbackEntered {
+ public:
+  void Signal() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    entered_ = true;
+    condition_.notify_all();
+  }
+
+  void Wait() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    ASSERT_TRUE(condition_.wait_for(lock, 3s, [this] { return entered_; }));
+  }
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable condition_;
+  bool entered_ = false;
+};
+
+Result<QueryReply> Reply(std::string key, std::span<const std::byte> payload) {
+  return Result<QueryReply>::Ok(
+      QueryReply{std::move(key), payload, Encoding{std::string(Encoding::kSitosV1)}});
+}
+
+template <typename Converter>
+std::future<void> StartReply(const std::shared_ptr<GetCompletion>& completion,
+                             CallbackEntered* entered, Converter converter) {
+  return std::async(std::launch::async,
+                    [completion, entered, converter = std::move(converter)]() mutable {
+                      auto lease = completion->AcquireCallbackLease();
+                      if (entered != nullptr) entered->Signal();
+                      completion->ProcessReply(converter);
+                    });
+}
+
+TEST(TransportGetCompletionTest, WaitsForDropAndInFlightSink) {
+  std::vector<std::byte> payload = {std::byte{0x01}};
+  BlockingSink sink;
+  auto completion = std::make_shared<GetCompletion>(std::ref(sink));
+
+  auto waiter =
+      std::async(std::launch::async, [completion] { return completion->WaitForResult(); });
+  auto callback = StartReply(completion, nullptr, [&] { return Reply("sitos/test/one", payload); });
+  sink.WaitUntilEntered();
+
+  completion->MarkDropped();
+  EXPECT_EQ(waiter.wait_for(0ms), std::future_status::timeout);
+
+  sink.Release();
+  callback.get();
+  EXPECT_TRUE(waiter.get().IsOk());
+}
+
+TEST(TransportGetCompletionTest, FalseSuppressesQueuedCallbacksAndReturnsOk) {
+  std::vector<std::byte> payload = {std::byte{0x01}};
+  BlockingSink sink(false);
+  auto completion = std::make_shared<GetCompletion>(std::ref(sink));
+  CallbackEntered second_entered;
+  int second_converter_calls = 0;
+
+  auto first = StartReply(completion, nullptr, [&] { return Reply("sitos/test/first", payload); });
+  sink.WaitUntilEntered();
+  auto second = StartReply(completion, &second_entered, [&] {
+    ++second_converter_calls;
+    return Reply("sitos/test/second", payload);
+  });
+  second_entered.Wait();
+
+  sink.Release();
+  first.get();
+  second.get();
+  completion->MarkDropped();
+
+  EXPECT_EQ(second_converter_calls, 0);
+  EXPECT_TRUE(completion->WaitForResult().IsOk());
+}
+
+TEST(TransportGetCompletionTest, FalseStillWaitsForTerminalDrop) {
+  std::vector<std::byte> payload = {std::byte{0x01}};
+  auto completion = std::make_shared<GetCompletion>(
+      [](std::string_view, std::span<const std::byte>, const Encoding&) { return false; });
+
+  {
+    auto lease = completion->AcquireCallbackLease();
+    completion->ProcessReply([&] { return Reply("sitos/test/one", payload); });
+  }
+  auto waiter =
+      std::async(std::launch::async, [completion] { return completion->WaitForResult(); });
+
+  EXPECT_EQ(waiter.wait_for(0ms), std::future_status::timeout);
+  completion->MarkDropped();
+  EXPECT_TRUE(waiter.get().IsOk());
+}
+
+TEST(TransportGetCompletionTest, ExceptionSuppressesQueuedCallbacksAndReturnsError) {
+  std::vector<std::byte> payload = {std::byte{0x01}};
+  CallbackEntered second_entered;
+  int first_calls = 0;
+  int second_converter_calls = 0;
+  auto completion = std::make_shared<GetCompletion>(
+      [&](std::string_view, std::span<const std::byte>, const Encoding&) -> bool {
+        ++first_calls;
+        throw std::runtime_error("sink failure");
+      });
+
+  auto first = StartReply(completion, nullptr, [&] { return Reply("sitos/test/first", payload); });
+  auto second = StartReply(completion, &second_entered, [&] {
+    ++second_converter_calls;
+    return Reply("sitos/test/second", payload);
+  });
+  second_entered.Wait();
+
+  first.get();
+  second.get();
+  completion->MarkDropped();
+  const auto result = completion->WaitForResult();
+
+  EXPECT_EQ(first_calls, 1);
+  EXPECT_EQ(second_converter_calls, 0);
+  ASSERT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), Status::Error);
+}
+
+TEST(TransportGetCompletionTest, DeduplicatesConcreteKeysAndRetainsDistinctKeys) {
+  std::vector<std::byte> payload = {std::byte{0x01}};
+  std::vector<std::string> delivered;
+  auto completion = std::make_shared<GetCompletion>(
+      [&](std::string_view key, std::span<const std::byte>, const Encoding&) {
+        delivered.emplace_back(key);
+        return true;
+      });
+
+  for (const std::string_view key : {"sitos/test/one", "sitos/test/one", "sitos/test/two"}) {
+    auto lease = completion->AcquireCallbackLease();
+    completion->ProcessReply([&] { return Reply(std::string(key), payload); });
+  }
+  completion->MarkDropped();
+
+  EXPECT_TRUE(completion->WaitForResult().IsOk());
+  EXPECT_EQ(delivered, (std::vector<std::string>{"sitos/test/one", "sitos/test/two"}));
+}
+
+TEST(TransportGetCompletionTest, PreservesFirstConversionFailure) {
+  auto completion = std::make_shared<GetCompletion>(
+      [](std::string_view, std::span<const std::byte>, const Encoding&) { return true; });
+
+  {
+    auto lease = completion->AcquireCallbackLease();
+    completion->ProcessReply(
+        [] { return Result<QueryReply>::Err(Status::Error, "first conversion failure"); });
+  }
+  {
+    auto lease = completion->AcquireCallbackLease();
+    completion->ProcessReply(
+        [] { return Result<QueryReply>::Err(Status::Error, "second conversion failure"); });
+  }
+  completion->MarkDropped();
+
+  const auto result = completion->WaitForResult();
+  ASSERT_FALSE(result.IsOk());
+  EXPECT_EQ(result.Message(), "first conversion failure");
+}
+
+TEST(TransportGetCompletionTest, RepeatedStateTeardownIsSafe) {
+  std::vector<std::byte> payload = {std::byte{0x01}};
+  for (int index = 0; index < 100; ++index) {
+    auto completion = std::make_shared<GetCompletion>(
+        [](std::string_view, std::span<const std::byte>, const Encoding&) { return true; });
+    {
+      auto lease = completion->AcquireCallbackLease();
+      completion->ProcessReply([&] { return Reply("sitos/test/repeated", payload); });
+    }
+    completion->MarkDropped();
+    EXPECT_TRUE(completion->WaitForResult().IsOk());
+  }
+}
+
+TEST(TransportGetCompletionTest, IndependentRequestsInvokeSinksConcurrently) {
+  std::vector<std::byte> payload = {std::byte{0x01}};
+  BlockingSink first_sink;
+  BlockingSink second_sink;
+  auto first = std::make_shared<GetCompletion>(std::ref(first_sink));
+  auto second = std::make_shared<GetCompletion>(std::ref(second_sink));
+
+  auto first_callback =
+      StartReply(first, nullptr, [&] { return Reply("sitos/test/first", payload); });
+  auto second_callback =
+      StartReply(second, nullptr, [&] { return Reply("sitos/test/second", payload); });
+  first_sink.WaitUntilEntered();
+  second_sink.WaitUntilEntered();
+
+  first->MarkDropped();
+  second->MarkDropped();
+  first_sink.Release();
+  second_sink.Release();
+  first_callback.get();
+  second_callback.get();
+
+  EXPECT_TRUE(first->WaitForResult().IsOk());
+  EXPECT_TRUE(second->WaitForResult().IsOk());
+}
+
+}  // namespace

--- a/tests/unit/transport_get_completion_test.cpp
+++ b/tests/unit/transport_get_completion_test.cpp
@@ -84,8 +84,9 @@ std::future<void> StartReply(const std::shared_ptr<GetCompletion>& completion,
                              CallbackEntered* entered, Converter converter) {
   return std::async(std::launch::async,
                     [completion, entered, converter = std::move(converter)]() mutable {
-                      auto lease = completion->AcquireCallbackLease(completion);
+                      auto lease = completion->AcquireCallbackLease();
                       if (entered != nullptr) entered->Signal();
+                      if (!lease.IsEnrolled()) return;
                       completion->ProcessReply(converter);
                     });
 }
@@ -117,7 +118,7 @@ TEST(TransportGetCompletionTest, DropsLateCallbacksWithoutDelivery) {
       });
 
   completion->MarkDropped();
-  auto lease = completion->AcquireCallbackLease(completion);
+  auto lease = completion->AcquireCallbackLease();
 
   EXPECT_FALSE(lease.IsEnrolled());
   EXPECT_TRUE(completion->WaitForResult().IsOk());
@@ -154,7 +155,7 @@ TEST(TransportGetCompletionTest, FalseStillWaitsForTerminalDrop) {
       [](std::string_view, std::span<const std::byte>, const Encoding&) { return false; });
 
   {
-    auto lease = completion->AcquireCallbackLease(completion);
+    auto lease = completion->AcquireCallbackLease();
     completion->ProcessReply([&] { return Reply("sitos/test/one", payload); });
   }
   auto waiter =
@@ -223,7 +224,7 @@ TEST(TransportGetCompletionTest, DeduplicatesConcreteKeysAndRetainsDistinctKeys)
       });
 
   for (const std::string_view key : {"sitos/test/one", "sitos/test/one", "sitos/test/two"}) {
-    auto lease = completion->AcquireCallbackLease(completion);
+    auto lease = completion->AcquireCallbackLease();
     completion->ProcessReply([&] { return Reply(std::string(key), payload); });
   }
   completion->MarkDropped();
@@ -239,14 +240,14 @@ TEST(TransportGetCompletionTest, PreservesFirstConversionFailure) {
   const auto second_cause = std::make_error_code(std::errc::invalid_argument);
 
   {
-    auto lease = completion->AcquireCallbackLease(completion);
+    auto lease = completion->AcquireCallbackLease();
     completion->ProcessReply([&] {
       return Result<QueryReply>::Err(Status::InvalidArgument, "first conversion failure",
                                      first_cause);
     });
   }
   {
-    auto lease = completion->AcquireCallbackLease(completion);
+    auto lease = completion->AcquireCallbackLease();
     completion->ProcessReply([&] {
       return Result<QueryReply>::Err(Status::Error, "second conversion failure", second_cause);
     });
@@ -266,7 +267,7 @@ TEST(TransportGetCompletionTest, RepeatedStateTeardownIsSafe) {
     auto completion = std::make_shared<GetCompletion>(
         [](std::string_view, std::span<const std::byte>, const Encoding&) { return true; });
     {
-      auto lease = completion->AcquireCallbackLease(completion);
+      auto lease = completion->AcquireCallbackLease();
       completion->ProcessReply([&] { return Reply("sitos/test/repeated", payload); });
     }
     completion->MarkDropped();

--- a/tests/unit/transport_get_completion_test.cpp
+++ b/tests/unit/transport_get_completion_test.cpp
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -75,7 +76,7 @@ class CallbackEntered {
 
 Result<QueryReply> Reply(std::string key, std::span<const std::byte> payload) {
   return Result<QueryReply>::Ok(
-      QueryReply{std::move(key), payload, Encoding{std::string(Encoding::kSitosV1)}});
+      QueryReply{std::move(key), payload, Encoding{std::string(Encoding::kSitosV1)}, nullptr});
 }
 
 template <typename Converter>
@@ -199,22 +200,27 @@ TEST(TransportGetCompletionTest, DeduplicatesConcreteKeysAndRetainsDistinctKeys)
 TEST(TransportGetCompletionTest, PreservesFirstConversionFailure) {
   auto completion = std::make_shared<GetCompletion>(
       [](std::string_view, std::span<const std::byte>, const Encoding&) { return true; });
+  const auto first_cause = std::make_error_code(std::errc::io_error);
+  const auto second_cause = std::make_error_code(std::errc::invalid_argument);
 
   {
     auto lease = completion->AcquireCallbackLease();
-    completion->ProcessReply(
-        [] { return Result<QueryReply>::Err(Status::Error, "first conversion failure"); });
+    completion->ProcessReply([&] {
+      return Result<QueryReply>::Err(Status::Error, "first conversion failure", first_cause);
+    });
   }
   {
     auto lease = completion->AcquireCallbackLease();
-    completion->ProcessReply(
-        [] { return Result<QueryReply>::Err(Status::Error, "second conversion failure"); });
+    completion->ProcessReply([&] {
+      return Result<QueryReply>::Err(Status::Error, "second conversion failure", second_cause);
+    });
   }
   completion->MarkDropped();
 
   const auto result = completion->WaitForResult();
   ASSERT_FALSE(result.IsOk());
-  EXPECT_EQ(result.Message(), "first conversion failure");
+  EXPECT_EQ(result.Error(), first_cause);
+  EXPECT_EQ(result.Message(), "failed to process zenoh get reply");
 }
 
 TEST(TransportGetCompletionTest, RepeatedStateTeardownIsSafe) {

--- a/tests/unit/transport_get_completion_test.cpp
+++ b/tests/unit/transport_get_completion_test.cpp
@@ -84,7 +84,7 @@ std::future<void> StartReply(const std::shared_ptr<GetCompletion>& completion,
                              CallbackEntered* entered, Converter converter) {
   return std::async(std::launch::async,
                     [completion, entered, converter = std::move(converter)]() mutable {
-                      auto lease = completion->AcquireCallbackLease();
+                      auto lease = completion->AcquireCallbackLease(&completion);
                       if (entered != nullptr) entered->Signal();
                       completion->ProcessReply(converter);
                     });
@@ -106,6 +106,22 @@ TEST(TransportGetCompletionTest, WaitsForDropAndInFlightSink) {
   sink.Release();
   callback.get();
   EXPECT_TRUE(waiter.get().IsOk());
+}
+
+TEST(TransportGetCompletionTest, DropsLateCallbacksWithoutDelivery) {
+  int sink_calls = 0;
+  auto completion = std::make_shared<GetCompletion>(
+      [&](std::string_view, std::span<const std::byte>, const Encoding&) {
+        ++sink_calls;
+        return true;
+      });
+
+  completion->MarkDropped();
+  auto lease = completion->AcquireCallbackLease(&completion);
+
+  EXPECT_FALSE(lease.IsEnrolled());
+  EXPECT_TRUE(completion->WaitForResult().IsOk());
+  EXPECT_EQ(sink_calls, 0);
 }
 
 TEST(TransportGetCompletionTest, FalseSuppressesQueuedCallbacksAndReturnsOk) {
@@ -138,7 +154,7 @@ TEST(TransportGetCompletionTest, FalseStillWaitsForTerminalDrop) {
       [](std::string_view, std::span<const std::byte>, const Encoding&) { return false; });
 
   {
-    auto lease = completion->AcquireCallbackLease();
+    auto lease = completion->AcquireCallbackLease(&completion);
     completion->ProcessReply([&] { return Reply("sitos/test/one", payload); });
   }
   auto waiter =
@@ -188,7 +204,7 @@ TEST(TransportGetCompletionTest, DeduplicatesConcreteKeysAndRetainsDistinctKeys)
       });
 
   for (const std::string_view key : {"sitos/test/one", "sitos/test/one", "sitos/test/two"}) {
-    auto lease = completion->AcquireCallbackLease();
+    auto lease = completion->AcquireCallbackLease(&completion);
     completion->ProcessReply([&] { return Reply(std::string(key), payload); });
   }
   completion->MarkDropped();
@@ -204,13 +220,13 @@ TEST(TransportGetCompletionTest, PreservesFirstConversionFailure) {
   const auto second_cause = std::make_error_code(std::errc::invalid_argument);
 
   {
-    auto lease = completion->AcquireCallbackLease();
+    auto lease = completion->AcquireCallbackLease(&completion);
     completion->ProcessReply([&] {
       return Result<QueryReply>::Err(Status::Error, "first conversion failure", first_cause);
     });
   }
   {
-    auto lease = completion->AcquireCallbackLease();
+    auto lease = completion->AcquireCallbackLease(&completion);
     completion->ProcessReply([&] {
       return Result<QueryReply>::Err(Status::Error, "second conversion failure", second_cause);
     });
@@ -229,7 +245,7 @@ TEST(TransportGetCompletionTest, RepeatedStateTeardownIsSafe) {
     auto completion = std::make_shared<GetCompletion>(
         [](std::string_view, std::span<const std::byte>, const Encoding&) { return true; });
     {
-      auto lease = completion->AcquireCallbackLease();
+      auto lease = completion->AcquireCallbackLease(&completion);
       completion->ProcessReply([&] { return Reply("sitos/test/repeated", payload); });
     }
     completion->MarkDropped();

--- a/tests/unit/transport_get_completion_test.cpp
+++ b/tests/unit/transport_get_completion_test.cpp
@@ -84,7 +84,7 @@ std::future<void> StartReply(const std::shared_ptr<GetCompletion>& completion,
                              CallbackEntered* entered, Converter converter) {
   return std::async(std::launch::async,
                     [completion, entered, converter = std::move(converter)]() mutable {
-                      auto lease = completion->AcquireCallbackLease(&completion);
+                      auto lease = completion->AcquireCallbackLease(completion);
                       if (entered != nullptr) entered->Signal();
                       completion->ProcessReply(converter);
                     });
@@ -117,7 +117,7 @@ TEST(TransportGetCompletionTest, DropsLateCallbacksWithoutDelivery) {
       });
 
   completion->MarkDropped();
-  auto lease = completion->AcquireCallbackLease(&completion);
+  auto lease = completion->AcquireCallbackLease(completion);
 
   EXPECT_FALSE(lease.IsEnrolled());
   EXPECT_TRUE(completion->WaitForResult().IsOk());
@@ -154,7 +154,7 @@ TEST(TransportGetCompletionTest, FalseStillWaitsForTerminalDrop) {
       [](std::string_view, std::span<const std::byte>, const Encoding&) { return false; });
 
   {
-    auto lease = completion->AcquireCallbackLease(&completion);
+    auto lease = completion->AcquireCallbackLease(completion);
     completion->ProcessReply([&] { return Reply("sitos/test/one", payload); });
   }
   auto waiter =
@@ -204,7 +204,7 @@ TEST(TransportGetCompletionTest, DeduplicatesConcreteKeysAndRetainsDistinctKeys)
       });
 
   for (const std::string_view key : {"sitos/test/one", "sitos/test/one", "sitos/test/two"}) {
-    auto lease = completion->AcquireCallbackLease(&completion);
+    auto lease = completion->AcquireCallbackLease(completion);
     completion->ProcessReply([&] { return Reply(std::string(key), payload); });
   }
   completion->MarkDropped();
@@ -220,13 +220,13 @@ TEST(TransportGetCompletionTest, PreservesFirstConversionFailure) {
   const auto second_cause = std::make_error_code(std::errc::invalid_argument);
 
   {
-    auto lease = completion->AcquireCallbackLease(&completion);
+    auto lease = completion->AcquireCallbackLease(completion);
     completion->ProcessReply([&] {
       return Result<QueryReply>::Err(Status::Error, "first conversion failure", first_cause);
     });
   }
   {
-    auto lease = completion->AcquireCallbackLease(&completion);
+    auto lease = completion->AcquireCallbackLease(completion);
     completion->ProcessReply([&] {
       return Result<QueryReply>::Err(Status::Error, "second conversion failure", second_cause);
     });
@@ -245,7 +245,7 @@ TEST(TransportGetCompletionTest, RepeatedStateTeardownIsSafe) {
     auto completion = std::make_shared<GetCompletion>(
         [](std::string_view, std::span<const std::byte>, const Encoding&) { return true; });
     {
-      auto lease = completion->AcquireCallbackLease(&completion);
+      auto lease = completion->AcquireCallbackLease(completion);
       completion->ProcessReply([&] { return Reply("sitos/test/repeated", payload); });
     }
     completion->MarkDropped();


### PR DESCRIPTION
Closes #86

## Summary

- Make `Transport::Get` wait for terminal reply-closure drop and in-flight reply callback quiescence.
- Add a Zenoh-independent per-request completion state compiled in Zenoh-ON and Zenoh-OFF builds.
- Record sink, error-reply, and observable payload-conversion failures as `Status::Error`; select native `LATEST` consolidation.
- Document the strengthened public thread/completion contract in proposed ADR-0020.
- Harden failure recording to avoid `noexcept` callback-path string allocation, wait for entered callbacks on native submission failure, and synchronize closure-owner copy/transfer with callback enrollment and terminal drop.

## ADR

- [x] ADR-0020 is included as **Proposed**. It changes the public Get completion/thread contract and will change to Accepted immediately before merge after final review.

## Scope checklist

- [x] Preserve the `Transport::Get` signature while strengthening completion and callback lifetime.
- [x] Reject zero and negative timeouts before session/native work.
- [x] Wait for reply-closure drop and every entered reply callback; prevent post-return callbacks.
- [x] Treat terminal zero replies as successful transport completion.
- [x] Deduplicate concrete keys, retain first observed adapter-visible reply, and use native `LATEST` consolidation.
- [x] Suppress subsequent delivery after sink false while retaining the completion wait.
- [x] Return Error after native error replies, inconsistent replies, observable payload conversion failures, or sink exceptions.
- [x] Serialize one request's sinks without serializing independent requests.
- [x] Document low-level blocking-Get reentrancy as unsupported while retaining nonblocking Put/Delete.
- [x] Add ADR-0020 and update API, architecture, and dependency-policy documentation.

## TDD RED evidence

Retrospectively reproduced against pre-#86 main (`d1de9e2`) in a temporary worktree after applying only the new zero-timeout assertion:

```text
cmake -S . -B build-red -G Ninja -DCMAKE_BUILD_TYPE=Debug -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=ON
cmake --build build-red --target sitos_transport_test
ctest --test-dir build-red --output-on-failure -R '^ZenohTransportStatusTest\\.InvalidArgumentsPreserveStatusMessageAndCause$'
```

```text
[ RUN      ] ZenohTransportStatusTest.InvalidArgumentsPreserveStatusMessageAndCause
transport_test.cpp(253): error: Value of: result.IsOk()
  Actual: true
Expected: false
[  FAILED  ] ZenohTransportStatusTest.InvalidArgumentsPreserveStatusMessageAndCause
```

The initial implementation accepts `timeout == 0`; the completed implementation returns `Status::InvalidArgument` with the adapter cause before session/native work.

## Validation

- [x] Windows/MSVC Zenoh OFF full suite: 186/186 passed.
- [x] Windows/MSVC Zenoh ON full suite: 226/226 passed.
- [x] Shared completion-state tests cover dropped-plus-in-flight quiescence, sink-false terminal waiting, queued callback suppression, sink exception containment, first-error retention, deduplication, concurrent independent requests, and repeated teardown.
- [x] Live same-session tests cover zero replies, delayed query completion, false-return suppression, sink exception containment plus subsequent session usability, timeout validation, and explicit LATEST selection.
- [ ] Linux ASan/UBSan and TSan CI will exercise `TransportGetCompletionTest` after PR creation.
- [x] Transport isolation remains unchanged; no raw zenoh header is introduced outside `src/transport/`.

## Existing test change justification

`TransportTest.GetSinkExceptionIsContained` previously expected `Get` success after containing a throwing low-level sink. It now correctly expects `Status::Error`, while retaining its post-exception successful round trip. This is the required public-contract change: exceptions are contained at the C ABI boundary but reported to the synchronous caller after quiescence.

## Out of scope

No ParamStore, ParamCache, acknowledgement, wire-format, callback-executor, or recursive blocking-Get support is included.
