### PR TITLE
fix(build): migrate remaining test targets off runtime discovery (#93)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,24 +31,26 @@ add_sitos_public_header_compile_test(
 add_executable(sitos_bootstrap_test unit/bootstrap_test.cpp)
 target_link_libraries(sitos_bootstrap_test PRIVATE GTest::gtest_main sitos::sitos)
 sitos_enable_warnings(sitos_bootstrap_test)
-gtest_discover_tests(sitos_bootstrap_test)
+# Use configure-time source discovery to avoid CMake 4.4 JSON discovery
+# failures on the Windows runner (#93).
+gtest_add_tests(TARGET sitos_bootstrap_test SOURCES unit/bootstrap_test.cpp)
 
 add_executable(sitos_param_value_test unit/param_value_test.cpp)
 target_link_libraries(sitos_param_value_test PRIVATE GTest::gtest_main sitos::sitos)
 target_compile_definitions(sitos_param_value_test PRIVATE
   SITOS_FIXTURE_DIR="${SITOS_FIXTURE_DIR}")
 sitos_enable_warnings(sitos_param_value_test)
-gtest_discover_tests(sitos_param_value_test)
+gtest_add_tests(TARGET sitos_param_value_test SOURCES unit/param_value_test.cpp)
 
 add_executable(sitos_result_test unit/result_test.cpp)
 target_link_libraries(sitos_result_test PRIVATE GTest::gtest_main sitos::sitos)
 sitos_enable_warnings(sitos_result_test)
-gtest_discover_tests(sitos_result_test)
+gtest_add_tests(TARGET sitos_result_test SOURCES unit/result_test.cpp)
 
 add_executable(sitos_client_config_test unit/client_config_test.cpp)
 target_link_libraries(sitos_client_config_test PRIVATE GTest::gtest_main sitos::sitos)
 sitos_enable_warnings(sitos_client_config_test)
-gtest_discover_tests(sitos_client_config_test)
+gtest_add_tests(TARGET sitos_client_config_test SOURCES unit/client_config_test.cpp)
 
 add_executable(sitos_client_transport_factory_test unit/client_transport_factory_test.cpp)
 target_link_libraries(sitos_client_transport_factory_test PRIVATE GTest::gtest_main sitos::sitos)
@@ -58,33 +60,43 @@ if(SITOS_WITH_ZENOH)
   sitos_copy_zenohc(sitos_client_transport_factory_test)
 endif()
 sitos_enable_warnings(sitos_client_transport_factory_test)
-gtest_discover_tests(sitos_client_transport_factory_test)
+gtest_add_tests(
+  TARGET sitos_client_transport_factory_test
+  SOURCES unit/client_transport_factory_test.cpp)
 
 add_executable(sitos_key_test unit/key_test.cpp)
 target_link_libraries(sitos_key_test PRIVATE GTest::gtest_main sitos::sitos)
 sitos_enable_warnings(sitos_key_test)
-gtest_discover_tests(sitos_key_test)
+gtest_add_tests(TARGET sitos_key_test SOURCES unit/key_test.cpp)
 
+# sitos_storage_engine_contract_test and sitos_in_memory_engine_test are
+# intentionally NOT migrated to gtest_add_tests: their TEST_P cases come from
+# INSTANTIATE_STORAGE_ENGINE_CONTRACT_SUITE (storage_engine_contract.hpp),
+# so the literal TEST_P(...) text CMake's source parser needs never appears
+# in these .cpp files. Switching them would silently register zero tests.
+# DISCOVERY_MODE PRE_TEST moves the flaky JSON discovery out of the build
+# step (ninja) and into ctest, so a discovery hiccup no longer breaks the
+# build itself (#93).
 add_executable(sitos_storage_engine_contract_test
   unit/storage_engine_contract_test.cpp)
 target_link_libraries(sitos_storage_engine_contract_test
   PRIVATE GTest::gtest_main sitos::sitos)
 sitos_enable_warnings(sitos_storage_engine_contract_test)
-gtest_discover_tests(sitos_storage_engine_contract_test)
+gtest_discover_tests(sitos_storage_engine_contract_test DISCOVERY_MODE PRE_TEST)
 
 add_executable(sitos_in_memory_engine_test
   unit/in_memory_engine_test.cpp)
 target_link_libraries(sitos_in_memory_engine_test
   PRIVATE GTest::gtest_main sitos::sitos)
 sitos_enable_warnings(sitos_in_memory_engine_test)
-gtest_discover_tests(sitos_in_memory_engine_test)
+gtest_discover_tests(sitos_in_memory_engine_test DISCOVERY_MODE PRE_TEST)
 
 add_executable(sitos_logging_test
   unit/logging_test.cpp)
 target_link_libraries(sitos_logging_test
   PRIVATE GTest::gtest_main sitos::sitos)
 sitos_enable_warnings(sitos_logging_test)
-gtest_discover_tests(sitos_logging_test)
+gtest_add_tests(TARGET sitos_logging_test SOURCES unit/logging_test.cpp)
 
 add_executable(sitos_transport_get_completion_test
   unit/transport_get_completion_test.cpp)
@@ -107,7 +119,7 @@ sitos_enable_warnings(sitos_storage_node_test)
 if(SITOS_WITH_ZENOH)
   sitos_copy_zenohc(sitos_storage_node_test)
 endif()
-gtest_discover_tests(sitos_storage_node_test)
+gtest_add_tests(TARGET sitos_storage_node_test SOURCES unit/storage_node_test.cpp)
 
 # --- Zenoh smoke test (integration) ---
 if(SITOS_WITH_ZENOH)
@@ -118,7 +130,9 @@ if(SITOS_WITH_ZENOH)
   # Do NOT apply sitos_enable_warnings: the zenoh C header may trigger warnings
   # under -Werror that we cannot fix.
   sitos_copy_zenohc(sitos_zenoh_smoke_test)
-  gtest_discover_tests(sitos_zenoh_smoke_test)
+  gtest_add_tests(
+    TARGET sitos_zenoh_smoke_test
+    SOURCES integration/zenoh_smoke_test.cpp)
 
   add_executable(sitos_transport_test
     integration/transport_test.cpp)
@@ -127,7 +141,7 @@ if(SITOS_WITH_ZENOH)
   target_include_directories(sitos_transport_test PRIVATE ${PROJECT_SOURCE_DIR})
   sitos_enable_warnings(sitos_transport_test)
   sitos_copy_zenohc(sitos_transport_test)
-  gtest_discover_tests(sitos_transport_test)
+  gtest_add_tests(TARGET sitos_transport_test SOURCES integration/transport_test.cpp)
 
   add_executable(sitos_storage_node_query_test
     integration/storage_node_query_test.cpp)
@@ -135,7 +149,9 @@ if(SITOS_WITH_ZENOH)
     PRIVATE GTest::gtest_main sitos::sitos)
   sitos_enable_warnings(sitos_storage_node_query_test)
   sitos_copy_zenohc(sitos_storage_node_query_test)
