### PR TITLE
feat(store): add ParamStore client operations (#15)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.20)
 project(sitos VERSION 0.1.0 LANGUAGES CXX)
 
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -55,6 +57,7 @@ endfunction()
 # Core library
 add_library(sitos STATIC
   src/client_config.cpp
+  src/param_store.cpp
   src/status.cpp
   src/param_value.cpp
   src/batch.cpp
@@ -85,3 +88,15 @@ if(SITOS_BUILD_TESTS)
   enable_testing()
   add_subdirectory(tests)
 endif()
+
+install(TARGETS sitos
+  EXPORT sitosTargets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(EXPORT sitosTargets
+  FILE sitosTargets.cmake
+  NAMESPACE sitos::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sitos)

--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -44,7 +44,7 @@ Requirement IDs ([01_requirements.md](01_requirements.md)) are referenced as [F.
 | `SessionView` | Logical view that resolves overlay → snapshot (thin facade over ParamStore/ParamCache) | ParamStore or ParamCache |
 
 **Design principle**: `engine/` does not know about zenoh. `ParamStore`/`ParamCache` do not
-know about engine. Direct dependencies on the zenoh-cpp API are confined to the
+know about engine. Direct dependencies on the zenoh-c API are confined to the
 `transport/zenoh` layer, and higher-level components see only the `Transport` abstraction.
 This limits the impact scope when zenoh is upgraded ([09_dependency_policy.md](09_dependency_policy.md)).
 
@@ -182,12 +182,12 @@ so `CloseSession` never invalidates an in-flight reply.
 * Relationship with puts around `CreateSession`: the snapshot contains
   “the contents already reflected in the engine at the moment StorageNode processes CreateSession”.
   The caller must confirm completion of all required base writes before starting a session
-  (because put passes through StorageNode receive processing,
-  `ParamStore::Put` by default performs a round-trip confirmation (ack) to the queryable. §6.2)
+  (because put passes through StorageNode receive processing, `ParamStore::Put` only reports
+  Transport submission; acknowledgement and retry policy belong to Issues #14 and #17. §6.2)
 
 ### 4.4 Transport Integration Pseudocode
 
-Pseudocode for implementers. StorageNode does not use the raw zenoh-cpp API directly;
+Pseudocode for implementers. StorageNode does not use the raw zenoh-c API directly;
 it goes through the `Transport` abstraction ([09_dependency_policy.md](09_dependency_policy.md) §3).
 
 ```cpp
@@ -286,21 +286,18 @@ initially fetches + subscribes to `base/**` (no snapshot isolation).
 
 ### 6.1 API Semantics
 
-* `Put(key, value)` / `Put(entries)` — a batch is one zenoh put
+* `Put(key, value)` / `PutBatch(entries)` — a batch is one `:batch` wire put
   (multi-entry format in the payload, [03](03_wire_protocol.md) §5) [F09]
-* `Get<T>(key)` — zenoh get (round trip). Not for the hot path
-* `List(prefix, sink)` — zenoh get `<prefix>**`
-* `Subscribe(pattern, callback)` — application-facing subscription [F13]
+* `Get<T>(key)` — synchronous exact zenoh get. Zero replies are `NotFound`.
+* `Contains(key)` — exact get with zero replies mapped to `Ok(false)`.
+* `List(prefix, sink)` — synchronous zenoh get using the narrowest safe chunk-boundary
+  selector, followed by client-side raw-prefix filtering and lexical sorting.
 
 ### 6.2 Put Completion Guarantee
 
-Because zenoh put is fire-and-forget, provide an option that guarantees
-“Put complete = reflected in StorageNode”:
-
-* `PutOptions::ack = true` (default): after put, get the StorageNode ack queryable
-  (`<prefix>/meta/ack/...`) to confirm reflection
-* `ack = false`: prioritize low latency (for example, in-flight puts to a session overlay,
-  where ordering alone is sufficient)
+ParamStore write success means only that Transport accepted/submitted the operation. It does
+not confirm StorageNode application, durability, or cache visibility. Acknowledged writes and
+retry policy belong to Issues #14 and #17; this API does not add a `put_ack` configuration field.
 
 ## 7. Session Lifecycle (Overall Sequence)
 
@@ -347,10 +344,9 @@ External client        Controller(StorageNode)          Calc(ParamCache)
 ## 10. Configuration (Config)
 
 ```cpp
-struct Config {
+struct ClientConfig {
     std::string prefix = "sitos";
-    std::optional<std::string> zenoh_config_json;  // zenoh Config (JSON5)
-    bool put_ack = true;
+    std::optional<std::string> zenoh_config_json;  // complete zenoh Config (JSON5)
     std::chrono::milliseconds query_timeout{5000};
 };
 ```

--- a/docs/04_api_cpp.md
+++ b/docs/04_api_cpp.md
@@ -86,20 +86,8 @@ struct ClientConfig {
 };
 Result<void> ValidateClientConfig(const ClientConfig& config);
 
-struct Config {
-    std::string prefix = "sitos";
-    std::optional<std::string> zenoh_config_json;  // zenoh Config (JSON5)
-    bool put_ack = true;
-    std::chrono::milliseconds query_timeout{5000};
-};
-
 /// Payload format identifier ([03] §2.2). Corresponds to transport Encoding.
 enum class Encoding { SitosV1, SitosV1Batch, Raw };
-
-/// Put completion guarantee option ([02] §6.2)
-struct PutOptions {
-    bool ack = true;
-};
 
 /// Common sink for List APIs. Returning false aborts enumeration.
 using ListSink = std::function<bool(std::string_view key, const ParamValue&)>;
@@ -117,10 +105,9 @@ Key arguments are `std::string_view` in all APIs. Invalid keys ([03] §1.2) prod
 The `Transport` abstraction (a zenoh adapter that provides put/get/queryable/subscriber) is
 defined in [09_dependency_policy.md](09_dependency_policy.md) §3. Its Get timeout must be
 strictly positive; successful Get returns after terminal reply completion with no subsequent
-sink callback (ADR-0020). `ParamStore`/`ParamCache`/`StorageNode` do not expose raw zenoh-cpp
-types in the public API.
-zenoh session injection [X04] is performed by converting the session to
-`std::shared_ptr<Transport>` with the `ZenohTransport::From(session)` factory before passing it in.
+sink callback (ADR-0020). `ParamStore`/`ParamCache`/`StorageNode` do not expose raw zenoh-c
+types in the public API. An injected `std::shared_ptr<Transport>` can be passed directly to
+`ParamStore::Open`; configuration-aware Zenoh session creation remains an internal factory detail.
 
 ### 1.1 Status / Python Exception Mapping
 
@@ -129,7 +116,7 @@ zenoh session injection [X04] is performed by converting the session to
 | `Ok` | Success | None |
 | `NotFound` | get target absent, nonexistent session | `sitos.NotFoundError` |
 | `TypeMismatch` | Type conversion impossible, Bytes dtype/size mismatch | `sitos.TypeMismatchError` |
-| `Timeout` | query/ack does not complete within `Config::query_timeout` | `sitos.TimeoutError` |
+| `Timeout` | query does not complete within `ClientConfig::query_timeout` | `sitos.TimeoutError` |
 | `Disconnected` | zenoh session disconnected, StorageNode stopped | `sitos.DisconnectedError` |
 | `ReadOnly` | put/delete through the library API to `snap/<sid>/**` | `sitos.ReadOnlyError` |
 | `InvalidKey` | Key/scope/session id violates the grammar | `ValueError` |
@@ -143,45 +130,44 @@ All other Status values are converted to exceptions.
 
 ```cpp
 class ParamStore {
-public:
-    /// Open a new zenoh session (creates ZenohTransport internally)
-    static Result<ParamStore> Open(const Config& config);
-    /// Share an existing Transport [X04]
-    static Result<ParamStore> Open(std::shared_ptr<Transport> transport,
-                                   const Config& config);
+ public:
+  static Result<ParamStore> Open(ClientConfig config = {});
+  static Result<ParamStore> Open(std::shared_ptr<Transport> transport,
+                                 ClientConfig config = {});
 
-    // ---- Writes (scope: "base" or "session/<sid>") ----
-    Result<void> Put(std::string_view scope, std::string_view key,
-                     const ParamValue& value);
-    template<typename T>
-    Result<void> Put(std::string_view scope, std::string_view key, T&& value);
-    /// Batch [F09]: atomically delivered in one zenoh put
-    Result<void> PutBatch(std::string_view scope,
-                          std::span<const std::pair<std::string, ParamValue>> entries);
-    Result<void> Delete(std::string_view scope, std::string_view key); // base only [F12]
+  ParamStore(const ParamStore&) = delete;
+  ParamStore& operator=(const ParamStore&) = delete;
+  ParamStore(ParamStore&&) noexcept = default;
+  ParamStore& operator=(ParamStore&&) noexcept = default;
 
-    // ---- Reads (round trip. Use ParamCache for the hot path) ----
-    Result<ParamValue> Get(std::string_view scope, std::string_view key);
-    template<typename T>
-    Result<T> Get(std::string_view scope, std::string_view key);
-    bool Contains(std::string_view scope, std::string_view key);      // [F11]
+  Result<void> Put(std::string_view scope, std::string_view key,
+                   const ParamValue& value);
+  template <ParamInput T>
+  Result<void> Put(std::string_view scope, std::string_view key, T&& value);
+  Result<void> PutBatch(std::string_view scope,
+                        std::span<const BatchEntry> entries);
+  Result<void> Delete(std::string_view scope, std::string_view key);
 
-    /// Enumerate under prefix (chunk boundary). Abort if sink returns false. [F03]
-    Result<void> List(std::string_view scope, std::string_view prefix,
-                      const ListSink& sink);
-
-    // ---- Subscription [F13] ----
-    class Subscription;  // RAII. Destruction unsubscribes
-    using SubscribeCallback =
-        std::function<void(std::string_view key, const ParamValue&)>;
-    Result<Subscription> Subscribe(std::string_view scope,
-                                   std::string_view key_pattern,
-                                   SubscribeCallback callback);
+  Result<ParamValue> Get(std::string_view scope, std::string_view key);
+  template <SupportedParamType T>
+  Result<T> Get(std::string_view scope, std::string_view key);
+  Result<bool> Contains(std::string_view scope, std::string_view key);
+  Result<void> List(std::string_view scope, std::string_view prefix,
+                    const ListSink& sink);
 };
 ```
 
-`scope` format: `"base"`, `"session/<sid>"`, `"snap/<sid>"` (read-only).
-Put/Delete to `snap` returns `Status::ReadOnly`.
+`scope` is `"base"`, `"session/<sid>"`, or `"snap/<sid>"`. Snapshot writes return
+`Status::ReadOnly`; session Delete returns `Status::InvalidKey`. `Put`, `PutBatch`, and
+`Delete` report Transport submission only and do not wait for node application. `PutBatch`
+uses the canonical `:batch` key and sends one `sitos.v1.batch` message; an empty valid batch
+sends no message.
+
+`Get` waits for synchronous Transport completion. Zero replies map to `NotFound`, while
+`Contains` maps them to `Ok(false)`. `List` collects and validates all matching replies,
+sorts relative keys lexicographically, then invokes the sink on the caller thread. A false
+sink result is normal early termination; sink exceptions propagate unchanged. Raw prefixes
+are used: `foo` matches `foo`, `foo/bar`, and `foobar`, while `foo/` matches descendants only.
 
 ## 3. StorageEngine / StorageNode — Storage Node Side
 

--- a/docs/05_api_python.md
+++ b/docs/05_api_python.md
@@ -21,12 +21,16 @@ nanobind wrapper for the C++ core + a thin pythonic layer [P01].
 
 ### 2.1 ParamStore
 
+The Python ParamStore API is planned for the v0.3 Python lane and is not implemented by
+Issue #15. Its future configuration must not imply acknowledged writes; acknowledgement
+and retry policy belong to Issues #14 and #17.
+
 ```python
+# Planned v0.3 API (not currently available)
 import sitos
 
-store = sitos.ParamStore(prefix="sitos", zenoh_config=None, put_ack=True)
-# Or share an existing zenoh session:
-# store = sitos.ParamStore.from_zenoh_session(session, prefix="sitos")
+store = sitos.ParamStore(prefix="sitos", zenoh_config=None)
+# Or share an existing transport/session when the Python facade is implemented.
 
 store.put("base", "recon/fov", 240.0)
 store.put_batch("base", {"recon/fov": 240.0, "recon/kernel": "sharp"})

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -38,7 +38,7 @@ sitos/
 * **Language** (D9): code, comments, commit messages, Issues/PRs, and docs are English.
   This design document set is the English edition in `docs/`
 * Dependency resolution:
-  - **zenoh-c/zenoh-cpp**: First choice is to use official prebuilt releases via
+  - **zenoh-c**: First choice is to use official prebuilt releases via
     `find_package(zenohc)`. CI pins versions with FetchContent.
     Also provide a Corrosion (Rust) path for environments that need source builds
   - **RocksDB** (when `SITOS_WITH_ROCKSDB=ON`): `find_package(RocksDB)`.
@@ -49,7 +49,18 @@ sitos/
 * Presets: define `dev-windows`, `dev-linux`, `release`, and `python-wheel` in
   `CMakePresets.json`
 
-## 3. Build (Python wheel)
+## 3. Install (C++ consumer)
+
+The C++ library and public headers can be installed with the generated CMake export:
+
+```sh
+cmake --install build/release --prefix /opt/sitos
+```
+
+This installs `include/sitos/*`, the static library, and `sitosTargets.cmake` under
+`lib/cmake/sitos`. Consumers can link the exported `sitos::sitos` target.
+
+## 4. Build (Python wheel)
 
 * scikit-build-core + nanobind. Generate wheels with `python -m build`
 * CI build with cibuildwheel: `cp310–cp313 × {win_amd64, manylinux_2_28_x86_64}` [P03]
@@ -58,12 +69,12 @@ sitos/
   RocksDBEngine is separated as a `sitos-rocksdb` wheel or a future optional extra.
 * Runtime dependency: `numpy>=1.24`
 
-## 4. Test strategy
+## 5. Test strategy
 
 | Layer | Framework | Target | Run in CI |
 |---|---|---|---|
-| unit | gtest | ParamValue encode/decode (payload v1 golden tests), StorageEngine contract tests (common test suite instantiated for each engine), key validation, Overlay resolution | Always |
-| integration | gtest | Connect StorageNode + ParamStore + ParamCache with multiple zenoh sessions in one process. Full session lifecycle ([02] §7), disconnect/reconnect [N10], batch, ack | Always |
+| unit | gtest | ParamValue encode/decode (payload v1 golden tests), StorageEngine contract tests (common test suite instantiated for each engine), key validation, ParamStore validation/read semantics, Overlay resolution | Always |
+| integration | gtest | Connect StorageNode + ParamStore + ParamCache through one injected same-process Transport. Full session lifecycle ([02] §7), ParamStore round trips, disconnect/reconnect [N10], batch, ack | Always |
 | multiprocess | gtest + spawn | Attach/delivery/crash recovery with real process isolation | Always (Linux) / nightly (Windows) |
 | interop | pytest + zenoh-python | Read/write using only the wire specification ([03]) without the sitos library [C03] | Always |
 | python | pytest | API parity, NumPy zero-copy (writeable=False, base-buffer identity), GIL (concurrent get inside callback) | Always |
@@ -76,7 +87,7 @@ form reusable for InMemory/RocksDB/(future user engines) [X01].
 for encoded results (the cornerstone of compatibility across languages and versions).
 The Python side also references the same fixtures.
 
-### 4.1 Required test names
+### 5.1 Required test names
 
 To prevent AI/implementers from misreading the intent, the following test names are fixed for
 major behaviors.
@@ -96,7 +107,7 @@ major behaviors.
 | `PutAckTimesOutWhenNodeUnavailable` | N10 | ack timeout/status mapping |
 | `PythonCallbackDoesNotDeadlockWithGet` | P04 | get inside callback does not deadlock |
 
-## 4.2 Lifecycle sanitizer runs
+## 5.2 Lifecycle sanitizer runs
 
 Issue #11 lifecycle tests and Issue #13 batch sequencing tests have reproducible
 sanitizer configurations. TSan runs the zenoh-independent fake-Transport stress
@@ -121,7 +132,7 @@ repeat the ASan/UBSan configuration with `-DSITOS_WITH_ZENOH=ON` and run the lif
 integration targets. The CI sanitizer job uses zenoh OFF to keep TSan independent of
 zenoh runtime internals.
 
-## 5. CI (GitHub Actions)
+## 6. CI (GitHub Actions)
 
 | workflow | Trigger | Contents |
 |---|---|---|
@@ -131,14 +142,14 @@ zenoh runtime internals.
 | `dependency-upgrade.yml` | nightly / manual | Build and interop tests with the minimum supported and latest stable zenoh versions. Details: [09_dependency_policy.md](09_dependency_policy.md) |
 | `docs.yml` | push main | Doxygen + Sphinx → GitHub Pages |
 
-## 6. Quality gates
+## 7. Quality gates
 
 * Code coverage: line 80% or higher (gcov/llvm-cov, Codecov)
 * sanitizer: ASan/UBSan (Linux CI), TSan nightly for integration
 * Static analysis: clang-tidy (modernize-*, bugprone-*, concurrency-*)
 * Commit convention: Conventional Commits (automatic CHANGELOG generation with release-please)
 
-## 7. Release
+## 8. Release
 
 * Semantic versioning [C04]. C++ and Python use the same version
 * Artifacts: GitHub Release (source + prebuilt static/shared libraries), PyPI wheel.

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -58,7 +58,8 @@ cmake --install build/release --prefix /opt/sitos
 ```
 
 This installs `include/sitos/*`, the static library, and `sitosTargets.cmake` under
-`lib/cmake/sitos`. Consumers can link the exported `sitos::sitos` target.
+the platform's `${CMAKE_INSTALL_LIBDIR}/cmake/sitos` directory (commonly
+`lib/cmake/sitos`). Consumers can link the exported `sitos::sitos` target.
 
 ## 4. Build (Python wheel)
 

--- a/include/sitos/batch.hpp
+++ b/include/sitos/batch.hpp
@@ -30,6 +30,9 @@ struct BatchEntry {
 [[nodiscard]] std::vector<std::byte> EncodeBatch(
     std::span<const std::pair<std::string, ParamValue>> entries);
 
+/// Encode a batch from the canonical BatchEntry representation.
+[[nodiscard]] std::vector<std::byte> EncodeBatch(std::span<const BatchEntry> entries);
+
 /// Decode a batch payload. Returns std::nullopt on malformed input
 /// (short count, truncated key/value, unknown value tag, or trailing bytes).
 [[nodiscard]] std::optional<std::vector<BatchEntry>> DecodeBatch(

--- a/include/sitos/param_store.hpp
+++ b/include/sitos/param_store.hpp
@@ -1,0 +1,124 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Thread-safe synchronous client operations against a StorageNode.
+
+#ifndef SITOS_PARAM_STORE_HPP
+#define SITOS_PARAM_STORE_HPP
+
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "sitos/batch.hpp"
+#include "sitos/client_config.hpp"
+#include "sitos/key.hpp"
+#include "sitos/param_value.hpp"
+#include "sitos/result.hpp"
+#include "sitos/transport.hpp"
+
+namespace sitos {
+
+using ListSink = std::function<bool(std::string_view key, const ParamValue& value)>;
+
+template <typename T>
+concept ParamStringInput =
+    std::same_as<std::remove_cvref_t<T>, std::string> ||
+    std::same_as<std::remove_cvref_t<T>, std::string_view> ||
+    (std::is_pointer_v<std::decay_t<T>> &&
+     std::same_as<std::remove_cv_t<std::remove_pointer_t<std::decay_t<T>>>, char>);
+
+template <typename T>
+concept ParamInput =
+    !std::same_as<std::remove_cvref_t<T>, ParamValue> &&
+    (std::same_as<std::remove_cvref_t<T>, bool> || std::integral<std::remove_cvref_t<T>> ||
+     std::floating_point<std::remove_cvref_t<T>> ||
+     std::same_as<std::remove_cvref_t<T>, std::byte> ||
+     std::same_as<std::remove_cvref_t<T>, std::vector<std::byte>> || ParamStringInput<T>);
+
+template <typename T>
+concept SupportedParamType =
+    std::same_as<std::remove_cvref_t<T>, bool> || std::integral<std::remove_cvref_t<T>> ||
+    std::floating_point<std::remove_cvref_t<T>> ||
+    std::same_as<std::remove_cvref_t<T>, std::string> ||
+    std::same_as<std::remove_cvref_t<T>, std::vector<std::byte>>;
+
+/// Move-only, thread-safe synchronous client for base/session parameter data.
+class ParamStore {
+ public:
+  static Result<ParamStore> Open(ClientConfig config = {});
+  static Result<ParamStore> Open(std::shared_ptr<Transport> transport, ClientConfig config = {});
+
+  ParamStore(const ParamStore&) = delete;
+  ParamStore& operator=(const ParamStore&) = delete;
+  ParamStore(ParamStore&&) noexcept = default;
+  ParamStore& operator=(ParamStore&&) noexcept = default;
+
+  Result<void> Put(std::string_view scope, std::string_view key, const ParamValue& value);
+
+  template <ParamInput T>
+  Result<void> Put(std::string_view scope, std::string_view key, T&& value) {
+    auto converted = MakeParamValue(std::forward<T>(value));
+    if (!converted.IsOk()) return Result<void>::ErrFrom(converted);
+    return Put(scope, key, converted.Value());
+  }
+
+  Result<void> PutBatch(std::string_view scope, std::span<const BatchEntry> entries);
+  Result<void> Delete(std::string_view scope, std::string_view key);
+
+  Result<ParamValue> Get(std::string_view scope, std::string_view key);
+
+  template <SupportedParamType T>
+  Result<T> Get(std::string_view scope, std::string_view key) {
+    auto value = Get(scope, key);
+    if (!value.IsOk()) return Result<T>::ErrFrom(value);
+    auto converted = value.Value().template As<T>();
+    if (!converted.has_value()) {
+      return Result<T>::Err(Status::TypeMismatch, "parameter value type mismatch");
+    }
+    return Result<T>::Ok(std::move(*converted));
+  }
+
+  Result<bool> Contains(std::string_view scope, std::string_view key);
+  Result<void> List(std::string_view scope, std::string_view prefix, const ListSink& sink);
+
+ private:
+  ParamStore(std::shared_ptr<Transport> transport, ClientConfig config)
+      : transport_(std::move(transport)), config_(std::move(config)) {}
+
+  template <typename T>
+  static Result<ParamValue> MakeParamValue(T&& value) {
+    using D = std::decay_t<T>;
+    if constexpr (std::is_pointer_v<D> &&
+                  std::is_same_v<std::remove_cv_t<std::remove_pointer_t<D>>, char>) {
+      if (value == nullptr) {
+        return Result<ParamValue>::Err(Status::InvalidArgument, "null string argument");
+      }
+    } else if constexpr (std::is_integral_v<D> && !std::is_same_v<D, bool>) {
+      if (!std::in_range<std::int64_t>(value)) {
+        return Result<ParamValue>::Err(Status::InvalidArgument,
+                                       "integral value is outside payload range");
+      }
+    }
+    return Result<ParamValue>::Ok(ParamValue(std::forward<T>(value)));
+  }
+
+  static Result<Scope> ParseAndValidateScope(std::string_view scope);
+  static Result<void> ValidateUserKey(std::string_view key);
+  static Result<void> ValidateListPrefix(std::string_view prefix);
+
+  std::shared_ptr<Transport> transport_;
+  ClientConfig config_;
+};
+
+}  // namespace sitos
+
+#endif  // SITOS_PARAM_STORE_HPP

--- a/include/sitos/sitos.hpp
+++ b/include/sitos/sitos.hpp
@@ -9,6 +9,7 @@
 #include "sitos/in_memory_engine.hpp"
 #include "sitos/key.hpp"
 #include "sitos/logging.hpp"
+#include "sitos/param_store.hpp"
 #include "sitos/param_value.hpp"
 #include "sitos/result.hpp"
 #include "sitos/session.hpp"

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -32,10 +33,27 @@ std::optional<std::uint32_t> ReadLeU32(std::span<const std::byte> p, std::size_t
 
 }  // namespace
 
-std::vector<std::byte> EncodeBatch(std::span<const std::pair<std::string, ParamValue>> entries) {
+namespace {
+
+template <typename Entry>
+std::vector<std::byte> EncodeBatchImpl(std::span<const Entry> entries) {
   std::vector<std::byte> out;
   AppendLeU32(static_cast<std::uint32_t>(entries.size()), out);
-  for (const auto& [key, value] : entries) {
+  for (const auto& entry : entries) {
+    const auto& key = [&]() -> const std::string& {
+      if constexpr (std::is_same_v<Entry, BatchEntry>) {
+        return entry.key;
+      } else {
+        return entry.first;
+      }
+    }();
+    const auto& value = [&]() -> const ParamValue& {
+      if constexpr (std::is_same_v<Entry, BatchEntry>) {
+        return entry.value;
+      } else {
+        return entry.second;
+      }
+    }();
     AppendLeU32(static_cast<std::uint32_t>(key.size()), out);
     const auto* kp = reinterpret_cast<const std::byte*>(key.data());
     out.insert(out.end(), kp, kp + key.size());
@@ -45,6 +63,16 @@ std::vector<std::byte> EncodeBatch(std::span<const std::pair<std::string, ParamV
     out.insert(out.end(), body.begin(), body.end());
   }
   return out;
+}
+
+}  // namespace
+
+std::vector<std::byte> EncodeBatch(std::span<const std::pair<std::string, ParamValue>> entries) {
+  return EncodeBatchImpl(entries);
+}
+
+std::vector<std::byte> EncodeBatch(std::span<const BatchEntry> entries) {
+  return EncodeBatchImpl(entries);
 }
 
 std::optional<std::vector<BatchEntry>> DecodeBatch(std::span<const std::byte> payload) {

--- a/src/param_store.cpp
+++ b/src/param_store.cpp
@@ -118,17 +118,27 @@ Result<ParamValue> DecodeReply(std::string_view expected_key, std::string_view a
   return Result<ParamValue>::Ok(std::move(*decoded));
 }
 
-Result<void> DecodeListReply(std::string_view config_prefix, const Scope& scope,
-                             std::string_view safe_parent, std::string_view prefix,
-                             std::string_view full_key, std::span<const std::byte> payload,
-                             const Encoding& encoding,
-                             std::vector<std::pair<std::string, ParamValue>>& values) {
-  auto parsed = ParseKey(config_prefix, full_key);
-  if (!parsed || !IsExpectedKind(*parsed, scope) || parsed->is_batch ||
-      !IsUnderSafeParent(parsed->relative_key, safe_parent)) {
+struct ListReplyContext {
+  // These views refer to storage owned by ParamStore::List and remain valid through
+  // synchronous Get.
+  std::string_view config_prefix;
+  Scope scope;
+  std::string_view safe_parent;
+  std::string_view prefix;
+};
+
+Result<void> DecodeListReply(
+    const ListReplyContext& context, std::string_view full_key,
+    std::span<const std::byte> payload, const Encoding& encoding,
+    std::vector<std::pair<std::string, ParamValue>>& values) {
+  auto parsed = ParseKey(context.config_prefix, full_key);
+  if (!parsed || !IsExpectedKind(*parsed, context.scope) || parsed->is_batch ||
+      !IsUnderSafeParent(parsed->relative_key, context.safe_parent)) {
     return Result<void>::Err(Status::Error, "transport returned an invalid list key");
   }
-  if (!prefix.empty() && !parsed->relative_key.starts_with(prefix)) return Result<void>::Ok();
+  if (!context.prefix.empty() && !parsed->relative_key.starts_with(context.prefix)) {
+    return Result<void>::Ok();
+  }
   if (encoding.id != Encoding::kSitosV1) {
     return Result<void>::Err(Status::Error, "transport returned an unexpected encoding");
   }
@@ -301,15 +311,16 @@ Result<void> ParamStore::List(std::string_view scope, std::string_view prefix,
   const std::string scope_path = ScopePath(parsed_scope.Value());
   const std::string safe_parent = SafeParent(prefix);
   const std::string selector = BuildScopeQuery(config_.prefix, scope_path, safe_parent);
+  const ListReplyContext context{config_.prefix, parsed_scope.Value(), safe_parent, prefix};
   std::vector<std::pair<std::string, ParamValue>> values;
   std::optional<Result<void>> callback_error;
 
   auto transport_result = transport_->Get(
       selector,
-      [this, parsed_scope, safe_parent, prefix, &callback_error, &values](
-          std::string_view full_key, std::span<const std::byte> payload, Encoding encoding) {
-        auto reply = DecodeListReply(config_.prefix, parsed_scope.Value(), safe_parent, prefix,
-                                     full_key, payload, encoding, values);
+      [&context, &callback_error, &values](std::string_view full_key,
+                                           std::span<const std::byte> payload,
+                                           Encoding encoding) {
+        auto reply = DecodeListReply(context, full_key, payload, encoding, values);
         if (!reply.IsOk()) {
           callback_error = std::move(reply);
           return false;

--- a/src/param_store.cpp
+++ b/src/param_store.cpp
@@ -86,8 +86,9 @@ std::string SafeParent(std::string_view requested_prefix) {
 
 bool IsUnderSafeParent(std::string_view relative, std::string_view safe_parent) {
   if (safe_parent.empty()) return true;
-  return relative.size() > safe_parent.size() && relative.starts_with(safe_parent) &&
-         relative[safe_parent.size()] == '/';
+  return relative == safe_parent ||
+         (relative.size() > safe_parent.size() && relative.starts_with(safe_parent) &&
+          relative[safe_parent.size()] == '/');
 }
 
 bool IsExpectedKind(const ParsedKey& parsed, const Scope& scope) {

--- a/src/param_store.cpp
+++ b/src/param_store.cpp
@@ -1,0 +1,319 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Thread-safe synchronous client operations against a StorageNode.
+
+#include "sitos/param_store.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace sitos {
+namespace {
+
+Result<void> InvalidKey(std::string_view message) {
+  return Result<void>::Err(Status::InvalidKey, std::string(message));
+}
+
+Result<void> InvalidArgument(std::string_view message) {
+  return Result<void>::Err(Status::InvalidArgument, std::string(message));
+}
+
+std::string ScopePath(const Scope& scope) {
+  switch (scope.kind) {
+    case ScopeKind::Base:
+      return "base";
+    case ScopeKind::Session:
+      return "session/" + scope.sid;
+    case ScopeKind::Snap:
+      return "snap/" + scope.sid;
+  }
+  return {};
+}
+
+bool ContainsWhitespaceOrWildcard(std::string_view value) {
+  for (char c : value) {
+    if (std::isspace(static_cast<unsigned char>(c)) || c == '*' || c == '?') return true;
+  }
+  return false;
+}
+
+bool ContainsBatchSegment(std::string_view value) {
+  std::size_t start = 0;
+  while (start <= value.size()) {
+    const std::size_t end = value.find('/', start);
+    const std::size_t length = end == std::string_view::npos ? value.size() - start : end - start;
+    if (value.substr(start, length) == ":batch") return true;
+    if (end == std::string_view::npos) break;
+    start = end + 1;
+  }
+  return false;
+}
+
+std::string BuildScopeQuery(std::string_view prefix, std::string_view scope_path,
+                            std::string_view safe_parent) {
+  std::string result;
+  result.reserve(prefix.size() + scope_path.size() + safe_parent.size() + 5);
+  result.append(prefix);
+  result.push_back('/');
+  result.append(scope_path);
+  result.push_back('/');
+  if (!safe_parent.empty()) {
+    result.append(safe_parent);
+    result.append("/**");
+  } else {
+    result.append("**");
+  }
+  return result;
+}
+
+std::string SafeParent(std::string_view requested_prefix) {
+  if (requested_prefix.empty() || requested_prefix.ends_with('/')) {
+    if (requested_prefix.empty()) return {};
+    return std::string(requested_prefix.substr(0, requested_prefix.size() - 1));
+  }
+  const std::size_t slash = requested_prefix.rfind('/');
+  if (slash == std::string_view::npos) return {};
+  return std::string(requested_prefix.substr(0, slash));
+}
+
+bool IsUnderSafeParent(std::string_view relative, std::string_view safe_parent) {
+  if (safe_parent.empty()) return true;
+  return relative.size() > safe_parent.size() && relative.starts_with(safe_parent) &&
+         relative[safe_parent.size()] == '/';
+}
+
+bool IsExpectedKind(const ParsedKey& parsed, const Scope& scope) {
+  switch (scope.kind) {
+    case ScopeKind::Base:
+      return parsed.kind == KeyKind::Base;
+    case ScopeKind::Session:
+      return parsed.kind == KeyKind::Session && parsed.sid == scope.sid;
+    case ScopeKind::Snap:
+      return parsed.kind == KeyKind::Snapshot && parsed.sid == scope.sid;
+  }
+  return false;
+}
+
+Result<ParamValue> DecodeReply(std::string_view expected_key, std::string_view actual_key,
+                               std::span<const std::byte> payload, const Encoding& encoding) {
+  if (actual_key != expected_key) {
+    return Result<ParamValue>::Err(Status::Error, "transport returned an unexpected key");
+  }
+  if (encoding.id != Encoding::kSitosV1) {
+    return Result<ParamValue>::Err(Status::Error, "transport returned an unexpected encoding");
+  }
+  auto decoded = ParamValue::Decode(payload);
+  if (!decoded.has_value()) {
+    return Result<ParamValue>::Err(Status::Error, "transport returned malformed payload");
+  }
+  return Result<ParamValue>::Ok(std::move(*decoded));
+}
+
+}  // namespace
+
+Result<ParamStore> ParamStore::Open(ClientConfig config) {
+  auto config_result = ValidateClientConfig(config);
+  if (!config_result.IsOk()) return Result<ParamStore>::ErrFrom(config_result);
+
+  std::optional<std::string_view> json;
+  if (config.zenoh_config_json.has_value()) json = *config.zenoh_config_json;
+  auto transport_result = OpenZenohTransport(json);
+  if (!transport_result.IsOk()) return Result<ParamStore>::ErrFrom(transport_result);
+  std::shared_ptr<Transport> transport(std::move(transport_result).Value());
+  return Result<ParamStore>::Ok(ParamStore(std::move(transport), std::move(config)));
+}
+
+Result<ParamStore> ParamStore::Open(std::shared_ptr<Transport> transport, ClientConfig config) {
+  if (!transport) return Result<ParamStore>::Err(Status::InvalidArgument, "null transport");
+  auto config_result = ValidateClientConfig(config);
+  if (!config_result.IsOk()) return Result<ParamStore>::ErrFrom(config_result);
+  if (config.zenoh_config_json.has_value()) {
+    return Result<ParamStore>::Err(Status::InvalidArgument,
+                                   "injected transport cannot apply zenoh configuration");
+  }
+  return Result<ParamStore>::Ok(ParamStore(std::move(transport), std::move(config)));
+}
+
+Result<Scope> ParamStore::ParseAndValidateScope(std::string_view scope) {
+  auto parsed = ParseScope(scope);
+  if (!parsed.has_value()) {
+    return Result<Scope>::Err(Status::InvalidKey, "invalid scope");
+  }
+  return Result<Scope>::Ok(std::move(*parsed));
+}
+
+Result<void> ParamStore::ValidateUserKey(std::string_view key) {
+  if (!IsValidKey(key)) return InvalidKey("invalid key");
+  return Result<void>::Ok();
+}
+
+Result<void> ParamStore::ValidateListPrefix(std::string_view prefix) {
+  if (prefix.empty()) return Result<void>::Ok();
+  if (prefix.front() == '/' || prefix.find("//") != std::string_view::npos ||
+      ContainsWhitespaceOrWildcard(prefix) || ContainsBatchSegment(prefix)) {
+    return InvalidKey("invalid list prefix");
+  }
+  if (prefix.back() == '/') {
+    if (prefix.size() == 1 || !IsValidPrefix(prefix.substr(0, prefix.size() - 1))) {
+      return InvalidKey("invalid list prefix");
+    }
+    return Result<void>::Ok();
+  }
+  if (!IsValidKey(prefix)) return InvalidKey("invalid list prefix");
+  return Result<void>::Ok();
+}
+
+Result<void> ParamStore::Put(std::string_view scope, std::string_view key,
+                             const ParamValue& value) {
+  if (!transport_) return InvalidArgument("moved-from ParamStore");
+  auto parsed_scope = ParseAndValidateScope(scope);
+  if (!parsed_scope.IsOk()) return Result<void>::ErrFrom(parsed_scope);
+  auto key_result = ValidateUserKey(key);
+  if (!key_result.IsOk()) return key_result;
+  if (parsed_scope.Value().kind == ScopeKind::Snap) {
+    return Result<void>::Err(Status::ReadOnly, "snapshot scope is read-only");
+  }
+  auto full_key = BuildKey(config_.prefix, scope, key);
+  if (!full_key.has_value()) return InvalidKey("invalid parameter key");
+  auto payload = value.Encode();
+  auto result =
+      transport_->Put(*full_key, payload, Encoding{std::string(Encoding::kSitosV1)}, PutOptions{});
+  if (!result.IsOk()) return Result<void>::ErrFrom(result);
+  return Result<void>::Ok();
+}
+
+Result<void> ParamStore::PutBatch(std::string_view scope, std::span<const BatchEntry> entries) {
+  if (!transport_) return InvalidArgument("moved-from ParamStore");
+  auto parsed_scope = ParseAndValidateScope(scope);
+  if (!parsed_scope.IsOk()) return Result<void>::ErrFrom(parsed_scope);
+  if (parsed_scope.Value().kind == ScopeKind::Snap) {
+    return Result<void>::Err(Status::ReadOnly, "snapshot scope is read-only");
+  }
+  if (!BuildBatchKey(config_.prefix, scope).has_value()) {
+    return InvalidKey("invalid batch scope");
+  }
+  for (const auto& entry : entries) {
+    auto key_result = ValidateUserKey(entry.key);
+    if (!key_result.IsOk()) return key_result;
+  }
+  if (entries.empty()) return Result<void>::Ok();
+
+  auto payload = EncodeBatch(entries);
+  auto key = BuildBatchKey(config_.prefix, scope);
+  auto result =
+      transport_->Put(*key, payload, Encoding{std::string(Encoding::kSitosV1Batch)}, PutOptions{});
+  if (!result.IsOk()) return Result<void>::ErrFrom(result);
+  return Result<void>::Ok();
+}
+
+Result<void> ParamStore::Delete(std::string_view scope, std::string_view key) {
+  if (!transport_) return InvalidArgument("moved-from ParamStore");
+  auto parsed_scope = ParseAndValidateScope(scope);
+  if (!parsed_scope.IsOk()) return Result<void>::ErrFrom(parsed_scope);
+  auto key_result = ValidateUserKey(key);
+  if (!key_result.IsOk()) return key_result;
+  if (parsed_scope.Value().kind == ScopeKind::Snap) {
+    return Result<void>::Err(Status::ReadOnly, "snapshot scope is read-only");
+  }
+  if (parsed_scope.Value().kind == ScopeKind::Session) {
+    return InvalidKey("session delete is not supported");
+  }
+  auto full_key = BuildKey(config_.prefix, scope, key);
+  if (!full_key.has_value()) return InvalidKey("invalid parameter key");
+  auto result = transport_->Delete(*full_key, PutOptions{});
+  if (!result.IsOk()) return Result<void>::ErrFrom(result);
+  return Result<void>::Ok();
+}
+
+Result<ParamValue> ParamStore::Get(std::string_view scope, std::string_view key) {
+  if (!transport_) return Result<ParamValue>::Err(Status::InvalidArgument, "moved-from ParamStore");
+  auto parsed_scope = ParseAndValidateScope(scope);
+  if (!parsed_scope.IsOk()) return Result<ParamValue>::ErrFrom(parsed_scope);
+  auto key_result = ValidateUserKey(key);
+  if (!key_result.IsOk()) return Result<ParamValue>::ErrFrom(key_result);
+  auto full_key = BuildKey(config_.prefix, scope, key);
+  if (!full_key.has_value()) {
+    return Result<ParamValue>::Err(Status::InvalidKey, "invalid parameter key");
+  }
+
+  std::optional<Result<ParamValue>> callback_result;
+  auto transport_result = transport_->Get(
+      *full_key,
+      [&](std::string_view actual_key, std::span<const std::byte> payload, Encoding encoding) {
+        if (callback_result.has_value()) return false;
+        callback_result = DecodeReply(*full_key, actual_key, payload, encoding);
+        return callback_result->IsOk();
+      },
+      config_.query_timeout);
+  if (!transport_result.IsOk()) return Result<ParamValue>::ErrFrom(transport_result);
+  if (callback_result.has_value()) return std::move(*callback_result);
+  return Result<ParamValue>::Err(Status::NotFound, "parameter not found");
+}
+
+Result<bool> ParamStore::Contains(std::string_view scope, std::string_view key) {
+  auto result = Get(scope, key);
+  if (!result.IsOk() && result.StatusCode() == Status::NotFound) return Result<bool>::Ok(false);
+  if (!result.IsOk()) return Result<bool>::ErrFrom(result);
+  return Result<bool>::Ok(true);
+}
+
+Result<void> ParamStore::List(std::string_view scope, std::string_view prefix,
+                              const ListSink& sink) {
+  if (!transport_) return InvalidArgument("moved-from ParamStore");
+  if (!sink) return InvalidArgument("null list sink");
+  auto parsed_scope = ParseAndValidateScope(scope);
+  if (!parsed_scope.IsOk()) return Result<void>::ErrFrom(parsed_scope);
+  auto prefix_result = ValidateListPrefix(prefix);
+  if (!prefix_result.IsOk()) return prefix_result;
+
+  const std::string scope_path = ScopePath(parsed_scope.Value());
+  const std::string safe_parent = SafeParent(prefix);
+  const std::string selector = BuildScopeQuery(config_.prefix, scope_path, safe_parent);
+  std::vector<std::pair<std::string, ParamValue>> values;
+  std::optional<Result<void>> callback_error;
+
+  auto transport_result = transport_->Get(
+      selector,
+      [&](std::string_view full_key, std::span<const std::byte> payload, Encoding encoding) {
+        auto parsed = ParseKey(config_.prefix, full_key);
+        if (!parsed || !IsExpectedKind(*parsed, parsed_scope.Value()) || parsed->is_batch ||
+            !IsUnderSafeParent(parsed->relative_key, safe_parent)) {
+          callback_error =
+              Result<void>::Err(Status::Error, "transport returned an invalid list key");
+          return false;
+        }
+        if (!prefix.empty() && !parsed->relative_key.starts_with(prefix)) return true;
+        if (encoding.id != Encoding::kSitosV1) {
+          callback_error =
+              Result<void>::Err(Status::Error, "transport returned an unexpected encoding");
+          return false;
+        }
+        auto decoded = ParamValue::Decode(payload);
+        if (!decoded.has_value()) {
+          callback_error = Result<void>::Err(Status::Error, "transport returned malformed payload");
+          return false;
+        }
+        values.emplace_back(parsed->relative_key, std::move(*decoded));
+        return true;
+      },
+      config_.query_timeout);
+  if (!transport_result.IsOk()) return Result<void>::ErrFrom(transport_result);
+  if (callback_error.has_value()) return *callback_error;
+
+  std::sort(values.begin(), values.end(),
+            [](const auto& left, const auto& right) { return left.first < right.first; });
+  for (const auto& [relative_key, value] : values) {
+    if (!sink(relative_key, value)) break;
+  }
+  return Result<void>::Ok();
+}
+
+}  // namespace sitos

--- a/src/param_store.cpp
+++ b/src/param_store.cpp
@@ -118,6 +118,28 @@ Result<ParamValue> DecodeReply(std::string_view expected_key, std::string_view a
   return Result<ParamValue>::Ok(std::move(*decoded));
 }
 
+Result<void> DecodeListReply(std::string_view config_prefix, const Scope& scope,
+                             std::string_view safe_parent, std::string_view prefix,
+                             std::string_view full_key, std::span<const std::byte> payload,
+                             const Encoding& encoding,
+                             std::vector<std::pair<std::string, ParamValue>>& values) {
+  auto parsed = ParseKey(config_prefix, full_key);
+  if (!parsed || !IsExpectedKind(*parsed, scope) || parsed->is_batch ||
+      !IsUnderSafeParent(parsed->relative_key, safe_parent)) {
+    return Result<void>::Err(Status::Error, "transport returned an invalid list key");
+  }
+  if (!prefix.empty() && !parsed->relative_key.starts_with(prefix)) return Result<void>::Ok();
+  if (encoding.id != Encoding::kSitosV1) {
+    return Result<void>::Err(Status::Error, "transport returned an unexpected encoding");
+  }
+  auto decoded = ParamValue::Decode(payload);
+  if (!decoded.has_value()) {
+    return Result<void>::Err(Status::Error, "transport returned malformed payload");
+  }
+  values.emplace_back(parsed->relative_key, std::move(*decoded));
+  return Result<void>::Ok();
+}
+
 }  // namespace
 
 Result<ParamStore> ParamStore::Open(ClientConfig config) {
@@ -248,7 +270,8 @@ Result<ParamValue> ParamStore::Get(std::string_view scope, std::string_view key)
   std::optional<Result<ParamValue>> callback_result;
   auto transport_result = transport_->Get(
       *full_key,
-      [&](std::string_view actual_key, std::span<const std::byte> payload, Encoding encoding) {
+      [&callback_result, &full_key](std::string_view actual_key,
+                                    std::span<const std::byte> payload, Encoding encoding) {
         if (callback_result.has_value()) return false;
         callback_result = DecodeReply(*full_key, actual_key, payload, encoding);
         return callback_result->IsOk();
@@ -283,26 +306,14 @@ Result<void> ParamStore::List(std::string_view scope, std::string_view prefix,
 
   auto transport_result = transport_->Get(
       selector,
-      [&](std::string_view full_key, std::span<const std::byte> payload, Encoding encoding) {
-        auto parsed = ParseKey(config_.prefix, full_key);
-        if (!parsed || !IsExpectedKind(*parsed, parsed_scope.Value()) || parsed->is_batch ||
-            !IsUnderSafeParent(parsed->relative_key, safe_parent)) {
-          callback_error =
-              Result<void>::Err(Status::Error, "transport returned an invalid list key");
+      [this, parsed_scope, safe_parent, prefix, &callback_error, &values](
+          std::string_view full_key, std::span<const std::byte> payload, Encoding encoding) {
+        auto reply = DecodeListReply(config_.prefix, parsed_scope.Value(), safe_parent, prefix,
+                                     full_key, payload, encoding, values);
+        if (!reply.IsOk()) {
+          callback_error = std::move(reply);
           return false;
         }
-        if (!prefix.empty() && !parsed->relative_key.starts_with(prefix)) return true;
-        if (encoding.id != Encoding::kSitosV1) {
-          callback_error =
-              Result<void>::Err(Status::Error, "transport returned an unexpected encoding");
-          return false;
-        }
-        auto decoded = ParamValue::Decode(payload);
-        if (!decoded.has_value()) {
-          callback_error = Result<void>::Err(Status::Error, "transport returned malformed payload");
-          return false;
-        }
-        values.emplace_back(parsed->relative_key, std::move(*decoded));
         return true;
       },
       config_.query_timeout);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,11 @@ add_sitos_public_header_compile_test(
   sitos_result_header_compile_test consumer/result_header_compile.cpp)
 add_sitos_public_header_compile_test(
   sitos_client_config_header_compile_test consumer/client_config_header_compile.cpp)
+add_sitos_public_header_compile_test(
+  sitos_param_store_header_compile_test consumer/param_store_header_compile.cpp)
+if(SITOS_WITH_ZENOH)
+  sitos_copy_zenohc(sitos_param_store_header_compile_test)
+endif()
 
 add_executable(sitos_bootstrap_test unit/bootstrap_test.cpp)
 target_link_libraries(sitos_bootstrap_test PRIVATE GTest::gtest_main sitos::sitos)
@@ -51,6 +56,14 @@ add_executable(sitos_client_config_test unit/client_config_test.cpp)
 target_link_libraries(sitos_client_config_test PRIVATE GTest::gtest_main sitos::sitos)
 sitos_enable_warnings(sitos_client_config_test)
 gtest_add_tests(TARGET sitos_client_config_test SOURCES unit/client_config_test.cpp)
+
+add_executable(sitos_param_store_test unit/param_store_test.cpp)
+target_link_libraries(sitos_param_store_test PRIVATE GTest::gtest_main sitos::sitos)
+sitos_enable_warnings(sitos_param_store_test)
+if(SITOS_WITH_ZENOH)
+  sitos_copy_zenohc(sitos_param_store_test)
+endif()
+gtest_add_tests(TARGET sitos_param_store_test SOURCES unit/param_store_test.cpp)
 
 add_executable(sitos_client_transport_factory_test unit/client_transport_factory_test.cpp)
 target_link_libraries(sitos_client_transport_factory_test PRIVATE GTest::gtest_main sitos::sitos)
@@ -190,4 +203,14 @@ if(SITOS_WITH_ZENOH)
   sitos_enable_warnings(sitos_batch_test)
   sitos_copy_zenohc(sitos_batch_test)
   gtest_add_tests(TARGET sitos_batch_test SOURCES integration/batch_test.cpp)
+
+  add_executable(sitos_param_store_integration_test
+    integration/param_store_test.cpp)
+  target_link_libraries(sitos_param_store_integration_test
+    PRIVATE GTest::gtest_main sitos::sitos)
+  sitos_enable_warnings(sitos_param_store_integration_test)
+  sitos_copy_zenohc(sitos_param_store_integration_test)
+  gtest_add_tests(
+    TARGET sitos_param_store_integration_test
+    SOURCES integration/param_store_test.cpp)
 endif()

--- a/tests/consumer/param_store_header_compile.cpp
+++ b/tests/consumer/param_store_header_compile.cpp
@@ -1,0 +1,14 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <type_traits>
+
+#include "sitos/param_store.hpp"
+
+static_assert(!std::is_copy_constructible_v<sitos::ParamStore>);
+static_assert(std::is_move_constructible_v<sitos::ParamStore>);
+
+int main() {
+  auto result = sitos::ParamStore::Open(std::shared_ptr<sitos::Transport>{});
+  return result.StatusCode() == sitos::Status::InvalidArgument ? 0 : 1;
+}

--- a/tests/integration/param_store_test.cpp
+++ b/tests/integration/param_store_test.cpp
@@ -1,0 +1,186 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// ParamStore round-trip coverage using one shared same-process zenoh transport.
+
+#include "sitos/param_store.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "sitos/in_memory_engine.hpp"
+#include "sitos/storage_node.hpp"
+#include "sitos/transport.hpp"
+
+namespace {
+
+using namespace std::chrono_literals;
+
+std::shared_ptr<sitos::Transport> MakeSharedZenohTransport() {
+  return std::shared_ptr<sitos::Transport>(sitos::MakeZenohTransport().release());
+}
+
+std::optional<sitos::ParamValue> GetEventually(sitos::ParamStore& store, std::string_view scope,
+                                               std::string_view key) {
+  for (int attempt = 0; attempt < 20; ++attempt) {
+    auto result = store.Get(scope, key);
+    if (result.IsOk()) return std::move(result).Value();
+    if (result.StatusCode() != sitos::Status::NotFound) return std::nullopt;
+    std::this_thread::sleep_for(10ms);
+  }
+  return std::nullopt;
+}
+
+class ParamStoreIntegrationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    transport_ = MakeSharedZenohTransport();
+    ASSERT_TRUE(transport_);
+    engine_ = std::make_shared<sitos::InMemoryEngine>();
+    ASSERT_TRUE(node_.Start(engine_, *transport_, {.prefix = std::string(kPrefix)}).IsOk());
+
+    sitos::ClientConfig config;
+    config.prefix = std::string(kPrefix);
+    config.query_timeout = 500ms;
+    auto store_result = sitos::ParamStore::Open(transport_, std::move(config));
+    ASSERT_TRUE(store_result.IsOk());
+    store_.emplace(std::move(store_result).Value());
+  }
+
+  void TearDown() override {
+    node_.Stop();
+    transport_.reset();
+  }
+
+  static constexpr std::string_view kPrefix = "sitos/param_store_test";
+  std::shared_ptr<sitos::Transport> transport_;
+  std::shared_ptr<sitos::InMemoryEngine> engine_;
+  sitos::StorageNode node_;
+  std::optional<sitos::ParamStore> store_;
+};
+
+TEST_F(ParamStoreIntegrationTest, BasePutGetListAndDeleteRoundTrip) {
+  ASSERT_TRUE(store_->Put("base", "foo/bar", std::int64_t{7}).IsOk());
+  ASSERT_TRUE(store_->Put("base", "foobar", std::string("outside")).IsOk());
+
+  auto value = GetEventually(*store_, "base", "foo/bar");
+  ASSERT_TRUE(value.has_value());
+  EXPECT_EQ(value->As<std::int64_t>(), 7);
+
+  std::vector<std::string> keys;
+  ASSERT_TRUE(store_
+                  ->List("base", "foo",
+                         [&](std::string_view key, const sitos::ParamValue&) {
+                           keys.emplace_back(key);
+                           return true;
+                         })
+                  .IsOk());
+  EXPECT_EQ(keys, (std::vector<std::string>{"foo/bar", "foobar"}));
+
+  keys.clear();
+  ASSERT_TRUE(store_
+                  ->List("base", "foo/",
+                         [&](std::string_view key, const sitos::ParamValue&) {
+                           keys.emplace_back(key);
+                           return true;
+                         })
+                  .IsOk());
+  EXPECT_EQ(keys, (std::vector<std::string>{"foo/bar"}));
+
+  ASSERT_TRUE(store_->Delete("base", "foo/bar").IsOk());
+  EXPECT_FALSE(GetEventually(*store_, "base", "foo/bar").has_value());
+}
+
+TEST_F(ParamStoreIntegrationTest, SessionOverlayAndSnapshotRoundTrip) {
+  ASSERT_TRUE(store_->Put("base", "before", std::int64_t{1}).IsOk());
+  auto before = GetEventually(*store_, "base", "before");
+  ASSERT_TRUE(before.has_value());
+
+  ASSERT_TRUE(node_.CreateSession("s1").IsOk());
+  ASSERT_TRUE(store_->Put("base", "after", std::int64_t{2}).IsOk());
+  ASSERT_TRUE(store_->Put("session/s1", "overlay", std::int64_t{3}).IsOk());
+
+  auto snapshot_before = GetEventually(*store_, "snap/s1", "before");
+  ASSERT_TRUE(snapshot_before.has_value());
+  EXPECT_EQ(snapshot_before->As<std::int64_t>(), 1);
+  EXPECT_FALSE(GetEventually(*store_, "snap/s1", "after").has_value());
+
+  auto overlay = GetEventually(*store_, "session/s1", "overlay");
+  ASSERT_TRUE(overlay.has_value());
+  EXPECT_EQ(overlay->As<std::int64_t>(), 3);
+}
+
+TEST_F(ParamStoreIntegrationTest, PutBatchSendsOneCanonicalMessageAndAppliesInOrder) {
+  ASSERT_TRUE(node_.CreateSession("s1").IsOk());
+
+  struct Observation {
+    std::mutex mutex;
+    std::condition_variable condition;
+    int count = 0;
+    std::string key;
+    std::vector<std::byte> payload;
+    std::string encoding;
+  };
+  auto observation = std::make_shared<Observation>();
+  auto subscriber_result = transport_->DeclareSubscriber(
+      std::string(kPrefix) + "/session/s1/**", [observation](const sitos::TransportSample& sample) {
+        std::lock_guard lock(observation->mutex);
+        ++observation->count;
+        observation->key = sample.key;
+        observation->payload.assign(sample.payload.begin(), sample.payload.end());
+        observation->encoding = sample.encoding.id;
+        observation->condition.notify_all();
+      });
+  ASSERT_TRUE(subscriber_result.IsOk());
+  auto subscriber = std::move(subscriber_result).Value();
+
+  const std::vector<sitos::BatchEntry> entries = {
+      {"first", sitos::ParamValue(std::int64_t{1})},
+      {"first", sitos::ParamValue(std::int64_t{2})},
+      {"second", sitos::ParamValue("two")},
+  };
+  ASSERT_TRUE(store_->PutBatch("session/s1", entries).IsOk());
+
+  {
+    std::unique_lock lock(observation->mutex);
+    ASSERT_TRUE(observation->condition.wait_for(lock, 3s, [&] { return observation->count == 1; }));
+    EXPECT_EQ(observation->key, std::string(kPrefix) + "/session/s1/:batch");
+    EXPECT_EQ(observation->encoding, sitos::Encoding::kSitosV1Batch);
+  }
+  auto decoded = sitos::DecodeBatch(observation->payload);
+  ASSERT_TRUE(decoded.has_value());
+  ASSERT_EQ(decoded->size(), entries.size());
+  EXPECT_EQ((*decoded)[0].key, "first");
+  EXPECT_EQ((*decoded)[1].value.As<std::int64_t>(), 2);
+  EXPECT_EQ((*decoded)[2].key, "second");
+
+  auto first = GetEventually(*store_, "session/s1", "first");
+  ASSERT_TRUE(first.has_value());
+  EXPECT_EQ(first->As<std::int64_t>(), 2);
+  auto second = GetEventually(*store_, "session/s1", "second");
+  ASSERT_TRUE(second.has_value());
+  EXPECT_EQ(second->As<std::string>(), "two");
+}
+
+TEST(ParamStoreFactoryIntegrationTest, DefaultOpenUsesConfigAndFactory) {
+  sitos::ClientConfig config;
+  config.prefix = "sitos/param_store_factory_test";
+  config.query_timeout = 500ms;
+  auto result = sitos::ParamStore::Open(std::move(config));
+  ASSERT_TRUE(result.IsOk()) << result.Message();
+}
+
+}  // namespace

--- a/tests/unit/param_store_test.cpp
+++ b/tests/unit/param_store_test.cpp
@@ -1,0 +1,310 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/param_store.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "sitos/batch.hpp"
+
+namespace {
+
+using sitos::BatchEntry;
+using sitos::ClientConfig;
+using sitos::Encoding;
+using sitos::ParamValue;
+using sitos::PutOptions;
+using sitos::Queryable;
+using sitos::Result;
+using sitos::Subscription;
+using sitos::Transport;
+using sitos::TransportQuery;
+using sitos::TransportSample;
+
+class FakeTransport final : public Transport {
+ public:
+  struct PutRecord {
+    std::string key;
+    std::vector<std::byte> payload;
+    Encoding encoding;
+  };
+
+  struct ReplyRecord {
+    std::string key;
+    std::vector<std::byte> payload;
+    Encoding encoding;
+  };
+
+  Result<void> Put(std::string_view key, std::span<const std::byte> payload, Encoding encoding,
+                   PutOptions) override {
+    puts.push_back({std::string(key), {payload.begin(), payload.end()}, std::move(encoding)});
+    return put_result;
+  }
+
+  Result<void> Delete(std::string_view key, PutOptions) override {
+    deletes.emplace_back(key);
+    return delete_result;
+  }
+
+  Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
+                   std::chrono::milliseconds) override {
+    get_keys.emplace_back(keyexpr);
+    for (const auto& reply : replies) {
+      if (!sink(reply.key, reply.payload, reply.encoding)) break;
+    }
+    return get_result;
+  }
+
+  Result<Subscription> DeclareSubscriber(std::string_view,
+                                         std::function<void(const TransportSample&)>) override {
+    return Result<Subscription>::Ok(Subscription{});
+  }
+
+  Result<Queryable> DeclareQueryable(std::string_view,
+                                     std::function<void(TransportQuery&)>) override {
+    return Result<Queryable>::Ok(Queryable{});
+  }
+
+  std::vector<PutRecord> puts;
+  std::vector<std::string> deletes;
+  std::vector<std::string> get_keys;
+  std::vector<ReplyRecord> replies;
+  Result<void> put_result = Result<void>::Ok();
+  Result<void> delete_result = Result<void>::Ok();
+  Result<void> get_result = Result<void>::Ok();
+};
+
+std::shared_ptr<FakeTransport> OpenFake() {
+  auto transport = std::make_shared<FakeTransport>();
+  auto result = sitos::ParamStore::Open(transport);
+  EXPECT_TRUE(result.IsOk()) << result.Message();
+  return transport;
+}
+
+TEST(ParamStoreTest, OpenRejectsNullTransportAndInapplicableJsonBeforeUse) {
+  auto null_result = sitos::ParamStore::Open(std::shared_ptr<Transport>{});
+  ASSERT_FALSE(null_result.IsOk());
+  EXPECT_EQ(null_result.StatusCode(), sitos::Status::InvalidArgument);
+
+  auto transport = std::make_shared<FakeTransport>();
+  ClientConfig config;
+  config.zenoh_config_json = "{mode: 'peer'}";
+  auto json_result = sitos::ParamStore::Open(transport, std::move(config));
+  ASSERT_FALSE(json_result.IsOk());
+  EXPECT_EQ(json_result.StatusCode(), sitos::Status::InvalidArgument);
+
+  ClientConfig invalid_prefix;
+  invalid_prefix.prefix = "";
+  auto prefix_result = sitos::ParamStore::Open(transport, std::move(invalid_prefix));
+  ASSERT_FALSE(prefix_result.IsOk());
+  EXPECT_EQ(prefix_result.StatusCode(), sitos::Status::InvalidKey);
+
+  ClientConfig invalid_timeout;
+  invalid_timeout.query_timeout = std::chrono::milliseconds::zero();
+  auto timeout_result = sitos::ParamStore::Open(transport, std::move(invalid_timeout));
+  ASSERT_FALSE(timeout_result.IsOk());
+  EXPECT_EQ(timeout_result.StatusCode(), sitos::Status::InvalidArgument);
+  EXPECT_TRUE(transport->puts.empty());
+  EXPECT_TRUE(transport->get_keys.empty());
+  EXPECT_TRUE(transport->deletes.empty());
+}
+
+TEST(ParamStoreTest, RejectsInvalidWritesWithoutTransportOperations) {
+  auto transport = OpenFake();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+
+  EXPECT_EQ(store.Put("invalid", "key", ParamValue(1)).StatusCode(), sitos::Status::InvalidKey);
+  EXPECT_EQ(store.Put("snap/session1", "key", ParamValue(1)).StatusCode(), sitos::Status::ReadOnly);
+  EXPECT_EQ(store.Delete("session/session1", "key").StatusCode(), sitos::Status::InvalidKey);
+  EXPECT_EQ(store.Delete("snap/session1", "key").StatusCode(), sitos::Status::ReadOnly);
+  EXPECT_TRUE(transport->puts.empty());
+  EXPECT_TRUE(transport->deletes.empty());
+}
+
+TEST(ParamStoreTest, TypedPutRejectsNullStringsAndOutOfRangeIntegersBeforeWire) {
+  auto transport = OpenFake();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+
+  const char* null_string = nullptr;
+  EXPECT_EQ(store.Put("base", "key", null_string).StatusCode(), sitos::Status::InvalidArgument);
+  EXPECT_EQ(store.Put("base", "key", std::numeric_limits<std::uint64_t>::max()).StatusCode(),
+            sitos::Status::InvalidArgument);
+  EXPECT_TRUE(transport->puts.empty());
+}
+
+TEST(ParamStoreTest, PutUsesCanonicalPayloadAndBatchIsOneWireMessage) {
+  auto transport = OpenFake();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+
+  ASSERT_TRUE(store.Put("base", "foo/bar", std::int64_t{7}).IsOk());
+  ASSERT_EQ(transport->puts.size(), 1U);
+  EXPECT_EQ(transport->puts[0].key, "sitos/base/foo/bar");
+  EXPECT_EQ(transport->puts[0].encoding.id, Encoding::kSitosV1);
+  ASSERT_EQ(transport->puts[0].payload.size(), 9U);
+
+  const std::vector<BatchEntry> entries = {{"foo", ParamValue(1)}, {"foo", ParamValue(2)}};
+  ASSERT_TRUE(store.PutBatch("base", {}).IsOk());
+  EXPECT_EQ(transport->puts.size(), 1U);
+  EXPECT_EQ(store.PutBatch("invalid", {}).StatusCode(), sitos::Status::InvalidKey);
+  ASSERT_TRUE(store.PutBatch("session/s1", entries).IsOk());
+  ASSERT_EQ(transport->puts.size(), 2U);
+  EXPECT_EQ(transport->puts[1].key, "sitos/session/s1/:batch");
+  EXPECT_EQ(transport->puts[1].encoding.id, Encoding::kSitosV1Batch);
+  auto decoded = sitos::DecodeBatch(transport->puts[1].payload);
+  ASSERT_TRUE(decoded.has_value());
+  ASSERT_EQ(decoded->size(), 2U);
+  EXPECT_EQ((*decoded)[0].key, "foo");
+  EXPECT_EQ((*decoded)[1].value.As<std::int64_t>(), 2);
+}
+
+TEST(ParamStoreTest, ExactGetAndContainsMapZeroReplyAndDecodeErrors) {
+  auto transport = OpenFake();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+
+  auto missing = store.Get("base", "missing");
+  ASSERT_FALSE(missing.IsOk());
+  EXPECT_EQ(missing.StatusCode(), sitos::Status::NotFound);
+  auto contains = store.Contains("base", "missing");
+  ASSERT_TRUE(contains.IsOk());
+  EXPECT_FALSE(contains.Value());
+
+  transport->replies.push_back(
+      {"sitos/base/key", {std::byte{0xff}}, Encoding{std::string(Encoding::kSitosV1)}});
+  auto malformed = store.Get("base", "key");
+  ASSERT_FALSE(malformed.IsOk());
+  EXPECT_EQ(malformed.StatusCode(), sitos::Status::Error);
+}
+
+TEST(ParamStoreTest, ListSortsRepliesFiltersPrefixAndStopsOnFalse) {
+  auto transport = OpenFake();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+
+  transport->replies = {
+      {"sitos/base/foo/z", ParamValue(2).Encode(), Encoding{std::string(Encoding::kSitosV1)}},
+      {"sitos/base/foo/a", ParamValue(1).Encode(), Encoding{std::string(Encoding::kSitosV1)}},
+  };
+  std::vector<std::string> keys;
+  ASSERT_TRUE(store
+                  .List("base", "foo/",
+                        [&](std::string_view key, const ParamValue&) {
+                          keys.emplace_back(key);
+                          return true;
+                        })
+                  .IsOk());
+  EXPECT_EQ(keys, (std::vector<std::string>{"foo/a", "foo/z"}));
+
+  transport->replies.push_back(
+      {"sitos/base/foobar", ParamValue(3).Encode(), Encoding{std::string(Encoding::kSitosV1)}});
+  keys.clear();
+  ASSERT_TRUE(store
+                  .List("base", "foo",
+                        [&](std::string_view key, const ParamValue&) {
+                          keys.emplace_back(key);
+                          return false;
+                        })
+                  .IsOk());
+  ASSERT_EQ(keys.size(), 1U);
+  EXPECT_EQ(keys[0], "foo/a");
+}
+
+TEST(ParamStoreTest, RejectsInvalidListPrefixesWithoutTransportOperations) {
+  auto transport = OpenFake();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+
+  for (const std::string_view prefix :
+       {"/foo", "foo//bar", "foo/*", "foo/:batch", "foo bar", "/"}) {
+    EXPECT_EQ(store.List("base", prefix, [](std::string_view, const ParamValue&) { return true; })
+                  .StatusCode(),
+              sitos::Status::InvalidKey);
+  }
+  EXPECT_TRUE(transport->get_keys.empty());
+}
+
+TEST(ParamStoreTest, PreservesTransportErrorsAndTypedConversionStatus) {
+  auto transport = OpenFake();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+
+  const auto cause = std::make_error_code(std::errc::connection_reset);
+  transport->get_result = Result<void>::Err(sitos::Status::Disconnected, "offline", cause);
+  auto disconnected = store.Get("base", "key");
+  ASSERT_FALSE(disconnected.IsOk());
+  EXPECT_EQ(disconnected.StatusCode(), sitos::Status::Disconnected);
+  EXPECT_EQ(disconnected.Message(), "offline");
+  EXPECT_EQ(disconnected.Error(), cause);
+
+  transport->get_result = Result<void>::Ok();
+  transport->replies = {
+      {"sitos/base/key", ParamValue("text").Encode(), Encoding{std::string(Encoding::kSitosV1)}}};
+  auto mismatch = store.Get<std::int64_t>("base", "key");
+  ASSERT_FALSE(mismatch.IsOk());
+  EXPECT_EQ(mismatch.StatusCode(), sitos::Status::TypeMismatch);
+}
+
+TEST(ParamStoreTest, ListIgnoresUnrelatedRepliesInsideSafeParentBeforeDecoding) {
+  auto transport = OpenFake();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+
+  transport->replies = {
+      {"sitos/base/foo/bar/value", ParamValue(1).Encode(),
+       Encoding{std::string(Encoding::kSitosV1)}},
+      {"sitos/base/foo/unrelated", {std::byte{0xff}}, Encoding{"application/octet-stream"}},
+  };
+  std::vector<std::string> keys;
+  ASSERT_TRUE(store
+                  .List("base", "foo/bar",
+                        [&](std::string_view key, const ParamValue&) {
+                          keys.emplace_back(key);
+                          return true;
+                        })
+                  .IsOk());
+  EXPECT_EQ(keys, (std::vector<std::string>{"foo/bar/value"}));
+}
+
+TEST(ParamStoreTest, ListSinkExceptionPropagatesAndStoreRemainsUsable) {
+  auto transport = OpenFake();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  transport->replies = {
+      {"sitos/base/key", ParamValue(1).Encode(), Encoding{std::string(Encoding::kSitosV1)}}};
+
+  EXPECT_THROW(store.List("base", "",
+                          [](std::string_view, const ParamValue&) -> bool {
+                            throw std::runtime_error("sink failure");
+                          }),
+               std::runtime_error);
+  transport->replies.clear();
+  auto contains = store.Contains("base", "missing");
+  ASSERT_TRUE(contains.IsOk());
+  EXPECT_FALSE(contains.Value());
+}
+
+}  // namespace

--- a/tests/unit/param_store_test.cpp
+++ b/tests/unit/param_store_test.cpp
@@ -5,15 +5,18 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -49,22 +52,47 @@ class FakeTransport final : public Transport {
 
   Result<void> Put(std::string_view key, std::span<const std::byte> payload, Encoding encoding,
                    PutOptions) override {
+    std::lock_guard lock(mutex_);
     puts.push_back({std::string(key), {payload.begin(), payload.end()}, std::move(encoding)});
     return put_result;
   }
 
   Result<void> Delete(std::string_view key, PutOptions) override {
+    std::lock_guard lock(mutex_);
     deletes.emplace_back(key);
     return delete_result;
   }
 
   Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
                    std::chrono::milliseconds) override {
-    get_keys.emplace_back(keyexpr);
-    for (const auto& reply : replies) {
-      if (!sink(reply.key, reply.payload, reply.encoding)) break;
+    std::vector<ReplyRecord> reply_copy;
+    Result<void> result = Result<void>::Ok();
+    {
+      std::lock_guard lock(mutex_);
+      get_keys.emplace_back(keyexpr);
+      reply_copy = replies;
+      result = get_result;
     }
-    return get_result;
+    const auto invoke = [&] {
+      {
+        std::lock_guard lock(mutex_);
+        callback_thread_id = std::this_thread::get_id();
+      }
+      for (const auto& reply : reply_copy) {
+        if (!sink(reply.key, reply.payload, reply.encoding)) break;
+      }
+    };
+    if (invoke_get_on_worker) {
+      std::thread worker(invoke);
+      worker.join();
+    } else {
+      invoke();
+    }
+    {
+      std::lock_guard lock(mutex_);
+      get_returned = true;
+    }
+    return result;
   }
 
   Result<Subscription> DeclareSubscriber(std::string_view,
@@ -84,6 +112,12 @@ class FakeTransport final : public Transport {
   Result<void> put_result = Result<void>::Ok();
   Result<void> delete_result = Result<void>::Ok();
   Result<void> get_result = Result<void>::Ok();
+  bool invoke_get_on_worker = false;
+  bool get_returned = false;
+  std::thread::id callback_thread_id;
+
+ private:
+  std::mutex mutex_;
 };
 
 std::shared_ptr<FakeTransport> OpenFake() {
@@ -195,6 +229,54 @@ TEST(ParamStoreTest, ExactGetAndContainsMapZeroReplyAndDecodeErrors) {
   EXPECT_EQ(malformed.StatusCode(), sitos::Status::Error);
 }
 
+TEST(ParamStoreTest, RejectsUnexpectedExactRepliesAndContainsPreservesErrors) {
+  auto transport = OpenFake();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+
+  transport->replies = {{"sitos/base/other", ParamValue(1).Encode(),
+                         Encoding{std::string(Encoding::kSitosV1)}}};
+  auto mismatched = store.Get("base", "key");
+  ASSERT_FALSE(mismatched.IsOk());
+  EXPECT_EQ(mismatched.StatusCode(), sitos::Status::Error);
+
+  transport->replies = {{"sitos/base/key", ParamValue(1).Encode(),
+                         Encoding{"application/octet-stream"}}};
+  auto wrong_encoding = store.Get("base", "key");
+  ASSERT_FALSE(wrong_encoding.IsOk());
+  EXPECT_EQ(wrong_encoding.StatusCode(), sitos::Status::Error);
+
+  auto contains = store.Contains("base", "key");
+  ASSERT_FALSE(contains.IsOk());
+  EXPECT_EQ(contains.StatusCode(), sitos::Status::Error);
+}
+
+TEST(ParamStoreTest, ListRejectsInvalidMatchingReplies) {
+  auto transport = OpenFake();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+
+  const std::vector<FakeTransport::ReplyRecord> invalid_replies = {
+      {"sitos/base/foo/key", ParamValue(1).Encode(), Encoding{"application/octet-stream"}},
+      {"sitos/base/foo/key", {std::byte{0xff}},
+       Encoding{std::string(Encoding::kSitosV1)}},
+      {"sitos/session/s1/foo/key", ParamValue(1).Encode(),
+       Encoding{std::string(Encoding::kSitosV1)}},
+      {"sitos/base/:batch", ParamValue(1).Encode(),
+       Encoding{std::string(Encoding::kSitosV1)}},
+  };
+  for (const auto& reply : invalid_replies) {
+    transport->replies = {reply};
+    auto result = store.List("base", "foo", [](std::string_view, const ParamValue&) {
+      ADD_FAILURE() << "invalid reply reached the ListSink";
+      return true;
+    });
+    EXPECT_EQ(result.StatusCode(), sitos::Status::Error);
+  }
+}
+
 TEST(ParamStoreTest, ListSortsRepliesFiltersPrefixAndStopsOnFalse) {
   auto transport = OpenFake();
   auto store_result = sitos::ParamStore::Open(transport);
@@ -286,6 +368,53 @@ TEST(ParamStoreTest, ListIgnoresUnrelatedRepliesInsideSafeParentBeforeDecoding) 
                         })
                   .IsOk());
   EXPECT_EQ(keys, (std::vector<std::string>{"foo/bar/value"}));
+}
+
+TEST(ParamStoreTest, ListRunsSinkOnCallerThreadAfterTransportCallback) {
+  auto transport = OpenFake();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  transport->invoke_get_on_worker = true;
+  transport->replies = {
+      {"sitos/base/key", ParamValue(1).Encode(), Encoding{std::string(Encoding::kSitosV1)}}};
+
+  const auto caller_thread_id = std::this_thread::get_id();
+  std::thread::id sink_thread_id;
+  bool callback_had_returned = false;
+  ASSERT_TRUE(store
+                  .List("base", "", [&](std::string_view, const ParamValue&) {
+                    sink_thread_id = std::this_thread::get_id();
+                    callback_had_returned = transport->get_returned;
+                    return true;
+                  })
+                  .IsOk());
+  EXPECT_EQ(sink_thread_id, caller_thread_id);
+  EXPECT_NE(transport->callback_thread_id, caller_thread_id);
+  EXPECT_TRUE(callback_had_returned);
+}
+
+TEST(ParamStoreTest, IndependentParamStoreCallsMakeProgressConcurrently) {
+  auto transport = OpenFake();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  transport->replies = {
+      {"sitos/base/key", ParamValue(1).Encode(), Encoding{std::string(Encoding::kSitosV1)}}};
+
+  std::atomic<bool> failed = false;
+  std::vector<std::thread> workers;
+  for (int i = 0; i < 8; ++i) {
+    workers.emplace_back([&, i] {
+      if (!store.Put("base", "key", static_cast<std::int64_t>(i)).IsOk() ||
+          !store.Get("base", "key").IsOk()) {
+        failed.store(true);
+      }
+    });
+  }
+  for (auto& worker : workers) worker.join();
+  EXPECT_FALSE(failed.load());
+  EXPECT_EQ(transport->puts.size(), 8U);
 }
 
 TEST(ParamStoreTest, ListSinkExceptionPropagatesAndStoreRemainsUsable) {

--- a/tests/unit/param_store_test.cpp
+++ b/tests/unit/param_store_test.cpp
@@ -357,6 +357,7 @@ TEST(ParamStoreTest, ListIgnoresUnrelatedRepliesInsideSafeParentBeforeDecoding) 
   transport->replies = {
       {"sitos/base/foo/bar/value", ParamValue(1).Encode(),
        Encoding{std::string(Encoding::kSitosV1)}},
+      {"sitos/base/foo", {std::byte{0xff}}, Encoding{"application/octet-stream"}},
       {"sitos/base/foo/unrelated", {std::byte{0xff}}, Encoding{"application/octet-stream"}},
   };
   std::vector<std::string> keys;


### PR DESCRIPTION
Closes #15

## Summary

- Add the move-only `ParamStore` C++ client on top of the shared `ClientConfig`, `Result`, and synchronous `Transport::Get` foundations.
- Implement validated base/session/snapshot Put, canonical `:batch` PutBatch, base Delete, exact Get, typed Get, Contains, and raw-prefix List.
- Add the `BatchEntry` encoder overload, public umbrella/header coverage, CMake install/export support, deterministic fake-Transport tests, and one-session Zenoh integration tests.
- Reconcile C++ architecture/API/build documentation and mark the Python facade as outside this issue.

## TDD / RED evidence

The following genuine failures were observed during implementation and then corrected:

- `ParamStoreIntegrationTest.BasePutGetListAndDeleteRoundTrip` initially failed because the test expected `List("foo")` to exclude `foobar`; the observed result `{foo/bar, foobar}` exposed the required raw-prefix semantics and the test was corrected.
- `ParamStoreTest.ListSinkExceptionPropagatesAndStoreRemainsUsable` initially failed because the fake retained a previous reply before the post-exception `Contains` check; clearing the fake reply state restored the intended regression coverage.
- The first Zenoh-enabled integration build failed with an MSVC type-conversion error when the test passed `string_view` to `StorageNode::Config.prefix`; the test was corrected to construct the required `std::string`.
- The first Zenoh-enabled focused discovery failed with `0xc0000135` because the new test executable did not have `zenohc.dll`; per-target `sitos_copy_zenohc()` registration fixed the setup failure.

These are recorded as retrospective implementation evidence; history was not rewritten.

## Acceptance criteria

- [x] Move-only `ParamStore` with injected and factory-created Transport paths.
- [x] Validation before wire calls for config, scope, key, prefix, values, and batch entries.
- [x] Submission-only Put/Delete semantics; snapshot writes are `ReadOnly` and session Delete is `InvalidKey`.
- [x] Canonical `:batch` key, `sitos.v1.batch` encoding, caller-order entries, duplicate-key preservation, and empty-batch zero wire calls.
- [x] Synchronous exact Get/Contains and typed `ParamValue::As<T>()` conversion/status preservation.
- [x] Safe-parent raw-prefix List, complete reply validation, owned collection, lexical sorting, caller-thread sink execution, early stop, and exception propagation.
- [x] Concurrent independent operation coverage and callback lifetime/thread-placement coverage.
- [x] Public headers, umbrella include, consumer compile target, install/export rules, API/architecture/build documentation, fake tests, and same-session Zenoh integration.

## Verification

- Zenoh OFF full suite: **202/202**
- Zenoh OFF ParamStore focused suite after final test additions: **14/14**
- Zenoh ON full suite before the final Zenoh-independent review-test additions: **241/241**
- Zenoh ON ParamStore focused suite: **15/15**
- Same-session ParamStore integration: **3/3**
- C++ install/export validation: passed
- Secret scan: passed
- `git diff --check`: passed

The final Zenoh-enabled CI run is expected to execute the additional Zenoh-independent unit coverage as well.
