### PR TITLE
feat(cache): implement ParamCache attachment lifecycle (#18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           UBSAN_OPTIONS: halt_on_error=1
         run: >-
           ctest --test-dir build/sanitizer-${{ matrix.name }}
-          --output-on-failure -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|TransportGetCompletionTest'
+          --output-on-failure -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|TransportGetCompletionTest|ParamCacheTest'
 
   build-windows:
     runs-on: windows-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ endfunction()
 add_library(sitos STATIC
   src/client_config.cpp
   src/param_store.cpp
+  src/param_cache.cpp
   src/status.cpp
   src/param_value.cpp
   src/batch.cpp

--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -247,17 +247,28 @@ Inside a queryable callback, do not wait; allow only short reads from engine/ove
 
 ### 5.1 Construction Sequence (Joining a Session)
 
+`ParamCache` is a move-only lifecycle object in this milestone. Its public read and write
+methods are deferred to Issue #19; tests use an internal test-access seam.
+
 ```
 ParamCache::Attach(sid):
-  1. declare subscriber: <prefix>/session/<sid>/**     … (a)
-  2. get: <prefix>/snap/<sid>/**    → store in cache   … (b)
-  3. get: <prefix>/session/<sid>/** → overwrite cache  … (c)
-  4. apply the buffer already received by (a), then apply sequentially thereafter
+  1. create an accepting candidate and declare <prefix>/session/<sid>/** (buffering);
+  2. get <prefix>/snap/<sid>/** into a private snapshot baseline;
+  3. get <prefix>/session/<sid>/** into a private overlay;
+  4. under the delta sequence lock, build baseline + overlay, drain buffered samples,
+     and atomically switch to live mode;
+  5. publish the candidate only after the transaction succeeds.
 ```
 
-Because the order is (a)→(b)→(c), puts that occur between (b) and (c) are also picked up by (a),
-so there are no missed updates (the same technique as zenoh Querying Subscriber).
-Duplicate application is idempotent because it overwrites the same key.
+The subscriber is declared before either Get. Every callback is either buffered or applied under
+one gap-free sequence lock, and the application order is snapshot, overlay, buffered samples,
+then live samples. A failed declaration, Get, or reply decode rolls back the candidate and leaves
+the cache detached and retryable. A valid session with zero replies (including an unknown session,
+which this protocol cannot distinguish from an empty one) attaches as an empty cache.
+
+`AttachBase()` uses the same subscriber-first transaction with `<prefix>/base/**` and a single
+base Get. `Detach()` closes callback admission, undeclares the subscription, waits for admitted
+callbacks, and only then clears state. No callback mutates the cache after Detach returns.
 
 ### 5.2 Data Structures and Zero-Copy Reads [N01]
 
@@ -279,8 +290,9 @@ class ParamCache {
 
 ### 5.3 Direct Base Reference Mode
 
-For simple use cases without sessions, also provide a mode where `Attach("base")`
-initially fetches + subscribes to `base/**` (no snapshot isolation).
+For simple use cases without sessions, `AttachBase()` initially fetches + subscribes to
+`base/**` (no snapshot isolation). A base DELETE erases its key. In session mode, a DELETE
+removes the overlay and restores the snapshot baseline when one exists.
 
 ## 6. ParamStore (Writes and Ad Hoc Reads)
 

--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -250,7 +250,7 @@ Inside a queryable callback, do not wait; allow only short reads from engine/ove
 `ParamCache` is a move-only lifecycle object in this milestone. Its public read and write
 methods are deferred to Issue #19; tests use an internal test-access seam.
 
-```
+```text
 ParamCache::Attach(sid):
   1. create an accepting candidate and declare <prefix>/session/<sid>/** (buffering);
   2. get <prefix>/snap/<sid>/** into a private snapshot baseline;

--- a/docs/04_api_cpp.md
+++ b/docs/04_api_cpp.md
@@ -220,62 +220,34 @@ public:
 
 ```cpp
 class ParamCache {
-public:
-    static Result<ParamCache> Open(const Config& config);
-    static Result<ParamCache> Open(std::shared_ptr<Transport> transport,
-                                   const Config& config);
+ public:
+  static Result<ParamCache> Open(ClientConfig config = {});
+  static Result<ParamCache> Open(std::shared_ptr<Transport> transport,
+                                 ClientConfig config = {});
 
-    /// Join a session: initially fetch snap + overlay, then start delta subscription.
-    /// Synchronously blocks until completion (timeout is config.query_timeout).
-    Result<void> Attach(std::string_view sid);
-    /// Direct base reference mode ([02] §5.3)
-    Result<void> AttachBase();
-    void Detach();
+  ~ParamCache();
+  ParamCache(const ParamCache&) = delete;
+  ParamCache& operator=(const ParamCache&) = delete;
+  ParamCache(ParamCache&&) noexcept;
+  ParamCache& operator=(ParamCache&&) noexcept;
 
-    // ---- Zero-copy reads [N01] ----
-    /// Shared reference to the value. The lock is held only during lookup. Return-value lifetime is managed by shared_ptr.
-    std::shared_ptr<const ParamValue> GetShared(std::string_view key) const;
-
-    template<typename T>
-    std::optional<T> Get(std::string_view key) const;          // Scalar (copy)
-    template<typename T>
-    T GetOr(std::string_view key, T default_value) const;
-
-    /// LUT reference: span pointing to the internal buffer + lifetime keepalive handle
-    template<typename T>
-    struct SpanHandle {
-        std::span<const T> span;
-        std::shared_ptr<const ParamValue> keepalive;
-    };
-    template<typename T>
-    std::optional<SpanHandle<T>> GetSpan(std::string_view key) const;
-
-    bool Contains(std::string_view key) const;
-    /// Enumerate within the cache (no communication)
-    void List(std::string_view prefix, const ListSink& sink) const;
-
-    // ---- Writes within a session (put to overlay) ----
-    Result<void> Put(std::string_view key, const ParamValue& value);
-    Result<void> PutBatch(std::span<const std::pair<std::string, ParamValue>> entries);
-
-    // ---- State ----
-    bool stale() const;   // true while disconnected. Recovers by refetching after reconnection [N10]
+  Result<void> Attach(std::string_view sid);
+  Result<void> AttachBase();
+  void Detach() noexcept;
 };
 ```
 
-### Usage Example (Compute Process)
+Issue #18 provides only construction and attachment lifecycle. Attach declares the subscriber
+before synchronously fetching snapshot and overlay data, buffers subscriber samples during the
+transaction, then drains that buffer and switches to live mode atomically. Failed declarations,
+transport errors, malformed replies, and invalid keys roll back all candidate state; a retry starts
+from detached state. A valid session with zero replies attaches empty because the current protocol
+cannot distinguish an unknown session from an empty one. Detach closes callback admission,
+undeclares the subscription, waits for in-flight callbacks, and then clears state.
 
-```cpp
-auto cache = sitos::ParamCache::Open(config).value.value();
-cache.Attach(sid);
-
-double fov   = cache.GetOr<double>("recon/fov", 240.0);
-auto lut     = cache.GetSpan<float>("recon/bhc/lut");   // zero-copy
-if (lut) Process(lut->span);
-
-cache.Put("recon/progress", 0.5);   // distributed to all participating processes
-```
-
+The internal cache uses immutable `shared_ptr<const ParamValue>` values and a shared mutex, but
+public `GetShared`, scalar Get/GetOr, GetSpan/SpanHandle, Contains, List, Put, PutBatch, and
+`stale()` belong to Issues #19/#20 and are not present in Issue #18.
 ## 5. SessionView — Composite View (Optional Use)
 
 A facade for the host process side that handles overlay → snapshot resolution through one read

--- a/docs/04_api_cpp.md
+++ b/docs/04_api_cpp.md
@@ -268,7 +268,7 @@ public:
 |---|---|
 | `ParamValue` | Immutable. Can be freely shared |
 | `ParamStore` | All methods may be called concurrently |
-| `ParamCache` | Get methods may run concurrently. Attach/Detach must be serialized externally |
+| `ParamCache` | Attach/Detach lifecycle methods are serialized internally. Public read/reconnect semantics are deferred to Issues #19/#20 |
 | `StorageNode` | All methods may be called concurrently |
 | callback | Called from zenoh threads. Blocking is prohibited. From inside a callback, only Get-style APIs on the same object may be called |
 

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -127,22 +127,22 @@ major behaviors.
 
 ## 5.2 Lifecycle sanitizer runs
 
-Issue #11 lifecycle tests and Issue #13 batch sequencing tests have reproducible
-sanitizer configurations. TSan runs the zenoh-independent fake-Transport stress
-paths; ASan/UBSan runs the same paths separately:
+Issue #11 lifecycle tests, Issue #13 batch sequencing tests, and Issue #18 ParamCache
+fake-Transport lifecycle tests have reproducible sanitizer configurations. TSan runs the
+zenoh-independent fake-Transport paths; ASan/UBSan runs the same paths separately:
 
 ```sh
 cmake -S . -B build/tsan -G Ninja -DCMAKE_BUILD_TYPE=Debug \
   -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF -DSITOS_ENABLE_TSAN=ON
 cmake --build build/tsan
 ctest --test-dir build/tsan --output-on-failure \
-  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest'
+  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|ParamCacheTest'
 
 cmake -S . -B build/asan -G Ninja -DCMAKE_BUILD_TYPE=Debug \
   -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF -DSITOS_ENABLE_ASAN_UBSAN=ON
 cmake --build build/asan
 ctest --test-dir build/asan --output-on-failure \
-  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest'
+  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|ParamCacheTest'
 ```
 
 For a platform where the zenoh-c standalone runtime supports sanitizer instrumentation,

--- a/include/sitos/param_cache.hpp
+++ b/include/sitos/param_cache.hpp
@@ -1,0 +1,47 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SITOS_PARAM_CACHE_HPP
+#define SITOS_PARAM_CACHE_HPP
+
+#include <memory>
+#include <string_view>
+
+#include "sitos/client_config.hpp"
+#include "sitos/result.hpp"
+#include "sitos/transport.hpp"
+
+namespace sitos {
+
+namespace param_cache_test_access {
+class ParamCacheTestAccess;
+}
+
+/// Subscriber-side cache lifecycle. Read and write APIs are provided by later issues.
+class ParamCache {
+ public:
+  static Result<ParamCache> Open(ClientConfig config = {});
+  static Result<ParamCache> Open(std::shared_ptr<Transport> transport,
+                                 ClientConfig config = {});
+
+  ~ParamCache();
+  ParamCache(const ParamCache&) = delete;
+  ParamCache& operator=(const ParamCache&) = delete;
+  ParamCache(ParamCache&&) noexcept;
+  ParamCache& operator=(ParamCache&&) noexcept;
+
+  Result<void> Attach(std::string_view sid);
+  Result<void> AttachBase();
+  void Detach() noexcept;
+
+  struct Impl;
+
+ private:
+  friend class param_cache_test_access::ParamCacheTestAccess;
+  explicit ParamCache(std::shared_ptr<Transport> transport, ClientConfig config);
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace sitos
+
+#endif  // SITOS_PARAM_CACHE_HPP

--- a/include/sitos/param_cache.hpp
+++ b/include/sitos/param_cache.hpp
@@ -17,6 +17,10 @@ namespace param_cache_test_access {
 class ParamCacheTestAccess;
 }
 
+namespace param_cache_detail {
+struct Access;
+}
+
 /// Subscriber-side cache lifecycle. Read and write APIs are provided by later issues.
 class ParamCache {
  public:
@@ -34,9 +38,9 @@ class ParamCache {
   Result<void> AttachBase();
   void Detach() noexcept;
 
-  struct Impl;
-
  private:
+  struct Impl;
+  friend struct param_cache_detail::Access;
   friend class param_cache_test_access::ParamCacheTestAccess;
   explicit ParamCache(std::shared_ptr<Transport> transport, ClientConfig config);
   std::unique_ptr<Impl> impl_;

--- a/include/sitos/sitos.hpp
+++ b/include/sitos/sitos.hpp
@@ -9,6 +9,7 @@
 #include "sitos/in_memory_engine.hpp"
 #include "sitos/key.hpp"
 #include "sitos/logging.hpp"
+#include "sitos/param_cache.hpp"
 #include "sitos/param_store.hpp"
 #include "sitos/param_value.hpp"
 #include "sitos/result.hpp"

--- a/src/param_cache.cpp
+++ b/src/param_cache.cpp
@@ -1,0 +1,448 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/param_cache.hpp"
+
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "sitos/batch.hpp"
+#include "sitos/key.hpp"
+#include "param_cache_test_access.hpp"
+
+namespace sitos {
+namespace {
+
+std::string ScopeQuery(const ClientConfig& config, std::string_view scope) {
+  return config.prefix + "/" + std::string(scope) + "/**";
+}
+
+Result<void> InvalidArgument(std::string_view message) {
+  return Result<void>::Err(Status::InvalidArgument, std::string(message));
+}
+
+Result<void> InvalidKey(std::string_view message) {
+  return Result<void>::Err(Status::InvalidKey, std::string(message));
+}
+
+}  // namespace
+
+struct ParamCache::Impl {
+  enum class Phase { Buffering, Live, Stopping };
+  enum class MutationKind { Put, Delete };
+
+  struct Mutation {
+    MutationKind kind;
+    std::string key;
+    std::shared_ptr<const ParamValue> value;
+  };
+
+  struct State {
+    explicit State(std::string prefix_value, bool session_value, std::string sid_value)
+        : prefix(std::move(prefix_value)), session(session_value), sid(std::move(sid_value)) {}
+
+    std::string prefix;
+    bool session;
+    std::string sid;
+    Phase phase = Phase::Buffering;
+    std::mutex gate_mutex;
+    std::condition_variable gate_condition;
+    bool accepting = true;
+    std::size_t in_flight = 0;
+    std::mutex sequence_mutex;
+    mutable std::shared_mutex map_mutex;
+    std::unordered_map<std::string, std::shared_ptr<const ParamValue>> snapshot_baseline;
+    std::unordered_map<std::string, std::shared_ptr<const ParamValue>> effective_map;
+    std::vector<Mutation> buffered;
+  };
+
+  explicit Impl(std::shared_ptr<Transport> transport_value, ClientConfig config_value)
+      : transport(std::move(transport_value)), config(std::move(config_value)) {}
+
+  std::shared_ptr<Transport> transport;
+  ClientConfig config;
+  std::mutex lifecycle_mutex;
+  std::shared_ptr<State> active_state;
+  Subscription subscription;
+};
+
+namespace {
+
+class CallbackLease {
+ public:
+  explicit CallbackLease(const std::shared_ptr<ParamCache::Impl::State>& state) : state_(state) {
+    std::lock_guard lock(state_->gate_mutex);
+    if (!state_->accepting) return;
+    ++state_->in_flight;
+    entered_ = true;
+  }
+
+  ~CallbackLease() {
+    if (!entered_) return;
+    std::lock_guard lock(state_->gate_mutex);
+    --state_->in_flight;
+    if (state_->in_flight == 0) state_->gate_condition.notify_all();
+  }
+
+  explicit operator bool() const noexcept { return entered_; }
+
+ private:
+  std::shared_ptr<ParamCache::Impl::State> state_;
+  bool entered_ = false;
+};
+
+void CloseGate(const std::shared_ptr<ParamCache::Impl::State>& state) {
+  std::lock_guard lock(state->gate_mutex);
+  state->accepting = false;
+}
+
+void WaitForCallbacks(const std::shared_ptr<ParamCache::Impl::State>& state) {
+  std::unique_lock lock(state->gate_mutex);
+  state->gate_condition.wait(lock, [&] { return state->in_flight == 0; });
+}
+
+bool IsExpected(const ParsedKey& parsed, const ParamCache::Impl::State& state,
+                bool batch_allowed) {
+  if (parsed.is_batch != batch_allowed) return false;
+  if (state.session) {
+    return parsed.kind == KeyKind::Session && parsed.sid == state.sid;
+  }
+  return parsed.kind == KeyKind::Base;
+}
+
+std::optional<ParamCache::Impl::Mutation> DecodeOrdinary(
+    const ParamCache::Impl::State& state, const TransportSample& sample) {
+  const auto parsed = ParseKey(state.prefix, sample.key);
+  if (!parsed || !IsExpected(*parsed, state, false)) return std::nullopt;
+  if (sample.kind == TransportSample::Kind::Delete) {
+    return ParamCache::Impl::Mutation{ParamCache::Impl::MutationKind::Delete,
+                                      parsed->relative_key, nullptr};
+  }
+  if (sample.encoding.id == Encoding::kSitosV1Batch) return std::nullopt;
+
+  std::optional<ParamValue> decoded;
+  if (sample.encoding.id == Encoding::kSitosV1) {
+    decoded = ParamValue::Decode(sample.payload);
+    if (!decoded.has_value()) return std::nullopt;
+  } else {
+    decoded = ParamValue(std::vector<std::byte>(sample.payload.begin(), sample.payload.end()));
+  }
+  return ParamCache::Impl::Mutation{ParamCache::Impl::MutationKind::Put,
+                                    parsed->relative_key,
+                                    std::make_shared<const ParamValue>(std::move(*decoded))};
+}
+
+std::optional<std::vector<ParamCache::Impl::Mutation>> DecodeSample(
+    const std::shared_ptr<ParamCache::Impl::State>& state, const TransportSample& sample) {
+  if (sample.kind == TransportSample::Kind::Delete) {
+    auto mutation = DecodeOrdinary(*state, sample);
+    if (!mutation.has_value()) return std::nullopt;
+    return std::vector<ParamCache::Impl::Mutation>{std::move(*mutation)};
+  }
+
+  const auto parsed = ParseKey(state->prefix, sample.key);
+  if (!parsed) return std::nullopt;
+  if (parsed->is_batch) {
+    if (!IsExpected(*parsed, *state, true) || sample.encoding.id != Encoding::kSitosV1Batch) {
+      return std::nullopt;
+    }
+    auto entries = DecodeBatch(sample.payload);
+    if (!entries.has_value()) return std::nullopt;
+    std::vector<ParamCache::Impl::Mutation> mutations;
+    mutations.reserve(entries->size());
+    for (auto& entry : *entries) {
+      if (!IsValidKey(entry.key)) return std::nullopt;
+      mutations.push_back(ParamCache::Impl::Mutation{
+          ParamCache::Impl::MutationKind::Put, std::move(entry.key),
+          std::make_shared<const ParamValue>(std::move(entry.value))});
+    }
+    return mutations;
+  }
+  auto ordinary = DecodeOrdinary(*state, sample);
+  if (!ordinary.has_value()) return std::nullopt;
+  return std::vector<ParamCache::Impl::Mutation>{std::move(*ordinary)};
+}
+
+void ApplyMutation(ParamCache::Impl::State& state,
+                   const ParamCache::Impl::Mutation& mutation) {
+  std::unique_lock lock(state.map_mutex);
+  if (mutation.kind == ParamCache::Impl::MutationKind::Put) {
+    state.effective_map[mutation.key] = mutation.value;
+    return;
+  }
+  if (state.session) {
+    const auto baseline = state.snapshot_baseline.find(mutation.key);
+    if (baseline != state.snapshot_baseline.end()) {
+      state.effective_map[mutation.key] = baseline->second;
+    } else {
+      state.effective_map.erase(mutation.key);
+    }
+  } else {
+    state.effective_map.erase(mutation.key);
+  }
+}
+
+void ApplyMutations(ParamCache::Impl::State& state,
+                    const std::vector<ParamCache::Impl::Mutation>& mutations) {
+  for (const auto& mutation : mutations) ApplyMutation(state, mutation);
+}
+
+void OnSample(const std::shared_ptr<ParamCache::Impl::State>& state,
+              const TransportSample& sample) {
+  CallbackLease lease(state);
+  if (!lease) return;
+  auto mutations = DecodeSample(state, sample);
+  if (!mutations.has_value()) return;
+
+  std::lock_guard sequence_lock(state->sequence_mutex);
+  if (state->phase == ParamCache::Impl::Phase::Buffering) {
+    for (auto& mutation : *mutations) state->buffered.push_back(std::move(mutation));
+    return;
+  }
+  if (state->phase != ParamCache::Impl::Phase::Live) return;
+  ApplyMutations(*state, *mutations);
+}
+
+Result<void> DecodeGetReply(const std::shared_ptr<ParamCache::Impl::State>& state,
+                            bool snapshot, std::string_view full_key,
+                            std::span<const std::byte> payload, const Encoding& encoding,
+                            std::unordered_map<std::string, std::shared_ptr<const ParamValue>>& out,
+                            bool& invalid) {
+  const auto parsed = ParseKey(state->prefix, full_key);
+  const bool expected = parsed.has_value() && !parsed->is_batch &&
+                       ((snapshot && parsed->kind == KeyKind::Snapshot &&
+                         parsed->sid == state->sid) ||
+                        (!snapshot && ((state->session && parsed->kind == KeyKind::Session &&
+                                        parsed->sid == state->sid) ||
+                                       (!state->session && parsed->kind == KeyKind::Base))));
+  if (!expected) {
+    invalid = true;
+    return Result<void>::Err(Status::Error, "transport returned an invalid cache key");
+  }
+  if (encoding.id == Encoding::kSitosV1Batch) {
+    invalid = true;
+    return Result<void>::Err(Status::Error, "transport returned a batch for a value query");
+  }
+  std::optional<ParamValue> value;
+  if (encoding.id == Encoding::kSitosV1) {
+    value = ParamValue::Decode(payload);
+    if (!value.has_value()) {
+      invalid = true;
+      return Result<void>::Err(Status::Error, "transport returned malformed payload");
+    }
+  } else {
+    value = ParamValue(std::vector<std::byte>(payload.begin(), payload.end()));
+  }
+  out[parsed->relative_key] = std::make_shared<const ParamValue>(std::move(*value));
+  return Result<void>::Ok();
+}
+
+Result<void> Fetch(const std::shared_ptr<ParamCache::Impl::State>& state,
+                   const std::shared_ptr<Transport>& transport, std::string_view query,
+                   bool snapshot,
+                   std::unordered_map<std::string, std::shared_ptr<const ParamValue>>& out,
+                   std::chrono::milliseconds timeout) {
+  bool invalid = false;
+  Result<void> protocol_error = Result<void>::Ok();
+  const auto sink = [&](std::string_view key, std::span<const std::byte> payload,
+                        Encoding encoding) {
+    auto decoded = DecodeGetReply(state, snapshot, key, payload, encoding, out, invalid);
+    if (!decoded.IsOk()) protocol_error = std::move(decoded);
+    return decoded.IsOk();
+  };
+  auto result = transport->Get(query, sink, timeout);
+  if (!result.IsOk()) return Result<void>::ErrFrom(result);
+  if (invalid) return Result<void>::ErrFrom(protocol_error);
+  return Result<void>::Ok();
+}
+
+void CleanupCandidate(const std::shared_ptr<ParamCache::Impl::State>& state,
+                      Subscription& subscription) {
+  CloseGate(state);
+  subscription = Subscription{};
+  WaitForCallbacks(state);
+  std::lock_guard sequence_lock(state->sequence_mutex);
+  state->phase = ParamCache::Impl::Phase::Stopping;
+  std::unique_lock map_lock(state->map_mutex);
+  state->snapshot_baseline.clear();
+  state->effective_map.clear();
+  state->buffered.clear();
+}
+
+}  // namespace
+
+ParamCache::ParamCache(std::shared_ptr<Transport> transport, ClientConfig config)
+    : impl_(std::make_unique<Impl>(std::move(transport), std::move(config))) {}
+
+ParamCache::~ParamCache() { Detach(); }
+
+ParamCache::ParamCache(ParamCache&&) noexcept = default;
+
+ParamCache& ParamCache::operator=(ParamCache&& other) noexcept {
+  if (this == &other) return *this;
+  Detach();
+  impl_ = std::move(other.impl_);
+  return *this;
+}
+
+Result<ParamCache> ParamCache::Open(ClientConfig config) {
+  auto validation = ValidateClientConfig(config);
+  if (!validation.IsOk()) return Result<ParamCache>::ErrFrom(validation);
+  std::optional<std::string_view> json;
+  if (config.zenoh_config_json.has_value()) json = *config.zenoh_config_json;
+  auto transport_result = OpenZenohTransport(json);
+  if (!transport_result.IsOk()) return Result<ParamCache>::ErrFrom(transport_result);
+  std::shared_ptr<Transport> transport(std::move(transport_result).Value());
+  return Result<ParamCache>::Ok(ParamCache(std::move(transport), std::move(config)));
+}
+
+Result<ParamCache> ParamCache::Open(std::shared_ptr<Transport> transport, ClientConfig config) {
+  if (!transport) return Result<ParamCache>::Err(Status::InvalidArgument, "null transport");
+  auto validation = ValidateClientConfig(config);
+  if (!validation.IsOk()) return Result<ParamCache>::ErrFrom(validation);
+  if (config.zenoh_config_json.has_value()) {
+    return Result<ParamCache>::Err(Status::InvalidArgument,
+                                   "injected transport cannot apply zenoh configuration");
+  }
+  return Result<ParamCache>::Ok(ParamCache(std::move(transport), std::move(config)));
+}
+
+Result<void> ParamCache::Attach(std::string_view sid) {
+  if (!impl_) return InvalidArgument("moved-from ParamCache");
+  if (!IsValidSessionId(sid)) return InvalidKey("invalid session id");
+  std::lock_guard lifecycle_lock(impl_->lifecycle_mutex);
+  if (impl_->active_state) return InvalidArgument("ParamCache is already attached");
+
+  auto state = std::make_shared<Impl::State>(impl_->config.prefix, true, std::string(sid));
+  Subscription subscription;
+  auto declared = impl_->transport->DeclareSubscriber(
+      ScopeQuery(impl_->config, "session/" + std::string(sid)),
+      [state](const TransportSample& sample) { OnSample(state, sample); });
+  if (!declared.IsOk()) {
+    CloseGate(state);
+    WaitForCallbacks(state);
+    return Result<void>::ErrFrom(declared);
+  }
+  subscription = std::move(declared).Value();
+
+  std::unordered_map<std::string, std::shared_ptr<const ParamValue>> snapshot;
+  std::unordered_map<std::string, std::shared_ptr<const ParamValue>> overlay;
+  auto snapshot_result = Fetch(state, impl_->transport,
+                               ScopeQuery(impl_->config, "snap/" + std::string(sid)), true,
+                               snapshot, impl_->config.query_timeout);
+  if (!snapshot_result.IsOk()) {
+    CleanupCandidate(state, subscription);
+    return snapshot_result;
+  }
+  auto overlay_result = Fetch(state, impl_->transport,
+                              ScopeQuery(impl_->config, "session/" + std::string(sid)), false,
+                              overlay, impl_->config.query_timeout);
+  if (!overlay_result.IsOk()) {
+    CleanupCandidate(state, subscription);
+    return overlay_result;
+  }
+
+  {
+    std::lock_guard sequence_lock(state->sequence_mutex);
+    {
+      std::unique_lock map_lock(state->map_mutex);
+      state->snapshot_baseline = std::move(snapshot);
+      state->effective_map = state->snapshot_baseline;
+      for (auto& [key, value] : overlay) state->effective_map[key] = std::move(value);
+    }
+    ApplyMutations(*state, state->buffered);
+    state->buffered.clear();
+    state->phase = Impl::Phase::Live;
+  }
+  impl_->active_state = state;
+  impl_->subscription = std::move(subscription);
+  return Result<void>::Ok();
+}
+
+Result<void> ParamCache::AttachBase() {
+  if (!impl_) return InvalidArgument("moved-from ParamCache");
+  std::lock_guard lifecycle_lock(impl_->lifecycle_mutex);
+  if (impl_->active_state) return InvalidArgument("ParamCache is already attached");
+
+  auto state = std::make_shared<Impl::State>(impl_->config.prefix, false, "");
+  Subscription subscription;
+  auto declared = impl_->transport->DeclareSubscriber(
+      ScopeQuery(impl_->config, "base"),
+      [state](const TransportSample& sample) { OnSample(state, sample); });
+  if (!declared.IsOk()) {
+    CloseGate(state);
+    WaitForCallbacks(state);
+    return Result<void>::ErrFrom(declared);
+  }
+  subscription = std::move(declared).Value();
+  std::unordered_map<std::string, std::shared_ptr<const ParamValue>> initial;
+  auto initial_result = Fetch(state, impl_->transport, ScopeQuery(impl_->config, "base"), false,
+                              initial, impl_->config.query_timeout);
+  if (!initial_result.IsOk()) {
+    CleanupCandidate(state, subscription);
+    return initial_result;
+  }
+  {
+    std::lock_guard sequence_lock(state->sequence_mutex);
+    {
+      std::unique_lock map_lock(state->map_mutex);
+      state->effective_map = std::move(initial);
+    }
+    ApplyMutations(*state, state->buffered);
+    state->buffered.clear();
+    state->phase = Impl::Phase::Live;
+  }
+  impl_->active_state = state;
+  impl_->subscription = std::move(subscription);
+  return Result<void>::Ok();
+}
+
+void ParamCache::Detach() noexcept {
+  if (!impl_) return;
+  std::lock_guard lifecycle_lock(impl_->lifecycle_mutex);
+  auto state = std::move(impl_->active_state);
+  if (!state) return;
+  CloseGate(state);
+  impl_->subscription = Subscription{};
+  WaitForCallbacks(state);
+  std::lock_guard sequence_lock(state->sequence_mutex);
+  state->phase = Impl::Phase::Stopping;
+  std::unique_lock map_lock(state->map_mutex);
+  state->snapshot_baseline.clear();
+  state->effective_map.clear();
+  state->buffered.clear();
+}
+
+namespace param_cache_test_access {
+
+bool ParamCacheTestAccess::IsAttached(const ParamCache& cache) {
+  return cache.impl_ != nullptr && cache.impl_->active_state != nullptr;
+}
+
+std::size_t ParamCacheTestAccess::Size(const ParamCache& cache) {
+  if (cache.impl_ == nullptr || cache.impl_->active_state == nullptr) return 0;
+  std::shared_lock lock(cache.impl_->active_state->map_mutex);
+  return cache.impl_->active_state->effective_map.size();
+}
+
+std::optional<ParamValue> ParamCacheTestAccess::Get(const ParamCache& cache,
+                                                     std::string_view key) {
+  if (cache.impl_ == nullptr || cache.impl_->active_state == nullptr) return std::nullopt;
+  std::shared_lock lock(cache.impl_->active_state->map_mutex);
+  const auto it = cache.impl_->active_state->effective_map.find(std::string(key));
+  if (it == cache.impl_->active_state->effective_map.end()) return std::nullopt;
+  return *it->second;
+}
+
+std::vector<std::string> ParamCacheTestAccess::Events(const ParamCache&) { return {}; }
+
+}  // namespace param_cache_test_access
+
+}  // namespace sitos

--- a/src/param_cache.cpp
+++ b/src/param_cache.cpp
@@ -94,6 +94,11 @@ class CallbackLease {
     entered_ = true;
   }
 
+  CallbackLease(const CallbackLease&) = delete;
+  CallbackLease& operator=(const CallbackLease&) = delete;
+  CallbackLease(CallbackLease&&) = delete;
+  CallbackLease& operator=(CallbackLease&&) = delete;
+
   ~CallbackLease() {
     if (!entered_) return;
     std::lock_guard lock(state_->gate_mutex);
@@ -270,8 +275,9 @@ Result<void> Fetch(const std::shared_ptr<param_cache_detail::Access::Impl::State
                         std::string_view key, std::span<const std::byte> payload,
                         Encoding encoding) {
     auto decoded = DecodeGetReply(state, snapshot, key, payload, encoding, out, invalid);
-    if (!decoded.IsOk()) protocol_error = std::move(decoded);
-    return decoded.IsOk();
+    const bool ok = decoded.IsOk();
+    if (!ok) protocol_error = std::move(decoded);
+    return ok;
   };
   auto result = transport->Get(query, sink, timeout);
   if (!result.IsOk()) return Result<void>::ErrFrom(result);

--- a/src/param_cache.cpp
+++ b/src/param_cache.cpp
@@ -4,6 +4,7 @@
 #include "sitos/param_cache.hpp"
 
 #include <condition_variable>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -61,6 +62,9 @@ struct ParamCache::Impl {
     std::unordered_map<std::string, std::shared_ptr<const ParamValue>> snapshot_baseline;
     std::unordered_map<std::string, std::shared_ptr<const ParamValue>> effective_map;
     std::vector<Mutation> buffered;
+    std::function<void()> callback_hook;
+    std::function<void(std::size_t)> mutation_hook;
+    std::size_t mutation_count = 0;
   };
 
   explicit Impl(std::shared_ptr<Transport> transport_value, ClientConfig config_value)
@@ -73,11 +77,17 @@ struct ParamCache::Impl {
   Subscription subscription;
 };
 
+namespace param_cache_detail {
+struct Access {
+  using Impl = ParamCache::Impl;
+};
+}  // namespace param_cache_detail
+
 namespace {
 
 class CallbackLease {
  public:
-  explicit CallbackLease(const std::shared_ptr<ParamCache::Impl::State>& state) : state_(state) {
+  explicit CallbackLease(const std::shared_ptr<param_cache_detail::Access::Impl::State>& state) : state_(state) {
     std::lock_guard lock(state_->gate_mutex);
     if (!state_->accepting) return;
     ++state_->in_flight;
@@ -94,21 +104,21 @@ class CallbackLease {
   explicit operator bool() const noexcept { return entered_; }
 
  private:
-  std::shared_ptr<ParamCache::Impl::State> state_;
+  std::shared_ptr<param_cache_detail::Access::Impl::State> state_;
   bool entered_ = false;
 };
 
-void CloseGate(const std::shared_ptr<ParamCache::Impl::State>& state) {
+void CloseGate(const std::shared_ptr<param_cache_detail::Access::Impl::State>& state) {
   std::lock_guard lock(state->gate_mutex);
   state->accepting = false;
 }
 
-void WaitForCallbacks(const std::shared_ptr<ParamCache::Impl::State>& state) {
+void WaitForCallbacks(const std::shared_ptr<param_cache_detail::Access::Impl::State>& state) {
   std::unique_lock lock(state->gate_mutex);
-  state->gate_condition.wait(lock, [&] { return state->in_flight == 0; });
+  state->gate_condition.wait(lock, [state] { return state->in_flight == 0; });
 }
 
-bool IsExpected(const ParsedKey& parsed, const ParamCache::Impl::State& state,
+bool IsExpected(const ParsedKey& parsed, const param_cache_detail::Access::Impl::State& state,
                 bool batch_allowed) {
   if (parsed.is_batch != batch_allowed) return false;
   if (state.session) {
@@ -117,12 +127,12 @@ bool IsExpected(const ParsedKey& parsed, const ParamCache::Impl::State& state,
   return parsed.kind == KeyKind::Base;
 }
 
-std::optional<ParamCache::Impl::Mutation> DecodeOrdinary(
-    const ParamCache::Impl::State& state, const TransportSample& sample) {
+std::optional<param_cache_detail::Access::Impl::Mutation> DecodeOrdinary(
+    const param_cache_detail::Access::Impl::State& state, const TransportSample& sample) {
   const auto parsed = ParseKey(state.prefix, sample.key);
   if (!parsed || !IsExpected(*parsed, state, false)) return std::nullopt;
   if (sample.kind == TransportSample::Kind::Delete) {
-    return ParamCache::Impl::Mutation{ParamCache::Impl::MutationKind::Delete,
+    return param_cache_detail::Access::Impl::Mutation{param_cache_detail::Access::Impl::MutationKind::Delete,
                                       parsed->relative_key, nullptr};
   }
   if (sample.encoding.id == Encoding::kSitosV1Batch) return std::nullopt;
@@ -134,17 +144,17 @@ std::optional<ParamCache::Impl::Mutation> DecodeOrdinary(
   } else {
     decoded = ParamValue(std::vector<std::byte>(sample.payload.begin(), sample.payload.end()));
   }
-  return ParamCache::Impl::Mutation{ParamCache::Impl::MutationKind::Put,
+  return param_cache_detail::Access::Impl::Mutation{param_cache_detail::Access::Impl::MutationKind::Put,
                                     parsed->relative_key,
                                     std::make_shared<const ParamValue>(std::move(*decoded))};
 }
 
-std::optional<std::vector<ParamCache::Impl::Mutation>> DecodeSample(
-    const std::shared_ptr<ParamCache::Impl::State>& state, const TransportSample& sample) {
+std::optional<std::vector<param_cache_detail::Access::Impl::Mutation>> DecodeSample(
+    const std::shared_ptr<param_cache_detail::Access::Impl::State>& state, const TransportSample& sample) {
   if (sample.kind == TransportSample::Kind::Delete) {
     auto mutation = DecodeOrdinary(*state, sample);
     if (!mutation.has_value()) return std::nullopt;
-    return std::vector<ParamCache::Impl::Mutation>{std::move(*mutation)};
+    return std::vector<param_cache_detail::Access::Impl::Mutation>{std::move(*mutation)};
   }
 
   const auto parsed = ParseKey(state->prefix, sample.key);
@@ -155,25 +165,25 @@ std::optional<std::vector<ParamCache::Impl::Mutation>> DecodeSample(
     }
     auto entries = DecodeBatch(sample.payload);
     if (!entries.has_value()) return std::nullopt;
-    std::vector<ParamCache::Impl::Mutation> mutations;
+    std::vector<param_cache_detail::Access::Impl::Mutation> mutations;
     mutations.reserve(entries->size());
     for (auto& entry : *entries) {
       if (!IsValidKey(entry.key)) return std::nullopt;
-      mutations.push_back(ParamCache::Impl::Mutation{
-          ParamCache::Impl::MutationKind::Put, std::move(entry.key),
+      mutations.push_back(param_cache_detail::Access::Impl::Mutation{
+          param_cache_detail::Access::Impl::MutationKind::Put, std::move(entry.key),
           std::make_shared<const ParamValue>(std::move(entry.value))});
     }
     return mutations;
   }
   auto ordinary = DecodeOrdinary(*state, sample);
   if (!ordinary.has_value()) return std::nullopt;
-  return std::vector<ParamCache::Impl::Mutation>{std::move(*ordinary)};
+  return std::vector<param_cache_detail::Access::Impl::Mutation>{std::move(*ordinary)};
 }
 
-void ApplyMutation(ParamCache::Impl::State& state,
-                   const ParamCache::Impl::Mutation& mutation) {
+void ApplyMutation(param_cache_detail::Access::Impl::State& state,
+                   const param_cache_detail::Access::Impl::Mutation& mutation) {
   std::unique_lock lock(state.map_mutex);
-  if (mutation.kind == ParamCache::Impl::MutationKind::Put) {
+  if (mutation.kind == param_cache_detail::Access::Impl::MutationKind::Put) {
     state.effective_map[mutation.key] = mutation.value;
     return;
   }
@@ -189,28 +199,33 @@ void ApplyMutation(ParamCache::Impl::State& state,
   }
 }
 
-void ApplyMutations(ParamCache::Impl::State& state,
-                    const std::vector<ParamCache::Impl::Mutation>& mutations) {
-  for (const auto& mutation : mutations) ApplyMutation(state, mutation);
+void ApplyMutations(param_cache_detail::Access::Impl::State& state,
+                    const std::vector<param_cache_detail::Access::Impl::Mutation>& mutations) {
+  for (const auto& mutation : mutations) {
+    ApplyMutation(state, mutation);
+    ++state.mutation_count;
+    if (state.mutation_hook) state.mutation_hook(state.mutation_count);
+  }
 }
 
-void OnSample(const std::shared_ptr<ParamCache::Impl::State>& state,
+void OnSample(const std::shared_ptr<param_cache_detail::Access::Impl::State>& state,
               const TransportSample& sample) {
   CallbackLease lease(state);
   if (!lease) return;
+  if (state->callback_hook) state->callback_hook();
   auto mutations = DecodeSample(state, sample);
   if (!mutations.has_value()) return;
 
   std::lock_guard sequence_lock(state->sequence_mutex);
-  if (state->phase == ParamCache::Impl::Phase::Buffering) {
+  if (state->phase == param_cache_detail::Access::Impl::Phase::Buffering) {
     for (auto& mutation : *mutations) state->buffered.push_back(std::move(mutation));
     return;
   }
-  if (state->phase != ParamCache::Impl::Phase::Live) return;
+  if (state->phase != param_cache_detail::Access::Impl::Phase::Live) return;
   ApplyMutations(*state, *mutations);
 }
 
-Result<void> DecodeGetReply(const std::shared_ptr<ParamCache::Impl::State>& state,
+Result<void> DecodeGetReply(const std::shared_ptr<param_cache_detail::Access::Impl::State>& state,
                             bool snapshot, std::string_view full_key,
                             std::span<const std::byte> payload, const Encoding& encoding,
                             std::unordered_map<std::string, std::shared_ptr<const ParamValue>>& out,
@@ -244,14 +259,15 @@ Result<void> DecodeGetReply(const std::shared_ptr<ParamCache::Impl::State>& stat
   return Result<void>::Ok();
 }
 
-Result<void> Fetch(const std::shared_ptr<ParamCache::Impl::State>& state,
+Result<void> Fetch(const std::shared_ptr<param_cache_detail::Access::Impl::State>& state,
                    const std::shared_ptr<Transport>& transport, std::string_view query,
                    bool snapshot,
                    std::unordered_map<std::string, std::shared_ptr<const ParamValue>>& out,
                    std::chrono::milliseconds timeout) {
   bool invalid = false;
   Result<void> protocol_error = Result<void>::Ok();
-  const auto sink = [&](std::string_view key, std::span<const std::byte> payload,
+  const auto sink = [&state, snapshot, &out, &invalid, &protocol_error](
+                        std::string_view key, std::span<const std::byte> payload,
                         Encoding encoding) {
     auto decoded = DecodeGetReply(state, snapshot, key, payload, encoding, out, invalid);
     if (!decoded.IsOk()) protocol_error = std::move(decoded);
@@ -263,13 +279,13 @@ Result<void> Fetch(const std::shared_ptr<ParamCache::Impl::State>& state,
   return Result<void>::Ok();
 }
 
-void CleanupCandidate(const std::shared_ptr<ParamCache::Impl::State>& state,
+void CleanupCandidate(const std::shared_ptr<param_cache_detail::Access::Impl::State>& state,
                       Subscription& subscription) {
   CloseGate(state);
   subscription = Subscription{};
   WaitForCallbacks(state);
   std::lock_guard sequence_lock(state->sequence_mutex);
-  state->phase = ParamCache::Impl::Phase::Stopping;
+  state->phase = param_cache_detail::Access::Impl::Phase::Stopping;
   std::unique_lock map_lock(state->map_mutex);
   state->snapshot_baseline.clear();
   state->effective_map.clear();
@@ -407,7 +423,7 @@ Result<void> ParamCache::AttachBase() {
 void ParamCache::Detach() noexcept {
   if (!impl_) return;
   std::lock_guard lifecycle_lock(impl_->lifecycle_mutex);
-  auto state = std::move(impl_->active_state);
+  const auto state = impl_->active_state;
   if (!state) return;
   CloseGate(state);
   impl_->subscription = Subscription{};
@@ -418,6 +434,7 @@ void ParamCache::Detach() noexcept {
   state->snapshot_baseline.clear();
   state->effective_map.clear();
   state->buffered.clear();
+  impl_->active_state.reset();
 }
 
 namespace param_cache_test_access {
@@ -442,6 +459,17 @@ std::optional<ParamValue> ParamCacheTestAccess::Get(const ParamCache& cache,
 }
 
 std::vector<std::string> ParamCacheTestAccess::Events(const ParamCache&) { return {}; }
+
+void ParamCacheTestAccess::SetCallbackHook(ParamCache& cache, std::function<void()> hook) {
+  if (cache.impl_ == nullptr || cache.impl_->active_state == nullptr) return;
+  cache.impl_->active_state->callback_hook = std::move(hook);
+}
+
+void ParamCacheTestAccess::SetMutationHook(
+    ParamCache& cache, std::function<void(std::size_t)> hook) {
+  if (cache.impl_ == nullptr || cache.impl_->active_state == nullptr) return;
+  cache.impl_->active_state->mutation_hook = std::move(hook);
+}
 
 }  // namespace param_cache_test_access
 

--- a/src/param_cache.cpp
+++ b/src/param_cache.cpp
@@ -464,8 +464,6 @@ std::optional<ParamValue> ParamCacheTestAccess::Get(const ParamCache& cache,
   return *it->second;
 }
 
-std::vector<std::string> ParamCacheTestAccess::Events(const ParamCache&) { return {}; }
-
 void ParamCacheTestAccess::SetCallbackHook(ParamCache& cache, std::function<void()> hook) {
   if (cache.impl_ == nullptr || cache.impl_->active_state == nullptr) return;
   cache.impl_->active_state->callback_hook = std::move(hook);

--- a/src/param_cache_test_access.hpp
+++ b/src/param_cache_test_access.hpp
@@ -1,0 +1,26 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+#ifndef SITOS_PARAM_CACHE_TEST_ACCESS_HPP
+#define SITOS_PARAM_CACHE_TEST_ACCESS_HPP
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "sitos/param_cache.hpp"
+#include "sitos/param_value.hpp"
+
+namespace sitos::param_cache_test_access {
+
+class ParamCacheTestAccess {
+ public:
+  static bool IsAttached(const ParamCache& cache);
+  static std::size_t Size(const ParamCache& cache);
+  static std::optional<ParamValue> Get(const ParamCache& cache, std::string_view key);
+  static std::vector<std::string> Events(const ParamCache& cache);
+};
+
+}  // namespace sitos::param_cache_test_access
+#endif  // SITOS_PARAM_CACHE_TEST_ACCESS_HPP

--- a/src/param_cache_test_access.hpp
+++ b/src/param_cache_test_access.hpp
@@ -8,7 +8,6 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <vector>
 
 #include "sitos/param_cache.hpp"
 #include "sitos/param_value.hpp"
@@ -20,8 +19,9 @@ class ParamCacheTestAccess {
   static bool IsAttached(const ParamCache& cache);
   static std::size_t Size(const ParamCache& cache);
   static std::optional<ParamValue> Get(const ParamCache& cache, std::string_view key);
-  static std::vector<std::string> Events(const ParamCache& cache);
+  // Precondition: no callback is executing while the hook is being set.
   static void SetCallbackHook(ParamCache& cache, std::function<void()> hook);
+  // Precondition: no callback is executing while the hook is being set.
   static void SetMutationHook(ParamCache& cache, std::function<void(std::size_t)> hook);
 };
 

--- a/src/param_cache_test_access.hpp
+++ b/src/param_cache_test_access.hpp
@@ -4,6 +4,7 @@
 #define SITOS_PARAM_CACHE_TEST_ACCESS_HPP
 
 #include <cstddef>
+#include <functional>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -20,6 +21,8 @@ class ParamCacheTestAccess {
   static std::size_t Size(const ParamCache& cache);
   static std::optional<ParamValue> Get(const ParamCache& cache, std::string_view key);
   static std::vector<std::string> Events(const ParamCache& cache);
+  static void SetCallbackHook(ParamCache& cache, std::function<void()> hook);
+  static void SetMutationHook(ParamCache& cache, std::function<void(std::size_t)> hook);
 };
 
 }  // namespace sitos::param_cache_test_access

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,8 @@ add_sitos_public_header_compile_test(
   sitos_client_config_header_compile_test consumer/client_config_header_compile.cpp)
 add_sitos_public_header_compile_test(
   sitos_param_store_header_compile_test consumer/param_store_header_compile.cpp)
+add_sitos_public_header_compile_test(
+  sitos_param_cache_header_compile_test consumer/param_cache_header_compile.cpp)
 if(SITOS_WITH_ZENOH)
   sitos_copy_zenohc(sitos_param_store_header_compile_test)
 endif()
@@ -58,6 +60,12 @@ add_executable(sitos_client_config_test unit/client_config_test.cpp)
 target_link_libraries(sitos_client_config_test PRIVATE GTest::gtest_main sitos::sitos)
 sitos_enable_warnings(sitos_client_config_test)
 gtest_add_tests(TARGET sitos_client_config_test SOURCES unit/client_config_test.cpp)
+
+add_executable(sitos_param_cache_attach_test unit/param_cache_attach_test.cpp)
+target_link_libraries(sitos_param_cache_attach_test PRIVATE GTest::gtest_main sitos::sitos)
+target_include_directories(sitos_param_cache_attach_test PRIVATE ${PROJECT_SOURCE_DIR}/src)
+sitos_enable_warnings(sitos_param_cache_attach_test)
+gtest_add_tests(TARGET sitos_param_cache_attach_test SOURCES unit/param_cache_attach_test.cpp)
 
 add_executable(sitos_param_store_test unit/param_store_test.cpp)
 target_link_libraries(sitos_param_store_test PRIVATE GTest::gtest_main sitos::sitos)
@@ -215,4 +223,15 @@ if(SITOS_WITH_ZENOH)
   gtest_add_tests(
     TARGET sitos_param_store_integration_test
     SOURCES integration/param_store_test.cpp)
+
+  add_executable(sitos_param_cache_integration_test
+    integration/param_cache_attach_test.cpp)
+  target_link_libraries(sitos_param_cache_integration_test
+    PRIVATE GTest::gtest_main sitos::sitos)
+  target_include_directories(sitos_param_cache_integration_test PRIVATE ${PROJECT_SOURCE_DIR}/src)
+  sitos_enable_warnings(sitos_param_cache_integration_test)
+  sitos_copy_zenohc(sitos_param_cache_integration_test)
+  gtest_add_tests(
+    TARGET sitos_param_cache_integration_test
+    SOURCES integration/param_cache_attach_test.cpp)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ add_sitos_public_header_compile_test(
   sitos_param_cache_header_compile_test consumer/param_cache_header_compile.cpp)
 if(SITOS_WITH_ZENOH)
   sitos_copy_zenohc(sitos_param_store_header_compile_test)
+  sitos_copy_zenohc(sitos_param_cache_header_compile_test)
 endif()
 
 add_executable(sitos_bootstrap_test unit/bootstrap_test.cpp)
@@ -65,6 +66,9 @@ add_executable(sitos_param_cache_attach_test unit/param_cache_attach_test.cpp)
 target_link_libraries(sitos_param_cache_attach_test PRIVATE GTest::gtest_main sitos::sitos)
 target_include_directories(sitos_param_cache_attach_test PRIVATE ${PROJECT_SOURCE_DIR}/src)
 sitos_enable_warnings(sitos_param_cache_attach_test)
+if(SITOS_WITH_ZENOH)
+  sitos_copy_zenohc(sitos_param_cache_attach_test)
+endif()
 gtest_add_tests(TARGET sitos_param_cache_attach_test SOURCES unit/param_cache_attach_test.cpp)
 
 add_executable(sitos_param_store_test unit/param_store_test.cpp)

--- a/tests/consumer/param_cache_header_compile.cpp
+++ b/tests/consumer/param_cache_header_compile.cpp
@@ -1,0 +1,10 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/param_cache.hpp"
+
+int main() {
+  sitos::ClientConfig config;
+  auto result = sitos::ParamCache::Open(std::shared_ptr<sitos::Transport>{}, config);
+  return result.IsOk() ? 1 : 0;
+}

--- a/tests/consumer/public_headers_compile.cpp
+++ b/tests/consumer/public_headers_compile.cpp
@@ -7,6 +7,7 @@ int main() {
   sitos::ClientConfig config;
   auto validation = sitos::ValidateClientConfig(config);
   sitos::ParamValue value(1);
+  static_cast<void>(sitos::ParamCache::Open(std::shared_ptr<sitos::Transport>{}));
   sitos::InMemoryEngine engine;
   static_cast<void>(engine);
   return validation.IsOk() && value.As<int>() == 1 ? 0 : 1;

--- a/tests/integration/param_cache_attach_test.cpp
+++ b/tests/integration/param_cache_attach_test.cpp
@@ -6,16 +6,20 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <thread>
 #include <vector>
 
 #include "param_cache_test_access.hpp"
+#include "sitos/batch.hpp"
 #include "sitos/in_memory_engine.hpp"
 #include "sitos/param_store.hpp"
 #include "sitos/storage_node.hpp"
@@ -25,15 +29,109 @@ namespace {
 using namespace std::chrono_literals;
 using Access = sitos::param_cache_test_access::ParamCacheTestAccess;
 
-std::shared_ptr<sitos::Transport> MakeTransport() {
-  return std::shared_ptr<sitos::Transport>(sitos::MakeZenohTransport().release());
-}
+class TrackingTransport final : public sitos::Transport {
+ public:
+  explicit TrackingTransport(std::shared_ptr<sitos::Transport> inner)
+      : inner_(std::move(inner)) {}
+
+  sitos::Result<void> Put(std::string_view key, std::span<const std::byte> payload,
+                          sitos::Encoding encoding, sitos::PutOptions options) override {
+    return inner_->Put(key, payload, std::move(encoding), options);
+  }
+
+  sitos::Result<void> Delete(std::string_view key, sitos::PutOptions options) override {
+    return inner_->Delete(key, options);
+  }
+
+  sitos::Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
+                          std::chrono::milliseconds timeout) override {
+    {
+      std::unique_lock lock(mutex_);
+      ++get_count_;
+      get_condition_.notify_all();
+      if (block_first_get_ && get_count_ == 1) {
+        get_condition_.wait(lock, [this] { return release_first_get_; });
+      }
+    }
+    return inner_->Get(keyexpr, sink, timeout);
+  }
+
+  sitos::Result<sitos::Subscription> DeclareSubscriber(
+      std::string_view keyexpr,
+      std::function<void(const sitos::TransportSample&)> callback) override {
+    auto wrapped = [this, callback = std::move(callback)](
+                       const sitos::TransportSample& sample) {
+      {
+        std::lock_guard lock(mutex_);
+        ++callback_count_;
+        callback_condition_.notify_all();
+      }
+      callback(sample);
+    };
+    auto result = inner_->DeclareSubscriber(keyexpr, std::move(wrapped));
+    {
+      std::lock_guard lock(mutex_);
+      subscriber_declared_ = result.IsOk();
+      declaration_condition_.notify_all();
+    }
+    return result;
+  }
+
+  sitos::Result<sitos::Queryable> DeclareQueryable(
+      std::string_view keyexpr,
+      std::function<void(sitos::TransportQuery&)> callback) override {
+    return inner_->DeclareQueryable(keyexpr, std::move(callback));
+  }
+
+  void EnableFirstGetBarrier() {
+    std::lock_guard lock(mutex_);
+    block_first_get_ = true;
+  }
+
+  void WaitForSubscriberAndGet() {
+    std::unique_lock lock(mutex_);
+    ASSERT_TRUE(declaration_condition_.wait_for(lock, 5s,
+                                                [this] { return subscriber_declared_; }));
+    ASSERT_TRUE(get_condition_.wait_for(lock, 5s, [this] { return get_count_ >= 1; }));
+  }
+
+  void ReleaseFirstGet() {
+    std::lock_guard lock(mutex_);
+    release_first_get_ = true;
+    get_condition_.notify_all();
+  }
+
+  void WaitForCallbackAfter(std::size_t previous) {
+    std::unique_lock lock(mutex_);
+    ASSERT_TRUE(callback_condition_.wait_for(lock, 5s, [this, previous] {
+      return callback_count_ > previous;
+    }));
+  }
+
+  std::size_t CallbackCount() const {
+    std::lock_guard lock(mutex_);
+    return callback_count_;
+  }
+
+ private:
+  std::shared_ptr<sitos::Transport> inner_;
+  mutable std::mutex mutex_;
+  std::condition_variable declaration_condition_;
+  std::condition_variable get_condition_;
+  std::condition_variable callback_condition_;
+  bool subscriber_declared_ = false;
+  bool block_first_get_ = false;
+  bool release_first_get_ = false;
+  std::size_t get_count_ = 0;
+  std::size_t callback_count_ = 0;
+};
 
 class ParamCacheIntegrationTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    transport_ = MakeTransport();
+    transport_ = std::shared_ptr<sitos::Transport>(sitos::MakeZenohTransport().release());
     ASSERT_TRUE(transport_);
+    tracking_ = std::make_shared<TrackingTransport>(transport_);
     engine_ = std::make_shared<sitos::InMemoryEngine>();
     ASSERT_TRUE(node_.Start(engine_, *transport_, {.prefix = std::string(kPrefix)}).IsOk());
     sitos::ClientConfig config;
@@ -42,7 +140,7 @@ class ParamCacheIntegrationTest : public ::testing::Test {
     auto store = sitos::ParamStore::Open(transport_, config);
     ASSERT_TRUE(store.IsOk());
     store_.emplace(std::move(store).Value());
-    auto cache = sitos::ParamCache::Open(transport_, config);
+    auto cache = sitos::ParamCache::Open(tracking_, config);
     ASSERT_TRUE(cache.IsOk());
     cache_.emplace(std::move(cache).Value());
   }
@@ -50,11 +148,13 @@ class ParamCacheIntegrationTest : public ::testing::Test {
   void TearDown() override {
     if (cache_.has_value()) cache_->Detach();
     node_.Stop();
+    tracking_.reset();
     transport_.reset();
   }
 
   static constexpr std::string_view kPrefix = "sitos/param_cache_test";
   std::shared_ptr<sitos::Transport> transport_;
+  std::shared_ptr<TrackingTransport> tracking_;
   std::shared_ptr<sitos::InMemoryEngine> engine_;
   sitos::StorageNode node_;
   std::optional<sitos::ParamStore> store_;
@@ -64,35 +164,75 @@ class ParamCacheIntegrationTest : public ::testing::Test {
 TEST_F(ParamCacheIntegrationTest, AttachDoesNotMissConcurrentPut) {
   ASSERT_TRUE(store_->Put("base", "before", std::int64_t{1}).IsOk());
   ASSERT_TRUE(node_.CreateSession("s1").IsOk());
+  tracking_->EnableFirstGetBarrier();
 
-  std::thread attach([&] { ASSERT_TRUE(cache_->Attach("s1").IsOk()); });
+  sitos::Result<void> attach_result = sitos::Result<void>::Err(sitos::Status::Error, "unset");
+  std::thread attach([&] { attach_result = cache_->Attach("s1"); });
+  tracking_->WaitForSubscriberAndGet();
+  const auto previous = tracking_->CallbackCount();
   ASSERT_TRUE(store_->Put("session/s1", "during_attach", std::int64_t{7}).IsOk());
+  tracking_->WaitForCallbackAfter(previous);
+  tracking_->ReleaseFirstGet();
   attach.join();
 
-  bool observed = false;
-  for (int attempt = 0; attempt < 100 && !observed; ++attempt) {
-    observed = Access::Get(*cache_, "during_attach").has_value();
-    if (!observed) std::this_thread::sleep_for(10ms);
-  }
-  ASSERT_TRUE(observed);
-  EXPECT_EQ(Access::Get(*cache_, "during_attach")->As<std::int64_t>(), 7);
+  ASSERT_TRUE(attach_result.IsOk()) << attach_result.Message();
+  const auto value = Access::Get(*cache_, "during_attach");
+  ASSERT_TRUE(value.has_value());
+  EXPECT_EQ(value->As<std::int64_t>(), 7);
   const auto before = Access::Get(*cache_, "before");
   ASSERT_TRUE(before.has_value());
   EXPECT_EQ(before->As<std::int64_t>(), 1);
 }
 
-TEST_F(ParamCacheIntegrationTest, BaseBatchAndDeleteRoundTrip) {
-  ASSERT_TRUE(store_->Put("base", "value", std::int64_t{1}).IsOk());
+TEST_F(ParamCacheIntegrationTest, SnapshotOverlayAndSessionDeltaRoundTrip) {
+  ASSERT_TRUE(store_->Put("base", "inherited", std::int64_t{1}).IsOk());
+  ASSERT_TRUE(node_.CreateSession("s1").IsOk());
+  ASSERT_TRUE(store_->Put("session/s1", "inherited", std::int64_t{2}).IsOk());
+  ASSERT_TRUE(cache_->Attach("s1").IsOk());
+  ASSERT_EQ(Access::Get(*cache_, "inherited")->As<std::int64_t>(), 2);
+
+  const auto previous = tracking_->CallbackCount();
+  ASSERT_TRUE(store_->Put("session/s1", "delta", std::int64_t{3}).IsOk());
+  tracking_->WaitForCallbackAfter(previous);
+  ASSERT_TRUE(Access::Get(*cache_, "delta").has_value());
+  EXPECT_EQ(Access::Get(*cache_, "delta")->As<std::int64_t>(), 3);
+}
+
+TEST_F(ParamCacheIntegrationTest, BatchDuringAndAfterAttachIsAppliedInOrder) {
+  ASSERT_TRUE(node_.CreateSession("s1").IsOk());
+  tracking_->EnableFirstGetBarrier();
+  sitos::Result<void> attach_result = sitos::Result<void>::Err(sitos::Status::Error, "unset");
+  std::thread attach([&] { attach_result = cache_->Attach("s1"); });
+  tracking_->WaitForSubscriberAndGet();
+  const auto during = std::vector<sitos::BatchEntry>{{"during_a", sitos::ParamValue(1)},
+                                                     {"during_b", sitos::ParamValue(2)}};
+  const auto previous = tracking_->CallbackCount();
+  ASSERT_TRUE(store_->PutBatch("session/s1", during).IsOk());
+  tracking_->WaitForCallbackAfter(previous);
+  tracking_->ReleaseFirstGet();
+  attach.join();
+  ASSERT_TRUE(attach_result.IsOk()) << attach_result.Message();
+  EXPECT_EQ(Access::Get(*cache_, "during_a")->As<std::int64_t>(), 1);
+  EXPECT_EQ(Access::Get(*cache_, "during_b")->As<std::int64_t>(), 2);
+
+  const auto after = std::vector<sitos::BatchEntry>{{"after_a", sitos::ParamValue(4)},
+                                                     {"after_b", sitos::ParamValue(5)}};
+  const auto after_previous = tracking_->CallbackCount();
+  ASSERT_TRUE(store_->PutBatch("session/s1", after).IsOk());
+  tracking_->WaitForCallbackAfter(after_previous);
+  EXPECT_EQ(Access::Get(*cache_, "after_a")->As<std::int64_t>(), 4);
+  EXPECT_EQ(Access::Get(*cache_, "after_b")->As<std::int64_t>(), 5);
+}
+
+TEST_F(ParamCacheIntegrationTest, DetachStopsFurtherUpdates) {
   ASSERT_TRUE(cache_->AttachBase().IsOk());
-  for (int attempt = 0; attempt < 100 && !Access::Get(*cache_, "value"); ++attempt) {
-    std::this_thread::sleep_for(10ms);
-  }
-  ASSERT_TRUE(Access::Get(*cache_, "value").has_value());
-  ASSERT_TRUE(store_->Delete("base", "value").IsOk());
-  for (int attempt = 0; attempt < 100 && Access::Get(*cache_, "value"); ++attempt) {
-    std::this_thread::sleep_for(10ms);
-  }
-  EXPECT_FALSE(Access::Get(*cache_, "value").has_value());
+  const auto previous = tracking_->CallbackCount();
+  ASSERT_TRUE(store_->Put("base", "before_detach", std::int64_t{1}).IsOk());
+  tracking_->WaitForCallbackAfter(previous);
+  ASSERT_TRUE(Access::Get(*cache_, "before_detach").has_value());
+  cache_->Detach();
+  ASSERT_TRUE(store_->Put("base", "after_detach", std::int64_t{2}).IsOk());
+  EXPECT_FALSE(Access::Get(*cache_, "after_detach").has_value());
 }
 
 }  // namespace

--- a/tests/integration/param_cache_attach_test.cpp
+++ b/tests/integration/param_cache_attach_test.cpp
@@ -61,12 +61,12 @@ class TrackingTransport final : public sitos::Transport {
       std::function<void(const sitos::TransportSample&)> callback) override {
     auto wrapped = [this, callback = std::move(callback)](
                        const sitos::TransportSample& sample) {
+      callback(sample);
       {
         std::lock_guard lock(mutex_);
         ++callback_count_;
         callback_condition_.notify_all();
       }
-      callback(sample);
     };
     auto result = inner_->DeclareSubscriber(keyexpr, std::move(wrapped));
     {

--- a/tests/integration/param_cache_attach_test.cpp
+++ b/tests/integration/param_cache_attach_test.cpp
@@ -1,0 +1,98 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/param_cache.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+#include "param_cache_test_access.hpp"
+#include "sitos/in_memory_engine.hpp"
+#include "sitos/param_store.hpp"
+#include "sitos/storage_node.hpp"
+
+namespace {
+
+using namespace std::chrono_literals;
+using Access = sitos::param_cache_test_access::ParamCacheTestAccess;
+
+std::shared_ptr<sitos::Transport> MakeTransport() {
+  return std::shared_ptr<sitos::Transport>(sitos::MakeZenohTransport().release());
+}
+
+class ParamCacheIntegrationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    transport_ = MakeTransport();
+    ASSERT_TRUE(transport_);
+    engine_ = std::make_shared<sitos::InMemoryEngine>();
+    ASSERT_TRUE(node_.Start(engine_, *transport_, {.prefix = std::string(kPrefix)}).IsOk());
+    sitos::ClientConfig config;
+    config.prefix = std::string(kPrefix);
+    config.query_timeout = 1000ms;
+    auto store = sitos::ParamStore::Open(transport_, config);
+    ASSERT_TRUE(store.IsOk());
+    store_.emplace(std::move(store).Value());
+    auto cache = sitos::ParamCache::Open(transport_, config);
+    ASSERT_TRUE(cache.IsOk());
+    cache_.emplace(std::move(cache).Value());
+  }
+
+  void TearDown() override {
+    if (cache_.has_value()) cache_->Detach();
+    node_.Stop();
+    transport_.reset();
+  }
+
+  static constexpr std::string_view kPrefix = "sitos/param_cache_test";
+  std::shared_ptr<sitos::Transport> transport_;
+  std::shared_ptr<sitos::InMemoryEngine> engine_;
+  sitos::StorageNode node_;
+  std::optional<sitos::ParamStore> store_;
+  std::optional<sitos::ParamCache> cache_;
+};
+
+TEST_F(ParamCacheIntegrationTest, AttachDoesNotMissConcurrentPut) {
+  ASSERT_TRUE(store_->Put("base", "before", std::int64_t{1}).IsOk());
+  ASSERT_TRUE(node_.CreateSession("s1").IsOk());
+
+  std::thread attach([&] { ASSERT_TRUE(cache_->Attach("s1").IsOk()); });
+  ASSERT_TRUE(store_->Put("session/s1", "during_attach", std::int64_t{7}).IsOk());
+  attach.join();
+
+  bool observed = false;
+  for (int attempt = 0; attempt < 100 && !observed; ++attempt) {
+    observed = Access::Get(*cache_, "during_attach").has_value();
+    if (!observed) std::this_thread::sleep_for(10ms);
+  }
+  ASSERT_TRUE(observed);
+  EXPECT_EQ(Access::Get(*cache_, "during_attach")->As<std::int64_t>(), 7);
+  const auto before = Access::Get(*cache_, "before");
+  ASSERT_TRUE(before.has_value());
+  EXPECT_EQ(before->As<std::int64_t>(), 1);
+}
+
+TEST_F(ParamCacheIntegrationTest, BaseBatchAndDeleteRoundTrip) {
+  ASSERT_TRUE(store_->Put("base", "value", std::int64_t{1}).IsOk());
+  ASSERT_TRUE(cache_->AttachBase().IsOk());
+  for (int attempt = 0; attempt < 100 && !Access::Get(*cache_, "value"); ++attempt) {
+    std::this_thread::sleep_for(10ms);
+  }
+  ASSERT_TRUE(Access::Get(*cache_, "value").has_value());
+  ASSERT_TRUE(store_->Delete("base", "value").IsOk());
+  for (int attempt = 0; attempt < 100 && Access::Get(*cache_, "value"); ++attempt) {
+    std::this_thread::sleep_for(10ms);
+  }
+  EXPECT_FALSE(Access::Get(*cache_, "value").has_value());
+}
+
+}  // namespace

--- a/tests/unit/param_cache_attach_test.cpp
+++ b/tests/unit/param_cache_attach_test.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <cstddef>
@@ -128,7 +129,7 @@ class FakeTransport final : public Transport {
   TransportSample declaration_sample{
       "sitos/base/declaration", {}, Encoding{std::string(Encoding::kSitosV1)}, std::nullopt,
       TransportSample::Kind::Put};
-  int reset_count = 0;
+  std::atomic<int> reset_count{0};
   std::function<void()> reset_hook;
 };
 

--- a/tests/unit/param_cache_attach_test.cpp
+++ b/tests/unit/param_cache_attach_test.cpp
@@ -1,0 +1,281 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/param_cache.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "sitos/batch.hpp"
+#include "param_cache_test_access.hpp"
+
+namespace {
+
+using sitos::BatchEntry;
+using sitos::ClientConfig;
+using sitos::Encoding;
+using sitos::ParamCache;
+using sitos::ParamValue;
+using sitos::PutOptions;
+using sitos::Queryable;
+using sitos::Result;
+using sitos::Subscription;
+using sitos::Transport;
+using sitos::TransportQuery;
+using sitos::TransportSample;
+using Access = sitos::param_cache_test_access::ParamCacheTestAccess;
+
+class FakeTransport final : public Transport {
+ public:
+  struct Reply {
+    std::string key;
+    std::vector<std::byte> payload;
+    Encoding encoding;
+  };
+
+  Result<void> Put(std::string_view, std::span<const std::byte>, Encoding,
+                   PutOptions) override {
+    return Result<void>::Ok();
+  }
+  Result<void> Delete(std::string_view, PutOptions) override { return Result<void>::Ok(); }
+
+  Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
+                   std::chrono::milliseconds) override {
+    std::function<void()> hook;
+    std::vector<Reply> replies_copy;
+    {
+      std::lock_guard lock(mutex);
+      calls.push_back("get:" + std::string(keyexpr));
+      hook = get_hook;
+      replies_copy = replies[std::string(keyexpr)];
+    }
+    if (hook) hook();
+    for (const auto& reply : replies_copy) {
+      if (!sink(reply.key, reply.payload, reply.encoding)) break;
+    }
+    return get_result;
+  }
+
+  Result<Subscription> DeclareSubscriber(
+      std::string_view keyexpr,
+      std::function<void(const TransportSample&)> callback) override {
+    {
+      std::lock_guard lock(mutex);
+      calls.push_back("declare:" + std::string(keyexpr));
+      subscriber = std::move(callback);
+    }
+    return std::move(declaration_result);
+  }
+
+  Result<Queryable> DeclareQueryable(std::string_view,
+                                     std::function<void(TransportQuery&)>) override {
+    return Result<Queryable>::Ok(Queryable{});
+  }
+
+  void EmitOwned(std::string key, std::vector<std::byte> payload,
+                 std::string encoding = std::string(Encoding::kSitosV1),
+                 TransportSample::Kind kind = TransportSample::Kind::Put) {
+    std::function<void(const TransportSample&)> callback;
+    {
+      std::lock_guard lock(mutex);
+      callback = subscriber;
+    }
+    ASSERT_TRUE(callback);
+    TransportSample sample{std::move(key), payload, Encoding{std::move(encoding)}, std::nullopt,
+                           kind};
+    callback(sample);
+  }
+
+  std::mutex mutex;
+  std::vector<std::string> calls;
+  std::unordered_map<std::string, std::vector<Reply>> replies;
+  std::function<void()> get_hook;
+  std::function<void(const TransportSample&)> subscriber;
+  Result<Subscription> declaration_result = Result<Subscription>::Ok(Subscription{});
+  Result<void> get_result = Result<void>::Ok();
+};
+
+std::vector<std::byte> Payload(const ParamValue& value) { return value.Encode(); }
+
+TEST(ParamCacheTest, OpenValidationAndMovedFromBehavior) {
+  auto null_result = ParamCache::Open(std::shared_ptr<Transport>{});
+  ASSERT_FALSE(null_result.IsOk());
+  EXPECT_EQ(null_result.StatusCode(), sitos::Status::InvalidArgument);
+
+  auto transport = std::make_shared<FakeTransport>();
+  ClientConfig config;
+  config.zenoh_config_json = "{mode: 'peer'}";
+  auto injected = ParamCache::Open(transport, config);
+  ASSERT_FALSE(injected.IsOk());
+  EXPECT_EQ(injected.StatusCode(), sitos::Status::InvalidArgument);
+
+  auto opened = ParamCache::Open(transport);
+  ASSERT_TRUE(opened.IsOk()) << opened.Message();
+  auto cache = std::move(opened).Value();
+  auto moved = std::move(cache);
+  EXPECT_EQ(cache.Attach("s1").StatusCode(), sitos::Status::InvalidArgument);
+  cache.Detach();
+  EXPECT_FALSE(Access::IsAttached(moved));
+}
+
+TEST(ParamCacheTest, AttachUsesSubscriberFirstAndAppliesSnapshotOverlayAndBufferedDelta) {
+  auto transport = std::make_shared<FakeTransport>();
+  const auto snapshot_payload = Payload(ParamValue(std::int64_t{1}));
+  const auto overlay_payload = Payload(ParamValue(std::int64_t{2}));
+  transport->replies["sitos/snap/s1/**"] = {
+      {"sitos/snap/s1/inherited", snapshot_payload, Encoding{std::string(Encoding::kSitosV1)}}};
+  transport->replies["sitos/session/s1/**"] = {
+      {"sitos/session/s1/overlaid", overlay_payload, Encoding{std::string(Encoding::kSitosV1)}}};
+  bool emitted = false;
+  transport->get_hook = [&] {
+    if (!emitted) {
+      emitted = true;
+      transport->EmitOwned("sitos/session/s1/inherited", Payload(ParamValue(3)));
+    }
+  };
+
+  auto result = ParamCache::Open(transport);
+  ASSERT_TRUE(result.IsOk());
+  auto cache = std::move(result).Value();
+  ASSERT_TRUE(cache.Attach("s1").IsOk());
+  ASSERT_EQ(transport->calls.size(), 3U);
+  EXPECT_TRUE(transport->calls[0].starts_with("declare:sitos/session/s1/**"));
+  EXPECT_EQ(Access::Get(cache, "inherited")->As<std::int64_t>(), 3);
+  EXPECT_EQ(Access::Get(cache, "overlaid")->As<std::int64_t>(), 2);
+}
+
+TEST(ParamCacheTest, AttachDoesNotMissConcurrentPut) {
+  auto transport = std::make_shared<FakeTransport>();
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool entered = false;
+  bool release = false;
+  transport->get_hook = [&] {
+    std::unique_lock lock(mutex);
+    if (entered) return;
+    entered = true;
+    condition.notify_all();
+    condition.wait(lock, [&] { return release; });
+  };
+
+  auto result = ParamCache::Open(transport);
+  ASSERT_TRUE(result.IsOk());
+  auto cache = std::move(result).Value();
+  std::thread attach([&] { EXPECT_TRUE(cache.Attach("s1").IsOk()); });
+  {
+    std::unique_lock lock(mutex);
+    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(2), [&] { return entered; }));
+  }
+  transport->EmitOwned("sitos/session/s1/concurrent", Payload(ParamValue(7)));
+  {
+    std::lock_guard lock(mutex);
+    release = true;
+  }
+  condition.notify_all();
+  attach.join();
+  ASSERT_TRUE(Access::Get(cache, "concurrent").has_value());
+  EXPECT_EQ(Access::Get(cache, "concurrent")->As<std::int64_t>(), 7);
+}
+
+TEST(ParamCacheTest, SessionDeleteRestoresSnapshotAndBatchIsAllOrNothing) {
+  auto transport = std::make_shared<FakeTransport>();
+  transport->replies["sitos/snap/s1/**"] = {
+      {"sitos/snap/s1/key", Payload(ParamValue(1)), Encoding{std::string(Encoding::kSitosV1)}}};
+  auto result = ParamCache::Open(transport);
+  ASSERT_TRUE(result.IsOk());
+  auto cache = std::move(result).Value();
+  ASSERT_TRUE(cache.Attach("s1").IsOk());
+
+  transport->EmitOwned("sitos/session/s1/key", Payload(ParamValue(2)));
+  ASSERT_EQ(Access::Get(cache, "key")->As<std::int64_t>(), 2);
+  transport->EmitOwned("sitos/session/s1/key", {}, "ignored", TransportSample::Kind::Delete);
+  ASSERT_EQ(Access::Get(cache, "key")->As<std::int64_t>(), 1);
+
+  const std::vector<BatchEntry> entries = {{"a", ParamValue(3)}, {"a", ParamValue(4)}};
+  auto batch = sitos::EncodeBatch(entries);
+  transport->EmitOwned("sitos/session/s1/:batch", std::move(batch),
+                       std::string(Encoding::kSitosV1Batch));
+  EXPECT_EQ(Access::Get(cache, "a")->As<std::int64_t>(), 4);
+
+  transport->EmitOwned("sitos/session/s1/:batch", {std::byte{0xff}},
+                       std::string(Encoding::kSitosV1Batch));
+  EXPECT_FALSE(Access::Get(cache, "bad").has_value());
+  EXPECT_EQ(Access::Get(cache, "a")->As<std::int64_t>(), 4);
+}
+
+TEST(ParamCacheTest, DetachClearsStateAndRejectsLateSamples) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto result = ParamCache::Open(transport);
+  ASSERT_TRUE(result.IsOk());
+  auto cache = std::move(result).Value();
+  ASSERT_TRUE(cache.AttachBase().IsOk());
+  transport->EmitOwned("sitos/base/key", Payload(ParamValue(1)));
+  ASSERT_TRUE(Access::Get(cache, "key").has_value());
+  cache.Detach();
+  EXPECT_FALSE(Access::IsAttached(cache));
+  transport->EmitOwned("sitos/base/key", Payload(ParamValue(2)));
+  EXPECT_FALSE(Access::Get(cache, "key").has_value());
+  cache.Detach();
+}
+
+TEST(ParamCacheTest, AttachBaseUsesSubscriberFirstAndDeleteErases) {
+  auto transport = std::make_shared<FakeTransport>();
+  transport->replies["sitos/base/**"] = {
+      {"sitos/base/key", Payload(ParamValue(1)), Encoding{std::string(Encoding::kSitosV1)}}};
+  auto result = ParamCache::Open(transport);
+  ASSERT_TRUE(result.IsOk());
+  auto cache = std::move(result).Value();
+  ASSERT_TRUE(cache.AttachBase().IsOk());
+  ASSERT_EQ(transport->calls.size(), 2U);
+  EXPECT_TRUE(transport->calls[0].starts_with("declare:sitos/base/**"));
+  EXPECT_EQ(Access::Get(cache, "key")->As<std::int64_t>(), 1);
+  transport->EmitOwned("sitos/base/key", {}, "ignored", TransportSample::Kind::Delete);
+  EXPECT_FALSE(Access::Get(cache, "key").has_value());
+}
+
+TEST(ParamCacheTest, UnknownEncodingUsesBytesAndMalformedKnownValueIsIgnored) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto result = ParamCache::Open(transport);
+  ASSERT_TRUE(result.IsOk());
+  auto cache = std::move(result).Value();
+  ASSERT_TRUE(cache.AttachBase().IsOk());
+  transport->EmitOwned("sitos/base/raw", {std::byte{1}, std::byte{2}}, "application/octet-stream");
+  auto raw = Access::Get(cache, "raw");
+  ASSERT_TRUE(raw.has_value());
+  ASSERT_TRUE(raw->As<std::vector<std::byte>>().has_value());
+  EXPECT_EQ(raw->As<std::vector<std::byte>>()->size(), 2U);
+  transport->EmitOwned("sitos/base/bad", {std::byte{0xff}}, std::string(Encoding::kSitosV1));
+  EXPECT_FALSE(Access::Get(cache, "bad").has_value());
+}
+
+TEST(ParamCacheTest, FailedAttachPreservesTransportErrorAndCanRetry) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto result = ParamCache::Open(transport);
+  ASSERT_TRUE(result.IsOk());
+  auto cache = std::move(result).Value();
+  const auto cause = std::make_error_code(std::errc::connection_reset);
+  transport->get_result = Result<void>::Err(sitos::Status::Disconnected, "offline", cause);
+  auto failed = cache.AttachBase();
+  ASSERT_FALSE(failed.IsOk());
+  EXPECT_EQ(failed.StatusCode(), sitos::Status::Disconnected);
+  EXPECT_EQ(failed.Message(), "offline");
+  EXPECT_EQ(failed.Error(), cause);
+  EXPECT_FALSE(Access::IsAttached(cache));
+  transport->get_result = Result<void>::Ok();
+  ASSERT_TRUE(cache.AttachBase().IsOk());
+}
+
+}  // namespace

--- a/tests/unit/param_cache_attach_test.cpp
+++ b/tests/unit/param_cache_attach_test.cpp
@@ -264,6 +264,15 @@ TEST(ParamCacheTest, SessionDeleteRestoresSnapshotAndBatchIsAllOrNothing) {
                        std::string(Encoding::kSitosV1Batch));
   EXPECT_EQ(Access::Get(cache, "a")->As<std::int64_t>(), 4);
 
+  auto malformed_batch = sitos::EncodeBatch(
+      std::vector<BatchEntry>{{"prevalidated", ParamValue(5)}, {"malformed", ParamValue(6)}});
+  ASSERT_FALSE(malformed_batch.empty());
+  malformed_batch.pop_back();
+  transport->EmitOwned("sitos/session/s1/:batch", std::move(malformed_batch),
+                       std::string(Encoding::kSitosV1Batch));
+  EXPECT_FALSE(Access::Get(cache, "prevalidated").has_value());
+  EXPECT_FALSE(Access::Get(cache, "malformed").has_value());
+
   transport->EmitOwned("sitos/session/s1/:batch", {std::byte{0xff}},
                        std::string(Encoding::kSitosV1Batch));
   EXPECT_FALSE(Access::Get(cache, "bad").has_value());

--- a/tests/unit/param_cache_attach_test.cpp
+++ b/tests/unit/param_cache_attach_test.cpp
@@ -177,7 +177,9 @@ TEST(ParamCacheTest, AttachUsesSubscriberFirstAndAppliesSnapshotOverlayAndBuffer
   auto cache = std::move(result).Value();
   ASSERT_TRUE(cache.Attach("s1").IsOk());
   ASSERT_EQ(transport->calls.size(), 3U);
-  EXPECT_TRUE(transport->calls[0].starts_with("declare:sitos/session/s1/**"));
+  EXPECT_EQ(transport->calls[0], "declare:sitos/session/s1/**");
+  EXPECT_EQ(transport->calls[1], "get:sitos/snap/s1/**");
+  EXPECT_EQ(transport->calls[2], "get:sitos/session/s1/**");
   EXPECT_EQ(Access::Get(cache, "inherited")->As<std::int64_t>(), 3);
   EXPECT_EQ(Access::Get(cache, "overlaid")->As<std::int64_t>(), 2);
 }
@@ -272,6 +274,13 @@ TEST(ParamCacheTest, SessionDeleteRestoresSnapshotAndBatchIsAllOrNothing) {
                        std::string(Encoding::kSitosV1Batch));
   EXPECT_FALSE(Access::Get(cache, "prevalidated").has_value());
   EXPECT_FALSE(Access::Get(cache, "malformed").has_value());
+
+  const std::vector<BatchEntry> invalid_key_entries = {
+      {"valid_first", ParamValue(7)}, {"invalid key", ParamValue(8)}};
+  auto invalid_key_batch = sitos::EncodeBatch(invalid_key_entries);
+  transport->EmitOwned("sitos/session/s1/:batch", std::move(invalid_key_batch),
+                       std::string(Encoding::kSitosV1Batch));
+  EXPECT_FALSE(Access::Get(cache, "valid_first").has_value());
 
   transport->EmitOwned("sitos/session/s1/:batch", {std::byte{0xff}},
                        std::string(Encoding::kSitosV1Batch));

--- a/tests/unit/param_cache_attach_test.cpp
+++ b/tests/unit/param_cache_attach_test.cpp
@@ -21,6 +21,7 @@
 
 #include "sitos/batch.hpp"
 #include "param_cache_test_access.hpp"
+#include "transport/declaration_handle_test_access.hpp"
 
 namespace {
 
@@ -77,7 +78,23 @@ class FakeTransport final : public Transport {
       calls.push_back("declare:" + std::string(keyexpr));
       subscriber = std::move(callback);
     }
-    return std::move(declaration_result);
+    if (!declaration_result.IsOk()) return std::move(declaration_result);
+    if (emit_during_declaration) {
+      std::function<void(const TransportSample&)> callback_copy;
+      {
+        std::lock_guard lock(mutex);
+        callback_copy = subscriber;
+      }
+      callback_copy(declaration_sample);
+    }
+    return Result<Subscription>::Ok(
+        sitos::transport_test_access::DeclarationHandleTestAccess::MakeSubscription([this] {
+          {
+            std::lock_guard lock(mutex);
+            ++reset_count;
+          }
+          if (reset_hook) reset_hook();
+        }));
   }
 
   Result<Queryable> DeclareQueryable(std::string_view,
@@ -106,6 +123,13 @@ class FakeTransport final : public Transport {
   std::function<void(const TransportSample&)> subscriber;
   Result<Subscription> declaration_result = Result<Subscription>::Ok(Subscription{});
   Result<void> get_result = Result<void>::Ok();
+  bool emit_during_declaration = false;
+  std::vector<std::byte> declaration_payload;
+  TransportSample declaration_sample{
+      "sitos/base/declaration", {}, Encoding{std::string(Encoding::kSitosV1)}, std::nullopt,
+      TransportSample::Kind::Put};
+  int reset_count = 0;
+  std::function<void()> reset_hook;
 };
 
 std::vector<std::byte> Payload(const ParamValue& value) { return value.Encode(); }
@@ -155,6 +179,35 @@ TEST(ParamCacheTest, AttachUsesSubscriberFirstAndAppliesSnapshotOverlayAndBuffer
   EXPECT_TRUE(transport->calls[0].starts_with("declare:sitos/session/s1/**"));
   EXPECT_EQ(Access::Get(cache, "inherited")->As<std::int64_t>(), 3);
   EXPECT_EQ(Access::Get(cache, "overlaid")->As<std::int64_t>(), 2);
+}
+
+TEST(ParamCacheTest, DeclarationCallbackIsBufferedBeforeInitialGet) {
+  auto transport = std::make_shared<FakeTransport>();
+  const auto payload = Payload(ParamValue(std::int64_t{9}));
+  transport->declaration_payload = payload;
+  transport->declaration_sample = TransportSample{
+      "sitos/base/declaration", transport->declaration_payload,
+      Encoding{std::string(Encoding::kSitosV1)}, std::nullopt, TransportSample::Kind::Put};
+  transport->emit_during_declaration = true;
+  auto result = ParamCache::Open(transport);
+  ASSERT_TRUE(result.IsOk());
+  auto cache = std::move(result).Value();
+  ASSERT_TRUE(cache.AttachBase().IsOk());
+  ASSERT_TRUE(Access::Get(cache, "declaration").has_value());
+  EXPECT_EQ(Access::Get(cache, "declaration")->As<std::int64_t>(), 9);
+}
+
+TEST(ParamCacheTest, AttachRejectsInvalidSidAndAlreadyAttachedWithoutWireCalls) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto result = ParamCache::Open(transport);
+  ASSERT_TRUE(result.IsOk());
+  auto cache = std::move(result).Value();
+  EXPECT_EQ(cache.Attach("bad sid").StatusCode(), sitos::Status::InvalidKey);
+  EXPECT_TRUE(transport->calls.empty());
+  ASSERT_TRUE(cache.AttachBase().IsOk());
+  const auto call_count = transport->calls.size();
+  EXPECT_EQ(cache.Attach("s1").StatusCode(), sitos::Status::InvalidArgument);
+  EXPECT_EQ(transport->calls.size(), call_count);
 }
 
 TEST(ParamCacheTest, AttachDoesNotMissConcurrentPut) {
@@ -216,6 +269,125 @@ TEST(ParamCacheTest, SessionDeleteRestoresSnapshotAndBatchIsAllOrNothing) {
   EXPECT_EQ(Access::Get(cache, "a")->As<std::int64_t>(), 4);
 }
 
+TEST(ParamCacheTest, BatchAndOrdinarySamplesDoNotInterleave) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto result = ParamCache::Open(transport);
+  ASSERT_TRUE(result.IsOk());
+  auto cache = std::move(result).Value();
+  ASSERT_TRUE(cache.AttachBase().IsOk());
+
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool first_mutation = false;
+  bool release = false;
+  Access::SetMutationHook(cache, [&](std::size_t count) {
+    if (count != 1) return;
+    std::unique_lock lock(mutex);
+    first_mutation = true;
+    condition.notify_all();
+    condition.wait(lock, [&] { return release; });
+  });
+  const std::vector<BatchEntry> entries = {{"batch_a", ParamValue(1)},
+                                            {"batch_b", ParamValue(2)}};
+  auto batch = sitos::EncodeBatch(entries);
+  std::thread batch_thread([&] {
+    transport->EmitOwned("sitos/base/:batch", std::move(batch),
+                         std::string(Encoding::kSitosV1Batch));
+  });
+  {
+    std::unique_lock lock(mutex);
+    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(2), [&] { return first_mutation; }));
+  }
+  std::thread ordinary_thread([&] {
+    transport->EmitOwned("sitos/base/ordinary", Payload(ParamValue(3)));
+  });
+  EXPECT_FALSE(Access::Get(cache, "ordinary").has_value());
+  {
+    std::lock_guard lock(mutex);
+    release = true;
+  }
+  condition.notify_all();
+  batch_thread.join();
+  ordinary_thread.join();
+  EXPECT_EQ(Access::Get(cache, "batch_a")->As<std::int64_t>(), 1);
+  EXPECT_EQ(Access::Get(cache, "batch_b")->As<std::int64_t>(), 2);
+  EXPECT_EQ(Access::Get(cache, "ordinary")->As<std::int64_t>(), 3);
+}
+
+TEST(ParamCacheTest, DetachWaitsForInFlightCallbackAndRejectsStaleCallback) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto result = ParamCache::Open(transport);
+  ASSERT_TRUE(result.IsOk());
+  auto cache = std::move(result).Value();
+  ASSERT_TRUE(cache.AttachBase().IsOk());
+
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool callback_entered = false;
+  bool release_callback = false;
+  bool detach_returned = false;
+  Access::SetCallbackHook(cache, [&] {
+    std::unique_lock lock(mutex);
+    callback_entered = true;
+    condition.notify_all();
+    condition.wait(lock, [&] { return release_callback; });
+  });
+  std::thread sample_thread([&] {
+    transport->EmitOwned("sitos/base/in_flight", Payload(ParamValue(1)));
+  });
+  {
+    std::unique_lock lock(mutex);
+    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(2), [&] { return callback_entered; }));
+  }
+  transport->reset_hook = [&] {
+    std::lock_guard lock(mutex);
+    condition.notify_all();
+  };
+  std::thread detach_thread([&] {
+    cache.Detach();
+    std::lock_guard lock(mutex);
+    detach_returned = true;
+    condition.notify_all();
+  });
+  {
+    std::unique_lock lock(mutex);
+    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(2), [&] {
+      return transport->reset_count == 1;
+    }));
+    EXPECT_FALSE(detach_returned);
+  }
+  {
+    std::lock_guard lock(mutex);
+    release_callback = true;
+  }
+  condition.notify_all();
+  sample_thread.join();
+  detach_thread.join();
+  EXPECT_FALSE(Access::IsAttached(cache));
+  EXPECT_FALSE(Access::Get(cache, "in_flight").has_value());
+  transport->EmitOwned("sitos/base/stale", Payload(ParamValue(2)));
+  EXPECT_FALSE(Access::Get(cache, "stale").has_value());
+  EXPECT_EQ(transport->reset_count, 1);
+}
+
+TEST(ParamCacheTest, ActiveMoveAssignmentResetsDestinationExactlyOnce) {
+  auto first_transport = std::make_shared<FakeTransport>();
+  auto second_transport = std::make_shared<FakeTransport>();
+  auto first_result = ParamCache::Open(first_transport);
+  auto second_result = ParamCache::Open(second_transport);
+  ASSERT_TRUE(first_result.IsOk());
+  ASSERT_TRUE(second_result.IsOk());
+  auto first = std::move(first_result).Value();
+  auto second = std::move(second_result).Value();
+  ASSERT_TRUE(first.AttachBase().IsOk());
+  ASSERT_TRUE(second.AttachBase().IsOk());
+  second = std::move(first);
+  EXPECT_EQ(second_transport->reset_count, 1);
+  EXPECT_TRUE(Access::IsAttached(second));
+  second.Detach();
+  EXPECT_EQ(first_transport->reset_count, 1);
+}
+
 TEST(ParamCacheTest, DetachClearsStateAndRejectsLateSamples) {
   auto transport = std::make_shared<FakeTransport>();
   auto result = ParamCache::Open(transport);
@@ -261,6 +433,29 @@ TEST(ParamCacheTest, UnknownEncodingUsesBytesAndMalformedKnownValueIsIgnored) {
   EXPECT_FALSE(Access::Get(cache, "bad").has_value());
 }
 
+TEST(ParamCacheTest, FailedAttachRollsBackPartialRepliesAndProtocolErrors) {
+  auto transport = std::make_shared<FakeTransport>();
+  transport->replies["sitos/base/**"] = {
+      {"sitos/base/partial", Payload(ParamValue(1)),
+       Encoding{std::string(Encoding::kSitosV1)}}};
+  auto result = ParamCache::Open(transport);
+  ASSERT_TRUE(result.IsOk());
+  auto cache = std::move(result).Value();
+  transport->get_result = Result<void>::Err(sitos::Status::Error, "after partial reply");
+  auto failed = cache.AttachBase();
+  ASSERT_FALSE(failed.IsOk());
+  EXPECT_FALSE(Access::IsAttached(cache));
+  EXPECT_FALSE(Access::Get(cache, "partial").has_value());
+  EXPECT_EQ(transport->reset_count, 1);
+
+  transport->get_result = Result<void>::Ok();
+  transport->replies["sitos/base/**"][0].payload = {std::byte{0xff}};
+  failed = cache.AttachBase();
+  ASSERT_FALSE(failed.IsOk());
+  EXPECT_FALSE(Access::IsAttached(cache));
+  EXPECT_EQ(transport->reset_count, 2);
+}
+
 TEST(ParamCacheTest, FailedAttachPreservesTransportErrorAndCanRetry) {
   auto transport = std::make_shared<FakeTransport>();
   auto result = ParamCache::Open(transport);
@@ -270,12 +465,16 @@ TEST(ParamCacheTest, FailedAttachPreservesTransportErrorAndCanRetry) {
   transport->get_result = Result<void>::Err(sitos::Status::Disconnected, "offline", cause);
   auto failed = cache.AttachBase();
   ASSERT_FALSE(failed.IsOk());
+  EXPECT_EQ(transport->reset_count, 1);
   EXPECT_EQ(failed.StatusCode(), sitos::Status::Disconnected);
   EXPECT_EQ(failed.Message(), "offline");
   EXPECT_EQ(failed.Error(), cause);
   EXPECT_FALSE(Access::IsAttached(cache));
   transport->get_result = Result<void>::Ok();
   ASSERT_TRUE(cache.AttachBase().IsOk());
+  EXPECT_EQ(transport->reset_count, 1);
+  cache.Detach();
+  EXPECT_EQ(transport->reset_count, 2);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Closes #18

Implements the move-only ParamCache attachment lifecycle with transactional snapshot/overlay initialization, subscriber delta buffering, batch application, and callback-quiescent detach.

## Requirements

- [x] Add `include/sitos/param_cache.hpp` and `src/param_cache.cpp`
- [x] Add `Open(config)` and injected `Open(transport, config)` with ClientConfig validation and ErrorInfo preservation
- [x] Implement subscriber-first `Attach(sid)` with snapshot then session overlay fetch
- [x] Implement subscriber-first `AttachBase()`
- [x] Implement rollback and retry after declaration, transport, or reply validation failure
- [x] Apply ordinary, delete, and canonical `:batch` subscriber samples
- [x] Preserve snapshot fallback when a session overlay delete removes an override
- [x] Guarantee callback gate quiescence before Detach clears state
- [x] Add deterministic Zenoh-OFF fake lifecycle coverage
- [x] Add same-session Zenoh integration coverage, including `AttachDoesNotMissConcurrentPut`
- [x] Add public-header and umbrella consumer compilation coverage
- [x] Update architecture/API/build/sanitizer documentation

## TDD evidence

A compiling TDD stub that returned `InvalidArgument("TDD stub")` from both Attach methods produced genuine behavioral RED evidence. The focused suite result was:

```
8 tests run; 7 failed, 1 passed
Failed: AttachUsesSubscriberFirstAndAppliesSnapshotOverlayAndBufferedDelta,
AttachDoesNotMissConcurrentPut, SessionDeleteRestoresSnapshotAndBatchIsAllOrNothing,
DetachClearsStateAndRejectsLateSamples, AttachBaseUsesSubscriberFirstAndDeleteErases,
UnknownEncodingUsesBytesAndMalformedKnownValueIsIgnored, FailedAttachPreservesTransportErrorAndCanRetry
```

The implementation was restored without rewriting history and the same focused suite then passed 8/8.

## Implementation commits

- `21f1eae` feat(cache): add ParamCache lifecycle foundation (#18)
- `c37208e` test(cache): cover ParamCache attach and delta delivery (#18)
- `a312783` docs(cache): document ParamCache lifecycle contract (#18)
- `a657bf5` fix(cache): preserve state through detach quiescence (#18)
- `957d3af` test(cache): harden lifecycle and integration coverage (#18)
- `73cd546` fix(cache): synchronize fake reset observation (#18)

## Validation

- Zenoh-OFF MSVC full build and ctest: **222/222 passed**
- Zenoh-OFF ParamCache focused suite: **14/14 passed**
- Zenoh-ON MSVC full build and ctest: **267/267 passed**
- Zenoh-ON ParamCache focused suite: **4/4 passed**
- Repeated same-session `AttachDoesNotMissConcurrentPut`: **5/5 passed**
- `git diff --check`: passed
- Public standalone and umbrella header consumer tests: passed

## Scope and non-goals

This PR intentionally does not add the Issue #19 public cache read/write APIs (`GetShared`, `Get`, `GetOr`, `GetSpan`, `Contains`, `List`, `Put`, or `PutBatch`), Issue #20 stale/reconnect behavior, Transport/API changes, wire changes, StorageNode changes, acknowledgements, or a new ADR. Internal test access is used to verify state without pulling those APIs forward.

## Known limitation

The current snapshot/session wire protocol cannot distinguish an unknown but syntactically valid session from an active empty session. Both attach successfully as an empty cache. Transport Put is submission-only and has no delivery watermark; the integration test waits for observed cache state rather than treating Put return as delivery proof.

Linux sanitizer jobs are provided by CI; local validation was performed with MSVC on Windows because this environment has no GCC toolchain.


## Additional review-fix TDD evidence

A detached RED worktree at commit `957d3af` temporarily replaced both Attach methods with a compiling TDD stub. The exact focused command was:

```text
cmake -S . -B build-red -G Ninja -DSITOS_WITH_ZENOH=OFF -DSITOS_BUILD_TESTS=ON
cmake --build build-red --target sitos_param_cache_attach_test -j 4
build-red/tests/sitos_param_cache_attach_test.exe --gtest_filter=ParamCacheTest.AttachUsesSubscriberFirstAndAppliesSnapshotOverlayAndBufferedDelta:ParamCacheTest.DetachWaitsForInFlightCallbackAndRejectsStaleCallback
```

Representative RED output:

```text
[  FAILED  ] ParamCacheTest.AttachUsesSubscriberFirstAndAppliesSnapshotOverlayAndBufferedDelta
  Value of: cache.Attach("s1").IsOk()
  Actual: false
  Expected: true
[  FAILED  ] ParamCacheTest.DetachWaitsForInFlightCallbackAndRejectsStaleCallback
  Value of: cache.AttachBase().IsOk()
  Actual: false
  Expected: true
[  PASSED  ] 0 tests.
[  FAILED  ] 2 tests
```

The stub was confined to the detached worktree and was not committed or pushed.

Post-fix validation additionally covers declaration-time callbacks, deterministic
buffer/live and batch/ordinary sequencing, partial-reply/protocol rollback,
exactly-once subscription reset, invalid-sid/no-wire behavior, active move
assignment, and callback-quiescent Detach with stale-callback rejection.