-  gtest_discover_tests(sitos_storage_node_query_test)
+  gtest_add_tests(
+    TARGET sitos_storage_node_query_test
+    SOURCES integration/storage_node_query_test.cpp)
 
   add_executable(sitos_storage_node_subscriber_test
     integration/storage_node_subscriber_test.cpp)
@@ -143,7 +159,9 @@ if(SITOS_WITH_ZENOH)
     PRIVATE GTest::gtest_main sitos::sitos)
   sitos_enable_warnings(sitos_storage_node_subscriber_test)
   sitos_copy_zenohc(sitos_storage_node_subscriber_test)
-  gtest_discover_tests(sitos_storage_node_subscriber_test)
+  gtest_add_tests(
+    TARGET sitos_storage_node_subscriber_test
+    SOURCES integration/storage_node_subscriber_test.cpp)
 
   add_executable(sitos_storage_node_lifecycle_test
     integration/storage_node_lifecycle_test.cpp)
@@ -151,7 +169,9 @@ if(SITOS_WITH_ZENOH)
     PRIVATE GTest::gtest_main sitos::sitos)
   sitos_enable_warnings(sitos_storage_node_lifecycle_test)
   sitos_copy_zenohc(sitos_storage_node_lifecycle_test)
-  gtest_discover_tests(sitos_storage_node_lifecycle_test)
+  gtest_add_tests(
+    TARGET sitos_storage_node_lifecycle_test
+    SOURCES integration/storage_node_lifecycle_test.cpp)
 
   add_executable(sitos_storage_node_session_test
     integration/storage_node_session_test.cpp)
