### PR TITLE
build(package): complete installed CMake export (#96)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,3 +106,34 @@ jobs:
 
       - name: Fixture validator (Python/struct independent check)
         run: python tests/fixtures/validate_fixtures.py
+
+  package-linux:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build libssl-dev
+
+      - name: Validate installed consumers and relocation
+        run: >-
+          cmake
+          -DSITOS_SOURCE_DIR="$GITHUB_WORKSPACE"
+          -DWORK_DIR="$GITHUB_WORKSPACE/build/package-validation"
+          -DCMAKE_GENERATOR=Ninja
+          -P tests/package/validate_installed_package.cmake
+
+  package-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Validate installed consumers and relocation (MSVC + Ninja)
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          $workspace = $env:GITHUB_WORKSPACE.Replace('\', '/')
+          $command = "call `"$vsPath\VC\Auxiliary\Build\vcvars64.bat`" && cmake -DSITOS_SOURCE_DIR=`"$workspace`" -DWORK_DIR=`"$workspace/build/package-validation`" -DCMAKE_GENERATOR=Ninja -P `"$workspace/tests/package/validate_installed_package.cmake`""
+          cmd /c $command
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   transport-isolation:
     # Acceptance criterion #2 for issue #3: the raw zenoh-c API must stay
@@ -39,6 +42,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -71,6 +76,8 @@ jobs:
             option: SITOS_ENABLE_ASAN_UBSAN=ON
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake ninja-build
@@ -96,6 +103,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Configure, build and test (MSVC + Ninja)
         shell: pwsh
@@ -111,6 +120,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake ninja-build libssl-dev
@@ -127,6 +138,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Validate installed consumers and relocation (MSVC + Ninja)
         shell: pwsh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ configure_package_config_file(
 write_basic_package_version_file(
   "${SITOS_PACKAGE_VERSION_CONFIG}"
   VERSION ${PROJECT_VERSION}
-  COMPATIBILITY SameMajorVersion)
+  COMPATIBILITY SameMinorVersion)
 
 install(EXPORT sitosTargets
   FILE sitosTargets.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.20)
 project(sitos VERSION 0.1.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -96,7 +97,24 @@ install(TARGETS sitos
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+set(SITOS_CMAKE_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/sitos)
+set(SITOS_PACKAGE_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/sitosConfig.cmake")
+set(SITOS_PACKAGE_VERSION_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/sitosConfigVersion.cmake")
+configure_package_config_file(
+  cmake/sitosConfig.cmake.in
+  "${SITOS_PACKAGE_CONFIG}"
+  INSTALL_DESTINATION "${SITOS_CMAKE_INSTALL_DIR}")
+write_basic_package_version_file(
+  "${SITOS_PACKAGE_VERSION_CONFIG}"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion)
+
 install(EXPORT sitosTargets
   FILE sitosTargets.cmake
   NAMESPACE sitos::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sitos)
+  DESTINATION ${SITOS_CMAKE_INSTALL_DIR})
+install(FILES
+  "${SITOS_PACKAGE_CONFIG}"
+  "${SITOS_PACKAGE_VERSION_CONFIG}"
+  cmake/Findzenohc.cmake
+  DESTINATION ${SITOS_CMAKE_INSTALL_DIR})

--- a/cmake/Findzenohc.cmake
+++ b/cmake/Findzenohc.cmake
@@ -1,0 +1,62 @@
+include(FindPackageHandleStandardArgs)
+
+if(TARGET zenohc::zenohc)
+  set(zenohc_FOUND TRUE)
+  return()
+endif()
+
+set(_zenohc_root_hints)
+if(zenohc_ROOT)
+  list(APPEND _zenohc_root_hints "${zenohc_ROOT}")
+endif()
+if(DEFINED ENV{ZENOHC_ROOT})
+  list(APPEND _zenohc_root_hints "$ENV{ZENOHC_ROOT}")
+endif()
+
+find_path(ZENOHC_INCLUDE_DIR
+  NAMES zenoh.h
+  HINTS ${_zenohc_root_hints}
+  PATH_SUFFIXES include)
+
+if(WIN32)
+  find_file(ZENOHC_IMPLIB
+    NAMES zenohc.dll.lib
+    HINTS ${_zenohc_root_hints}
+    PATH_SUFFIXES lib)
+  find_file(ZENOHC_RUNTIME
+    NAMES zenohc.dll
+    HINTS ${_zenohc_root_hints}
+    PATH_SUFFIXES bin)
+  find_package_handle_standard_args(zenohc
+    REQUIRED_VARS ZENOHC_INCLUDE_DIR ZENOHC_IMPLIB ZENOHC_RUNTIME)
+else()
+  find_library(ZENOHC_LIBRARY
+    NAMES zenohc
+    HINTS ${_zenohc_root_hints}
+    PATH_SUFFIXES lib)
+  find_package_handle_standard_args(zenohc
+    REQUIRED_VARS ZENOHC_INCLUDE_DIR ZENOHC_LIBRARY)
+endif()
+
+if(zenohc_FOUND AND NOT TARGET zenohc::zenohc)
+  add_library(zenohc::zenohc SHARED IMPORTED)
+  set_target_properties(zenohc::zenohc PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${ZENOHC_INCLUDE_DIR}")
+  if(WIN32)
+    set_target_properties(zenohc::zenohc PROPERTIES
+      IMPORTED_IMPLIB "${ZENOHC_IMPLIB}"
+      IMPORTED_LOCATION "${ZENOHC_RUNTIME}")
+    set_property(TARGET zenohc::zenohc APPEND PROPERTY
+      INTERFACE_LINK_LIBRARIES ws2_32 iphlpapi userenv bcrypt)
+  else()
+    set_target_properties(zenohc::zenohc PROPERTIES
+      IMPORTED_LOCATION "${ZENOHC_LIBRARY}")
+  endif()
+endif()
+
+mark_as_advanced(
+  ZENOHC_INCLUDE_DIR
+  ZENOHC_IMPLIB
+  ZENOHC_LIBRARY
+  ZENOHC_RUNTIME)
+unset(_zenohc_root_hints)

--- a/cmake/Findzenohc.cmake
+++ b/cmake/Findzenohc.cmake
@@ -5,34 +5,40 @@ if(TARGET zenohc::zenohc)
   return()
 endif()
 
-set(_zenohc_root_hints)
+set(_zenohc_root_hint)
 if(zenohc_ROOT)
-  list(APPEND _zenohc_root_hints "${zenohc_ROOT}")
+  set(_zenohc_root_hint "${zenohc_ROOT}")
+elseif(DEFINED ENV{ZENOHC_ROOT})
+  set(_zenohc_root_hint "$ENV{ZENOHC_ROOT}")
 endif()
-if(DEFINED ENV{ZENOHC_ROOT})
-  list(APPEND _zenohc_root_hints "$ENV{ZENOHC_ROOT}")
+
+set(_zenohc_find_options)
+if(_zenohc_root_hint)
+  list(APPEND _zenohc_find_options
+    HINTS "${_zenohc_root_hint}"
+    NO_DEFAULT_PATH)
 endif()
 
 find_path(ZENOHC_INCLUDE_DIR
   NAMES zenoh.h
-  HINTS ${_zenohc_root_hints}
+  ${_zenohc_find_options}
   PATH_SUFFIXES include)
 
 if(WIN32)
   find_file(ZENOHC_IMPLIB
     NAMES zenohc.dll.lib
-    HINTS ${_zenohc_root_hints}
+    ${_zenohc_find_options}
     PATH_SUFFIXES lib)
   find_file(ZENOHC_RUNTIME
     NAMES zenohc.dll
-    HINTS ${_zenohc_root_hints}
+    ${_zenohc_find_options}
     PATH_SUFFIXES bin)
   find_package_handle_standard_args(zenohc
     REQUIRED_VARS ZENOHC_INCLUDE_DIR ZENOHC_IMPLIB ZENOHC_RUNTIME)
 else()
   find_library(ZENOHC_LIBRARY
     NAMES zenohc
-    HINTS ${_zenohc_root_hints}
+    ${_zenohc_find_options}
     PATH_SUFFIXES lib)
   find_package_handle_standard_args(zenohc
     REQUIRED_VARS ZENOHC_INCLUDE_DIR ZENOHC_LIBRARY)
@@ -59,4 +65,5 @@ mark_as_advanced(
   ZENOHC_IMPLIB
   ZENOHC_LIBRARY
   ZENOHC_RUNTIME)
-unset(_zenohc_root_hints)
+unset(_zenohc_find_options)
+unset(_zenohc_root_hint)

--- a/cmake/Findzenohc.cmake
+++ b/cmake/Findzenohc.cmake
@@ -1,5 +1,8 @@
 include(FindPackageHandleStandardArgs)
 
+# Standalone zenoh-c releases do not expose portable installed version metadata. The supported
+# range is therefore enforced by the dependency-upgrade workflow and remains the consumer's
+# responsibility when selecting an externally provisioned root.
 if(TARGET zenohc::zenohc)
   set(zenohc_FOUND TRUE)
   return()

--- a/cmake/sitosConfig.cmake.in
+++ b/cmake/sitosConfig.cmake.in
@@ -1,0 +1,30 @@
+@PACKAGE_INIT@
+
+set(_sitos_with_zenoh "@SITOS_WITH_ZENOH@")
+if(_sitos_with_zenoh AND NOT TARGET zenohc::zenohc)
+  set(_sitos_module_path_defined FALSE)
+  if(DEFINED CMAKE_MODULE_PATH)
+    set(_sitos_module_path_defined TRUE)
+    set(_sitos_saved_module_path "${CMAKE_MODULE_PATH}")
+  endif()
+  list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+  find_package(zenohc MODULE QUIET)
+  if(_sitos_module_path_defined)
+    set(CMAKE_MODULE_PATH "${_sitos_saved_module_path}")
+  else()
+    unset(CMAKE_MODULE_PATH)
+  endif()
+  unset(_sitos_saved_module_path)
+  unset(_sitos_module_path_defined)
+
+  if(NOT zenohc_FOUND)
+    set(sitos_FOUND FALSE)
+    set(sitos_NOT_FOUND_MESSAGE
+        "sitos was built with Zenoh support, but zenoh-c was not found. "
+        "Set zenohc_ROOT or ZENOHC_ROOT, or add zenoh-c to CMAKE_PREFIX_PATH.")
+    return()
+  endif()
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/sitosTargets.cmake")
+check_required_components(sitos)

--- a/cmake/sitosConfig.cmake.in
+++ b/cmake/sitosConfig.cmake.in
@@ -19,9 +19,9 @@ if(_sitos_with_zenoh AND NOT TARGET zenohc::zenohc)
 
   if(NOT zenohc_FOUND)
     set(sitos_FOUND FALSE)
-    set(sitos_NOT_FOUND_MESSAGE
-        "sitos was built with Zenoh support, but zenoh-c was not found. "
-        "Set zenohc_ROOT or ZENOHC_ROOT, or add zenoh-c to CMAKE_PREFIX_PATH.")
+    string(CONCAT sitos_NOT_FOUND_MESSAGE
+      "sitos was built with Zenoh support, but zenoh-c was not found. "
+      "Set zenohc_ROOT or ZENOHC_ROOT, or add zenoh-c to CMAKE_PREFIX_PATH.")
     return()
   endif()
 endif()

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -60,7 +60,9 @@ cmake --install build/release --prefix /opt/sitos
 This installs `include/sitos/*`, the static library, `sitosTargets.cmake`,
 `sitosConfig.cmake`, and the version file under the platform's
 `${CMAKE_INSTALL_LIBDIR}/cmake/sitos` directory (commonly `lib/cmake/sitos`).
-Consumers can use the installed package through the exported target:
+Consumers can use the installed package through the exported target. Because sitos is currently
+pre-1.0, the generated version file uses `SameMinorVersion`: a `0.1.x` consumer requirement
+accepts only `0.1` patch releases, not `0.2`.
 
 ```sh
 cmake -S consumer -B build/consumer -G Ninja \
@@ -69,7 +71,7 @@ cmake --build build/consumer
 ```
 
 The consumer uses `find_package(sitos CONFIG REQUIRED)` and links
-`sitos::sitos`. The package version file provides `SameMajorVersion` compatibility.
+`sitos::sitos`. The package version file uses `SameMinorVersion` while sitos remains pre-1.0.
 Zenoh-OFF packages have no Zenoh dependency. Zenoh-ON packages require an
 externally provisioned zenoh-c standalone tree discoverable through
 `zenohc_ROOT`, `ZENOHC_ROOT`, or a normal CMake prefix; downstream package

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -57,9 +57,24 @@ The C++ library and public headers can be installed with the generated CMake exp
 cmake --install build/release --prefix /opt/sitos
 ```
 
-This installs `include/sitos/*`, the static library, and `sitosTargets.cmake` under
-the platform's `${CMAKE_INSTALL_LIBDIR}/cmake/sitos` directory (commonly
-`lib/cmake/sitos`). Consumers can link the exported `sitos::sitos` target.
+This installs `include/sitos/*`, the static library, `sitosTargets.cmake`,
+`sitosConfig.cmake`, and the version file under the platform's
+`${CMAKE_INSTALL_LIBDIR}/cmake/sitos` directory (commonly `lib/cmake/sitos`).
+Consumers can use the installed package through the exported target:
+
+```sh
+cmake -S consumer -B build/consumer -G Ninja \
+  -DCMAKE_PREFIX_PATH=/opt/sitos
+cmake --build build/consumer
+```
+
+The consumer uses `find_package(sitos CONFIG REQUIRED)` and links
+`sitos::sitos`. The package version file provides `SameMajorVersion` compatibility.
+Zenoh-OFF packages have no Zenoh dependency. Zenoh-ON packages require an
+externally provisioned zenoh-c standalone tree discoverable through
+`zenohc_ROOT`, `ZENOHC_ROOT`, or a normal CMake prefix; downstream package
+discovery never downloads zenoh-c. The application or package manager must
+deploy `zenohc.dll` or `libzenohc.so` at runtime.
 
 ## 4. Build (Python wheel)
 

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -44,7 +44,9 @@ uses its installed `Findzenohc.cmake` module to recreate or reuse the externally
 `zenohc::zenohc` target before loading the exported static `sitos::sitos` target. Package
 discovery never uses FetchContent or network access. Consumers provide zenoh-c through
 `zenohc_ROOT`, `ZENOHC_ROOT`, or a normal CMake prefix when it is not installed in a standard
-location.
+location. The installed find module cannot enforce the supported zenoh-c version range because
+standalone releases do not expose portable installed version metadata; dependency selection is
+the consumer's responsibility and the range is validated by the dependency-upgrade workflow.
 
 The sitos install tree does not bundle zenoh-c. The application or package manager is
 responsible for deploying the shared `zenohc.dll`/`libzenohc.so` runtime and configuring the

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -37,6 +37,19 @@ zenoh-c >= 1.9.0, < 2.0
 * After validation by `dependency-upgrade.yml`, zenoh-c patch/minor updates are incorporated into
   sitos patch/minor releases
 
+### 2.1 Installed CMake packages
+
+An installed Zenoh-OFF `sitos` package has no Zenoh dependency. An installed Zenoh-ON package
+uses its installed `Findzenohc.cmake` module to recreate or reuse the externally provisioned
+`zenohc::zenohc` target before loading the exported static `sitos::sitos` target. Package
+discovery never uses FetchContent or network access. Consumers provide zenoh-c through
+`zenohc_ROOT`, `ZENOHC_ROOT`, or a normal CMake prefix when it is not installed in a standard
+location.
+
+The sitos install tree does not bundle zenoh-c. The application or package manager is
+responsible for deploying the shared `zenohc.dll`/`libzenohc.so` runtime and configuring the
+platform runtime search path. See ADR-0021.
+
 ## 3. Transport adapter
 
 Only the transport adapter uses the zenoh-c API directly. `OpenZenohTransport` accepts an

--- a/docs/adr/0021-resolve-installed-zenoh-dependency.md
+++ b/docs/adr/0021-resolve-installed-zenoh-dependency.md
@@ -1,0 +1,50 @@
+# ADR-0021: Resolve installed Zenoh dependencies without fetching or bundling
+
+## Status
+
+Proposed — 2026-07-18
+
+## Context
+
+The installed static `sitos::sitos` target retains a link-only dependency on the
+shared `zenohc::zenohc` target when built with Zenoh enabled. The current build
+fetches zenoh-c into the build tree and does not install a package config for
+that dependency, so a downstream `find_package(sitos)` cannot reconstruct the
+imported target. Downstream package discovery must remain relocatable and must
+not perform hidden network access.
+
+## Decision
+
+We will install a `Findzenohc.cmake` module with the sitos package and use it to
+recreate or reuse an externally provisioned `zenohc::zenohc` target for Zenoh-ON
+packages. Zenoh-OFF packages have no Zenoh dependency; package discovery never
+fetches or bundles zenoh-c.
+
+## Consequences
+
+* Good: Installed packages are relocatable and have no hidden configure-time
+  network access.
+* Good: Static sitos consumers reconstruct the required shared zenoh-c target
+  before loading the exported sitos target.
+* Bad: Zenoh-ON consumers must provide zenoh-c through `zenohc_ROOT`,
+  `ZENOHC_ROOT`, or a normal CMake prefix when it is not installed in a standard
+  location.
+* Bad: The application or package manager owns deployment of `zenohc.dll` or
+  `libzenohc.so` and the corresponding runtime search-path configuration.
+
+## Options Considered
+
+* **Fetch zenoh-c from the installed package config** — rejected because package
+  discovery would require network access and would not be deterministic.
+* **Bundle zenoh-c in the sitos install tree** — rejected because the dependency
+  is a separately versioned shared runtime and bundling would create a new
+  redistribution and runtime deployment policy.
+* **Require consumers to create `zenohc::zenohc` manually** — rejected because
+  the exported sitos target would otherwise fail with an undocumented target
+  error during downstream CMake generation.
+
+## References
+
+* Issue #96
+* PR implementing Issue #96
+* [Dependency policy](../09_dependency_policy.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,3 +25,4 @@ See [docs/10_adr_process.md](../10_adr_process.md) for the process.
 | [0018](0018-use-zenoh-valid-batch-key-segment.md) | Use a zenoh-valid batch key segment |
 | [0019](0019-client-result-status-configuration.md) | Additive client result and configuration foundation |
 | [0020](0020-synchronously-complete-transport-get.md) | Synchronously complete Transport Get requests |
+| [0021](0021-resolve-installed-zenoh-dependency.md) | Resolve installed Zenoh dependencies without fetching or bundling |

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 include(FetchContent)
 
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+set(INSTALL_GMOCK OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
   googletest
   URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip

--- a/tests/package/check_clean_install.cmake
+++ b/tests/package/check_clean_install.cmake
@@ -1,0 +1,23 @@
+if(NOT DEFINED SITOS_PREFIX)
+  message(FATAL_ERROR "SITOS_PREFIX must name an installed sitos prefix")
+endif()
+
+set(_forbidden_paths
+  "${SITOS_PREFIX}/include/gtest"
+  "${SITOS_PREFIX}/include/gmock"
+  "${SITOS_PREFIX}/lib/cmake/GTest"
+  "${SITOS_PREFIX}/lib/pkgconfig/gtest.pc"
+  "${SITOS_PREFIX}/lib/pkgconfig/gmock.pc")
+foreach(_path IN LISTS _forbidden_paths)
+  if(EXISTS "${_path}")
+    message(FATAL_ERROR "Test-only artifact was installed: ${_path}")
+  endif()
+endforeach()
+
+file(GLOB_RECURSE _test_libraries
+  "${SITOS_PREFIX}/lib/*gtest*"
+  "${SITOS_PREFIX}/lib/*gmock*")
+if(_test_libraries)
+  list(JOIN _test_libraries "\n  " _test_library_list)
+  message(FATAL_ERROR "Test-only libraries were installed:\n  ${_test_library_list}")
+endif()

--- a/tests/package/check_clean_install.cmake
+++ b/tests/package/check_clean_install.cmake
@@ -1,13 +1,16 @@
 if(NOT DEFINED SITOS_PREFIX)
   message(FATAL_ERROR "SITOS_PREFIX must name an installed sitos prefix")
 endif()
+if(NOT DEFINED SITOS_INSTALL_LIBDIR)
+  set(SITOS_INSTALL_LIBDIR lib)
+endif()
 
 set(_forbidden_paths
   "${SITOS_PREFIX}/include/gtest"
   "${SITOS_PREFIX}/include/gmock"
-  "${SITOS_PREFIX}/lib/cmake/GTest"
-  "${SITOS_PREFIX}/lib/pkgconfig/gtest.pc"
-  "${SITOS_PREFIX}/lib/pkgconfig/gmock.pc")
+  "${SITOS_PREFIX}/${SITOS_INSTALL_LIBDIR}/cmake/GTest"
+  "${SITOS_PREFIX}/${SITOS_INSTALL_LIBDIR}/pkgconfig/gtest.pc"
+  "${SITOS_PREFIX}/${SITOS_INSTALL_LIBDIR}/pkgconfig/gmock.pc")
 foreach(_path IN LISTS _forbidden_paths)
   if(EXISTS "${_path}")
     message(FATAL_ERROR "Test-only artifact was installed: ${_path}")
@@ -15,8 +18,8 @@ foreach(_path IN LISTS _forbidden_paths)
 endforeach()
 
 file(GLOB_RECURSE _test_libraries
-  "${SITOS_PREFIX}/lib/*gtest*"
-  "${SITOS_PREFIX}/lib/*gmock*")
+  "${SITOS_PREFIX}/${SITOS_INSTALL_LIBDIR}/*gtest*"
+  "${SITOS_PREFIX}/${SITOS_INSTALL_LIBDIR}/*gmock*")
 if(_test_libraries)
   list(JOIN _test_libraries "\n  " _test_library_list)
   message(FATAL_ERROR "Test-only libraries were installed:\n  ${_test_library_list}")

--- a/tests/package/check_relocatable.cmake
+++ b/tests/package/check_relocatable.cmake
@@ -1,11 +1,11 @@
-foreach(_required_variable SITOS_PREFIX SITOS_SOURCE_DIR SITOS_BUILD_DIR ORIGINAL_PREFIX)
+foreach(_required_variable SITOS_PREFIX SITOS_SOURCE_DIR SITOS_BUILD_DIR ORIGINAL_PREFIX SITOS_INSTALL_LIBDIR)
   if(NOT DEFINED ${_required_variable})
     message(FATAL_ERROR "${_required_variable} must be defined")
   endif()
 endforeach()
 
 file(GLOB_RECURSE _package_files
-  "${SITOS_PREFIX}/lib/cmake/sitos/*.cmake")
+  "${SITOS_PREFIX}/${SITOS_INSTALL_LIBDIR}/cmake/sitos/*.cmake")
 set(_forbidden_strings
   "${SITOS_SOURCE_DIR}"
   "${SITOS_BUILD_DIR}"

--- a/tests/package/check_relocatable.cmake
+++ b/tests/package/check_relocatable.cmake
@@ -1,0 +1,22 @@
+foreach(_required_variable SITOS_PREFIX SITOS_SOURCE_DIR SITOS_BUILD_DIR ORIGINAL_PREFIX)
+  if(NOT DEFINED ${_required_variable})
+    message(FATAL_ERROR "${_required_variable} must be defined")
+  endif()
+endforeach()
+
+file(GLOB_RECURSE _package_files
+  "${SITOS_PREFIX}/lib/cmake/sitos/*.cmake")
+set(_forbidden_strings
+  "${SITOS_SOURCE_DIR}"
+  "${SITOS_BUILD_DIR}"
+  "${ORIGINAL_PREFIX}")
+foreach(_package_file IN LISTS _package_files)
+  file(READ "${_package_file}" _package_contents)
+  foreach(_forbidden_string IN LISTS _forbidden_strings)
+    string(FIND "${_package_contents}" "${_forbidden_string}" _match)
+    if(NOT _match EQUAL -1)
+      message(FATAL_ERROR
+        "Non-relocatable path '${_forbidden_string}' found in ${_package_file}")
+    endif()
+  endforeach()
+endforeach()

--- a/tests/package/consumer/CMakeLists.txt
+++ b/tests/package/consumer/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(sitos_package_consumer LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(sitos 0.1 CONFIG REQUIRED)
+
+add_executable(sitos_package_consumer main.cpp)
+target_link_libraries(sitos_package_consumer PRIVATE sitos::sitos)

--- a/tests/package/consumer/main.cpp
+++ b/tests/package/consumer/main.cpp
@@ -1,0 +1,8 @@
+#include <memory>
+
+#include "sitos/sitos.hpp"
+
+int main() {
+  auto (*factory)() -> std::unique_ptr<sitos::Transport> = &sitos::MakeZenohTransport;
+  return factory == nullptr ? 1 : 0;
+}

--- a/tests/package/consumer/main.cpp
+++ b/tests/package/consumer/main.cpp
@@ -1,8 +1,6 @@
-#include <memory>
-
 #include "sitos/sitos.hpp"
 
 int main() {
-  auto (*factory)() -> std::unique_ptr<sitos::Transport> = &sitos::MakeZenohTransport;
-  return factory == nullptr ? 1 : 0;
+  static_cast<void>(sitos::MakeZenohTransport());
+  return 0;
 }

--- a/tests/package/run_installed_consumer.cmake
+++ b/tests/package/run_installed_consumer.cmake
@@ -1,0 +1,39 @@
+if(NOT DEFINED SITOS_PREFIX)
+  message(FATAL_ERROR "SITOS_PREFIX must name an installed sitos prefix")
+endif()
+if(NOT DEFINED SITOS_SOURCE_DIR)
+  message(FATAL_ERROR "SITOS_SOURCE_DIR must name the sitos source tree")
+endif()
+if(NOT DEFINED CONSUMER_BUILD_DIR)
+  message(FATAL_ERROR "CONSUMER_BUILD_DIR must name the consumer build directory")
+endif()
+
+if(NOT DEFINED CMAKE_GENERATOR)
+  set(CMAKE_GENERATOR Ninja)
+endif()
+
+set(_consumer_source_dir "${SITOS_SOURCE_DIR}/tests/package/consumer")
+set(_configure_command
+  "${CMAKE_COMMAND}"
+  -S "${_consumer_source_dir}"
+  -B "${CONSUMER_BUILD_DIR}"
+  -G "${CMAKE_GENERATOR}"
+  -DCMAKE_BUILD_TYPE=Release
+  "-DCMAKE_PREFIX_PATH=${SITOS_PREFIX}")
+if(DEFINED ZENOHC_ROOT)
+  list(APPEND _configure_command "-Dzenohc_ROOT=${ZENOHC_ROOT}")
+endif()
+
+execute_process(
+  COMMAND ${_configure_command}
+  RESULT_VARIABLE _configure_result)
+if(_configure_result)
+  message(FATAL_ERROR "Installed consumer configuration failed")
+endif()
+
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" --build "${CONSUMER_BUILD_DIR}"
+  RESULT_VARIABLE _build_result)
+if(_build_result)
+  message(FATAL_ERROR "Installed consumer build failed")
+endif()

--- a/tests/package/run_installed_consumer.cmake
+++ b/tests/package/run_installed_consumer.cmake
@@ -23,6 +23,10 @@ set(_configure_command
 if(DEFINED ZENOHC_ROOT)
   list(APPEND _configure_command "-Dzenohc_ROOT=${ZENOHC_ROOT}")
 endif()
+if(DEFINED ZENOHC_ROOT_ENV)
+  list(PREPEND _configure_command
+    "${CMAKE_COMMAND}" -E env "ZENOHC_ROOT=${ZENOHC_ROOT_ENV}")
+endif()
 
 execute_process(
   COMMAND ${_configure_command}

--- a/tests/package/validate_installed_package.cmake
+++ b/tests/package/validate_installed_package.cmake
@@ -1,0 +1,92 @@
+if(NOT DEFINED SITOS_SOURCE_DIR)
+  message(FATAL_ERROR "SITOS_SOURCE_DIR must name the sitos source tree")
+endif()
+if(NOT DEFINED WORK_DIR)
+  message(FATAL_ERROR "WORK_DIR must name the package validation work directory")
+endif()
+if(NOT DEFINED CMAKE_GENERATOR)
+  set(CMAKE_GENERATOR Ninja)
+endif()
+
+function(run_checked)
+  execute_process(
+    COMMAND ${ARGV}
+    RESULT_VARIABLE _result)
+  if(_result)
+    message(FATAL_ERROR "Command failed with exit code ${_result}: ${ARGV}")
+  endif()
+endfunction()
+
+function(validate_clean_install prefix)
+  run_checked(
+    "${CMAKE_COMMAND}"
+    "-DSITOS_PREFIX=${prefix}"
+    -P "${SITOS_SOURCE_DIR}/tests/package/check_clean_install.cmake")
+endfunction()
+
+function(validate_relocation prefix original_prefix build_dir)
+  run_checked(
+    "${CMAKE_COMMAND}"
+    "-DSITOS_PREFIX=${prefix}"
+    "-DSITOS_SOURCE_DIR=${SITOS_SOURCE_DIR}"
+    "-DSITOS_BUILD_DIR=${build_dir}"
+    "-DORIGINAL_PREFIX=${original_prefix}"
+    -P "${SITOS_SOURCE_DIR}/tests/package/check_relocatable.cmake")
+endfunction()
+
+function(validate_consumer prefix build_dir)
+  set(_extra_args ${ARGN})
+  run_checked(
+    "${CMAKE_COMMAND}"
+    "-DSITOS_PREFIX=${prefix}"
+    "-DSITOS_SOURCE_DIR=${SITOS_SOURCE_DIR}"
+    "-DCONSUMER_BUILD_DIR=${build_dir}"
+    "-DCMAKE_GENERATOR=${CMAKE_GENERATOR}"
+    ${_extra_args}
+    -P "${SITOS_SOURCE_DIR}/tests/package/run_installed_consumer.cmake")
+endfunction()
+
+if(EXISTS "${WORK_DIR}")
+  run_checked("${CMAKE_COMMAND}" -E rm -rf "${WORK_DIR}")
+endif()
+
+set(_test_build "${WORK_DIR}/test-install-build")
+set(_test_prefix "${WORK_DIR}/test-install-prefix")
+run_checked(
+  "${CMAKE_COMMAND}" -S "${SITOS_SOURCE_DIR}" -B "${_test_build}"
+  -G "${CMAKE_GENERATOR}" -DCMAKE_BUILD_TYPE=Release
+  -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF)
+run_checked("${CMAKE_COMMAND}" --build "${_test_build}")
+run_checked("${CMAKE_COMMAND}" --install "${_test_build}" --prefix "${_test_prefix}")
+validate_clean_install("${_test_prefix}")
+
+set(_off_build "${WORK_DIR}/off-build")
+set(_off_original "${WORK_DIR}/off-original")
+set(_off_moved "${WORK_DIR}/off-moved")
+set(_off_consumer "${WORK_DIR}/off-consumer")
+run_checked(
+  "${CMAKE_COMMAND}" -S "${SITOS_SOURCE_DIR}" -B "${_off_build}"
+  -G "${CMAKE_GENERATOR}" -DCMAKE_BUILD_TYPE=Release
+  -DSITOS_BUILD_TESTS=OFF -DSITOS_WITH_ZENOH=OFF)
+run_checked("${CMAKE_COMMAND}" --build "${_off_build}")
+run_checked("${CMAKE_COMMAND}" --install "${_off_build}" --prefix "${_off_original}")
+validate_clean_install("${_off_original}")
+run_checked("${CMAKE_COMMAND}" -E copy_directory "${_off_original}" "${_off_moved}")
+validate_relocation("${_off_moved}" "${_off_original}" "${_off_build}")
+validate_consumer("${_off_moved}" "${_off_consumer}")
+
+set(_on_build "${WORK_DIR}/on-build")
+set(_on_original "${WORK_DIR}/on-original")
+set(_on_moved "${WORK_DIR}/on-moved")
+set(_on_consumer "${WORK_DIR}/on-consumer")
+set(_zenoh_root "${_on_build}/_deps/zenohc-src")
+run_checked(
+  "${CMAKE_COMMAND}" -S "${SITOS_SOURCE_DIR}" -B "${_on_build}"
+  -G "${CMAKE_GENERATOR}" -DCMAKE_BUILD_TYPE=Release
+  -DSITOS_BUILD_TESTS=OFF -DSITOS_WITH_ZENOH=ON)
+run_checked("${CMAKE_COMMAND}" --build "${_on_build}")
+run_checked("${CMAKE_COMMAND}" --install "${_on_build}" --prefix "${_on_original}")
+validate_clean_install("${_on_original}")
+run_checked("${CMAKE_COMMAND}" -E copy_directory "${_on_original}" "${_on_moved}")
+validate_relocation("${_on_moved}" "${_on_original}" "${_on_build}")
+validate_consumer("${_on_moved}" "${_on_consumer}" "-DZENOHC_ROOT=${_zenoh_root}")

--- a/tests/package/validate_installed_package.cmake
+++ b/tests/package/validate_installed_package.cmake
@@ -7,6 +7,7 @@ endif()
 if(NOT DEFINED CMAKE_GENERATOR)
   set(CMAKE_GENERATOR Ninja)
 endif()
+include(GNUInstallDirs)
 
 function(run_checked)
   execute_process(
@@ -21,6 +22,7 @@ function(validate_clean_install prefix)
   run_checked(
     "${CMAKE_COMMAND}"
     "-DSITOS_PREFIX=${prefix}"
+    "-DSITOS_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}"
     -P "${SITOS_SOURCE_DIR}/tests/package/check_clean_install.cmake")
 endfunction()
 
@@ -31,9 +33,12 @@ function(validate_relocation prefix original_prefix build_dir)
     "-DSITOS_SOURCE_DIR=${SITOS_SOURCE_DIR}"
     "-DSITOS_BUILD_DIR=${build_dir}"
     "-DORIGINAL_PREFIX=${original_prefix}"
+    "-DSITOS_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}"
     -P "${SITOS_SOURCE_DIR}/tests/package/check_relocatable.cmake")
 endfunction()
 
+# Consumers are intentionally built but not executed: runtime shared-library deployment belongs
+# to the application or package manager, as specified by ADR-0021.
 function(validate_consumer prefix build_dir)
   set(_extra_args ${ARGN})
   run_checked(

--- a/tests/package/validate_installed_package.cmake
+++ b/tests/package/validate_installed_package.cmake
@@ -89,4 +89,7 @@ run_checked("${CMAKE_COMMAND}" --install "${_on_build}" --prefix "${_on_original
 validate_clean_install("${_on_original}")
 run_checked("${CMAKE_COMMAND}" -E copy_directory "${_on_original}" "${_on_moved}")
 validate_relocation("${_on_moved}" "${_on_original}" "${_on_build}")
-validate_consumer("${_on_moved}" "${_on_consumer}" "-DZENOHC_ROOT=${_zenoh_root}")
+validate_consumer("${_on_moved}" "${_on_consumer}-cmake-root"
+  "-DZENOHC_ROOT=${_zenoh_root}")
+validate_consumer("${_on_moved}" "${_on_consumer}-environment-root"
+  "-DZENOHC_ROOT_ENV=${_zenoh_root}")


### PR DESCRIPTION
## Summary

Closes #96

Adds a relocatable installed CMake package for sitos consumers, including:

- `sitosConfig.cmake` and `sitosConfigVersion.cmake`
- external `Findzenohc.cmake` reconstruction for Zenoh-ON static sitos packages
- standalone external consumer configure/build validation
- Zenoh OFF/ON relocation checks on Windows and Linux CI
- protection against installing GoogleTest/GMock artifacts
- ADR-0021 and updated package/dependency documentation

Zenoh-ON package discovery does not fetch or bundle zenoh-c. Consumers provide an external zenoh-c tree through `zenohc_ROOT`, `ZENOHC_ROOT`, or a normal CMake prefix, and own runtime shared-library deployment.

## Requirements

- C04: preserve semantic-version compatibility guarantees for the installed package.
- N05: validate installed consumers on Windows and Linux.
- N06: keep Zenoh-C external and avoid hidden package-time fetching.

## Acceptance criteria

- [x] Zenoh-OFF installed package works with `find_package(sitos CONFIG REQUIRED)` and `sitos::sitos`.
- [x] Zenoh-ON exported static target reconstructs the external shared `zenohc::zenohc` dependency before loading `sitosTargets.cmake`.
- [x] Separate external consumer configure/build validation covers Windows and Linux CI.
- [x] Install-prefix relocation and generated-config path checks are included.
- [x] Test-only GoogleTest/GMock artifacts are excluded from installs.
- [x] Installation and dependency documentation plus proposed ADR-0021 are included.

## TDD RED evidence

Against merged main `2a0d1ac`, after installing a test-free Zenoh-OFF build, the standalone consumer configure failed as expected because the package config did not exist:

```text
CMake Error at CMakeLists.txt:8 (find_package):
  Could not find a package configuration file provided by "sitos" (requested
  version 0.1) with any of the following names:

    sitos.cps
    sitosConfig.cmake
    sitos-config.cmake
```

## Verification

- Windows/MSVC package matrix: passed Zenoh-OFF and Zenoh-ON installation, relocation, external consumer configure/build, and test-only artifact checks.
- Windows/MSVC Zenoh-OFF full suite: **207/207 passed**.
- Windows/MSVC Zenoh-ON full suite: **248/248 passed**.
- `git diff --check`: passed.
- Secret scan: passed.
- Linux package validation and full suite: delegated to CI.

ADR-0021 remains Proposed until final review and will be changed to Accepted immediately before merge.