@@ -159,7 +179,9 @@ if(SITOS_WITH_ZENOH)
     PRIVATE GTest::gtest_main sitos::sitos)
   sitos_enable_warnings(sitos_storage_node_session_test)
   sitos_copy_zenohc(sitos_storage_node_session_test)
-  gtest_discover_tests(sitos_storage_node_session_test)
+  gtest_add_tests(
+    TARGET sitos_storage_node_session_test
+    SOURCES integration/storage_node_session_test.cpp)
 
   add_executable(sitos_batch_test
     integration/batch_test.cpp)
@@ -167,5 +189,5 @@ if(SITOS_WITH_ZENOH)
     PRIVATE GTest::gtest_main sitos::sitos)
   sitos_enable_warnings(sitos_batch_test)
   sitos_copy_zenohc(sitos_batch_test)
-  gtest_discover_tests(sitos_batch_test)
+  gtest_add_tests(TARGET sitos_batch_test SOURCES integration/batch_test.cpp)
 endif()


### PR DESCRIPTION
Closes #93

## Summary

- Migrate 15 test targets from `gtest_discover_tests` (runtime discovery) to `gtest_add_tests` (configure-time source parsing), matching the pattern already proven for `sitos_transport_get_completion_test` in #92/#86.
- Leave `sitos_storage_engine_contract_test` and `sitos_in_memory_engine_test` on `gtest_discover_tests`, but add `DISCOVERY_MODE PRE_TEST` so the flaky JSON parse moves out of the `ninja` build step and into `ctest`.

## Why two targets couldn't move to `gtest_add_tests`

Both targets' `TEST_P` cases come from the `INSTANTIATE_STORAGE_ENGINE_CONTRACT_SUITE` macro defined in `tests/unit/storage_engine_contract.hpp`. The literal `TEST_P(...)` text that `gtest_add_tests`' configure-time source scanner requires never appears in `storage_engine_contract_test.cpp` or `in_memory_engine_test.cpp` — it's hidden inside the macro expansion. Migrating them naively would have made CMake register **zero tests** for those two targets, silently dropping ~17 test cases each from CI without any error.

`DISCOVERY_MODE PRE_TEST` was the flagged mitigation for this case in #93: it defers the `--gtest_list_tests` JSON discovery from build time (where a hiccup breaks the `ninja` build itself, as seen in #92's `build-windows` failure) to `ctest` invocation time, without changing how tests are enumerated.

## Validation

Confirmed no tests were silently dropped by explicitly enumerating the `PRE_TEST` targets:

```
ctest -N -R MockEngineContractTest      # 17 cases (sitos_storage_engine_contract_test)
ctest -N -R InMemoryEngineContractTest  # 17 cases (sitos_in_memory_engine_test)
```

Full suite, both build configs, both green:

- Zenoh-OFF (`build-off`, MSVC + Ninja): **192/192** passed
- Zenoh-ON (`build/dev-on`, MSVC + Ninja): **229/229** passed
- Both configs build and link warning-clean under `/WX`

## Out of scope

No test behavior or coverage changes — this is discovery-mechanism only. Investigating a CMake version pin/upgrade as an alternate root-cause fix is left for a future issue if this recurs.
