### PR TITLE
[ADR] refactor(cache): make ParamCache session-only (#100)

### DIFF
--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -266,9 +266,11 @@ then live samples. A failed declaration, Get, or reply decode rolls back the can
 the cache detached and retryable. A valid session with zero replies (including an unknown session,
 which this protocol cannot distinguish from an empty one) attaches as an empty cache.
 
-`AttachBase()` uses the same subscriber-first transaction with `<prefix>/base/**` and a single
-base Get. `Detach()` closes callback admission, undeclares the subscription, waits for admitted
-callbacks, and only then clears state. No callback mutates the cache after Detach returns.
+ParamCache is session-only: applications normally create the session before attaching, but
+Attach validates only the session-id syntax. The current protocol does not perform a session
+existence preflight, so an unknown or empty session may attach successfully with an empty cache.
+`Detach()` closes callback admission, undeclares the subscription, waits for admitted callbacks,
+and only then clears state. No callback mutates the cache after Detach returns.
 
 ### 5.2 Data Structures and Zero-Copy Reads [N01]
 
@@ -288,11 +290,11 @@ class ParamCache {
 * Delta application (writer) only replaces the value with a new `shared_ptr<const ParamValue>`.
   Old values held by existing readers are protected by shared_ptr
 
-### 5.3 Direct Base Reference Mode
+### 5.3 Session Overlay Deletion
 
-For simple use cases without sessions, `AttachBase()` initially fetches + subscribes to
-`base/**` (no snapshot isolation). A base DELETE erases its key. In session mode, a DELETE
-removes the overlay and restores the snapshot baseline when one exists.
+In session mode, a DELETE removes the overlay and restores the snapshot baseline when one exists.
+Base reads and writes use ParamStore's explicit `"base"` scope; ParamCache does not subscribe to
+or query `base/**`.
 
 ## 6. ParamStore (Writes and Ad Hoc Reads)
 

--- a/docs/04_api_cpp.md
+++ b/docs/04_api_cpp.md
@@ -232,18 +232,20 @@ class ParamCache {
   ParamCache& operator=(ParamCache&&) noexcept;
 
   Result<void> Attach(std::string_view sid);
-  Result<void> AttachBase();
   void Detach() noexcept;
 };
 ```
 
-Issue #18 provides only construction and attachment lifecycle. Attach declares the subscriber
-before synchronously fetching snapshot and overlay data, buffers subscriber samples during the
-transaction, then drains that buffer and switches to live mode atomically. Failed declarations,
-transport errors, malformed replies, and invalid keys roll back all candidate state; a retry starts
-from detached state. A valid session with zero replies attaches empty because the current protocol
-cannot distinguish an unknown session from an empty one. Detach closes callback admission,
-undeclares the subscription, waits for in-flight callbacks, and then clears state.
+Issue #18 provides only construction and attachment lifecycle. ParamCache attaches only to an
+explicit syntactically valid session id. It does not perform a session-existence preflight: a
+valid unknown or empty session may attach as an empty cache because the current protocol cannot
+distinguish those cases. Attach declares the subscriber before synchronously fetching snapshot and
+overlay data, buffers subscriber samples during the transaction, then drains that buffer and
+switches to live mode atomically. Failed declarations, transport errors, malformed replies, and
+invalid keys roll back all candidate state; a retry starts from detached state. Detach closes
+callback admission, undeclares the subscription, waits for in-flight callbacks, and then clears
+state. Base reads and writes use ParamStore's explicit `"base"` scope; ParamCache does not expose
+or subscribe to a base attachment mode.
 
 The internal cache uses immutable `shared_ptr<const ParamValue>` values and a shared mutex, but
 public `GetShared`, scalar Get/GetOr, GetSpan/SpanHandle, Contains, List, Put, PutBatch, and

--- a/docs/05_api_python.md
+++ b/docs/05_api_python.md
@@ -58,7 +58,6 @@ store.close()        # Supports context manager (__enter__/__exit__)
 ```python
 cache = sitos.ParamCache(prefix="sitos")
 cache.attach(sid)                     # Fetch snapshot + overlay
-# cache.attach_base()                 # Direct base reference mode
 
 fov  = cache.get("recon/fov", default=240.0)
 lut  = cache.get_array("recon/bhc/lut", dtype="float32")   # -> numpy.ndarray

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -247,21 +247,35 @@ so it is not a v0.2 blocker. Include it by v1.0.
 * References: [02] §5, [04] §4
 * Implementation targets: `include/sitos/param_cache.hpp`, `src/param_cache.cpp`,
   `tests/integration/param_cache_attach_test.cpp`
-* Scope: Attach(sid)/AttachBase/Detach, loss-prevention sequence (a)→(b)→(c),
-  shared_ptr-based cache, delta application
+* Scope: Attach(sid)/Detach, loss-prevention sequence (a)→(b)→(c), shared_ptr-based cache,
+  delta application; the former AttachBase mode is superseded by #100
 * Acceptance criteria: integration tests — final state is correct even with a concurrent put during Attach
   (race reproduction test), batch apply, subscription stops after Detach
 * Depends on: #5, #12, #13
+
+### #100 ParamCache: remove AttachBase mode
+* Milestone: v0.2
+* References: [02] §5, [04] §4, ADR-0022
+* Implementation targets: `include/sitos/param_cache.hpp`, `src/param_cache.cpp`,
+  `tests/unit/param_cache_attach_test.cpp`, `tests/integration/param_cache_attach_test.cpp`
+* Scope: remove the public AttachBase API and all ParamCache base-mode paths; require an
+  explicit syntactically valid session id without session-existence preflight; preserve #18
+  lifecycle and callback guarantees; make ADR-0022 Proposed until merge
+* Acceptance criteria: build-tree and installed consumers prove AttachBase is absent; session
+  lifecycle/concurrency tests remain green; no ParamCache base selector is declared or queried;
+  Zenoh-OFF/ON package validation passes
+* Depends on: #18; blocks #19
 
 ### #19 ParamCache: zero-copy reads and performance
 * Milestone: v0.2
 * References: [04] §4, [01] N01
 * Implementation targets: `include/sitos/param_cache.hpp`, `src/param_cache.cpp`,
   `tests/unit/param_cache_read_test.cpp`, `tests/bench/cache_get_bench.cpp`
-* Scope: GetShared/Get/GetOr/GetSpan (SpanHandle), List, bench harness
+* Scope: GetShared/Get/GetOr/GetSpan (SpanHandle), Contains, List, session-only Put/PutBatch,
+  operation lease, and benchmark harness
 * Acceptance criteria: bench — Get is in the target order (including confirmation of no interprocess communication).
   The old buffer remains valid even if the value is updated while holding SpanHandle (verified with ASan)
-* Depends on: #18
+* Depends on: #100
 
 ### #20 Disconnect/reconnect recovery
 * Milestone: v1.0

--- a/docs/adr/0022-make-param-cache-session-only.md
+++ b/docs/adr/0022-make-param-cache-session-only.md
@@ -1,0 +1,48 @@
+# ADR-0022: Make ParamCache session-only
+
+## Status
+
+Proposed — 2026-07-19
+
+## Context
+
+`ParamCache::AttachBase()` exposes a standalone live-base cache mode in addition to the
+session snapshot-plus-overlay cache used by compute-side participants. The mode is not
+required by the current MUST requirements and gives ParamCache writes no session overlay
+destination. It also forces lifecycle, callback, and future read/write APIs to carry an
+unnecessary base/session distinction.
+
+## Decision
+
+We will remove `ParamCache::AttachBase()` and require ParamCache to attach only with an
+explicit syntactically valid session id. ParamCache will not perform a session-existence
+preflight; an unknown or empty session may attach successfully as an empty cache, as defined
+by Issue #18. Base access remains available through ParamStore scope `"base"` and host-side
+StorageNode/StorageEngine APIs.
+
+## Consequences
+
+* Good: Every attached ParamCache has an unambiguous session overlay and snapshot baseline.
+* Good: ParamCache lifecycle, defensive sample validation, and future read/write APIs no longer
+  need a base-mode branch.
+* Good: Existing StorageNode and ParamStore base routing is unchanged.
+* Bad: Existing consumers of the pre-1.0 `AttachBase()` API must migrate to ParamStore or an
+  explicit session.
+* Neutral: A dedicated base hot-path cache is not provided; it can be proposed separately if a
+  concrete requirement emerges.
+
+## Options Considered
+
+* **Keep AttachBase alongside Attach** — rejected because it preserves an unnecessary dual mode
+  and leaves session-only writes ambiguous for base-attached caches.
+* **Make AttachBase writable against base** — rejected because ParamCache writes are session-only
+  and base writes belong to ParamStore/StorageNode APIs.
+* **Perform session metadata preflight in Attach** — rejected because it changes Issue #18's
+  zero-reply semantics and introduces a separate existence/TOCTOU contract.
+
+## References
+
+* Issue #18 — ParamCache initial fetch and delta subscription
+* Issue #19 — ParamCache reads, writes, and performance
+* Issue #100 — Remove ParamCache AttachBase mode
+* [ADR process](../10_adr_process.md)

--- a/docs/adr/0022-make-param-cache-session-only.md
+++ b/docs/adr/0022-make-param-cache-session-only.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed — 2026-07-19
+Accepted — 2026-07-19
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,3 +26,4 @@ See [docs/10_adr_process.md](../10_adr_process.md) for the process.
 | [0019](0019-client-result-status-configuration.md) | Additive client result and configuration foundation |
 | [0020](0020-synchronously-complete-transport-get.md) | Synchronously complete Transport Get requests |
 | [0021](0021-resolve-installed-zenoh-dependency.md) | Resolve installed Zenoh dependencies without fetching or bundling |
+| [0022](0022-make-param-cache-session-only.md) | Make ParamCache session-only |

--- a/include/sitos/param_cache.hpp
+++ b/include/sitos/param_cache.hpp
@@ -35,7 +35,6 @@ class ParamCache {
   ParamCache& operator=(ParamCache&&) noexcept;
 
   Result<void> Attach(std::string_view sid);
-  Result<void> AttachBase();
   void Detach() noexcept;
 
  private:

--- a/src/param_cache.cpp
+++ b/src/param_cache.cpp
@@ -46,11 +46,10 @@ struct ParamCache::Impl {
   };
 
   struct State {
-    explicit State(std::string prefix_value, bool session_value, std::string sid_value)
-        : prefix(std::move(prefix_value)), session(session_value), sid(std::move(sid_value)) {}
+    explicit State(std::string prefix_value, std::string sid_value)
+        : prefix(std::move(prefix_value)), sid(std::move(sid_value)) {}
 
     std::string prefix;
-    bool session;
     std::string sid;
     Phase phase = Phase::Buffering;
     std::mutex gate_mutex;
@@ -125,11 +124,8 @@ void WaitForCallbacks(const std::shared_ptr<param_cache_detail::Access::Impl::St
 
 bool IsExpected(const ParsedKey& parsed, const param_cache_detail::Access::Impl::State& state,
                 bool batch_allowed) {
-  if (parsed.is_batch != batch_allowed) return false;
-  if (state.session) {
-    return parsed.kind == KeyKind::Session && parsed.sid == state.sid;
-  }
-  return parsed.kind == KeyKind::Base;
+  return parsed.is_batch == batch_allowed && parsed.kind == KeyKind::Session &&
+         parsed.sid == state.sid;
 }
 
 std::optional<param_cache_detail::Access::Impl::Mutation> DecodeOrdinary(
@@ -192,13 +188,9 @@ void ApplyMutation(param_cache_detail::Access::Impl::State& state,
     state.effective_map[mutation.key] = mutation.value;
     return;
   }
-  if (state.session) {
-    const auto baseline = state.snapshot_baseline.find(mutation.key);
-    if (baseline != state.snapshot_baseline.end()) {
-      state.effective_map[mutation.key] = baseline->second;
-    } else {
-      state.effective_map.erase(mutation.key);
-    }
+  const auto baseline = state.snapshot_baseline.find(mutation.key);
+  if (baseline != state.snapshot_baseline.end()) {
+    state.effective_map[mutation.key] = baseline->second;
   } else {
     state.effective_map.erase(mutation.key);
   }
@@ -239,9 +231,8 @@ Result<void> DecodeGetReply(const std::shared_ptr<param_cache_detail::Access::Im
   const bool expected = parsed.has_value() && !parsed->is_batch &&
                        ((snapshot && parsed->kind == KeyKind::Snapshot &&
                          parsed->sid == state->sid) ||
-                        (!snapshot && ((state->session && parsed->kind == KeyKind::Session &&
-                                        parsed->sid == state->sid) ||
-                                       (!state->session && parsed->kind == KeyKind::Base))));
+                        (!snapshot && parsed->kind == KeyKind::Session &&
+                         parsed->sid == state->sid));
   if (!expected) {
     invalid = true;
     return Result<void>::Err(Status::Error, "transport returned an invalid cache key");
@@ -342,7 +333,7 @@ Result<void> ParamCache::Attach(std::string_view sid) {
   std::lock_guard lifecycle_lock(impl_->lifecycle_mutex);
   if (impl_->active_state) return InvalidArgument("ParamCache is already attached");
 
-  auto state = std::make_shared<Impl::State>(impl_->config.prefix, true, std::string(sid));
+  auto state = std::make_shared<Impl::State>(impl_->config.prefix, std::string(sid));
   Subscription subscription;
   auto declared = impl_->transport->DeclareSubscriber(
       ScopeQuery(impl_->config, "session/" + std::string(sid)),
@@ -378,44 +369,6 @@ Result<void> ParamCache::Attach(std::string_view sid) {
       state->snapshot_baseline = std::move(snapshot);
       state->effective_map = state->snapshot_baseline;
       for (auto& [key, value] : overlay) state->effective_map[key] = std::move(value);
-    }
-    ApplyMutations(*state, state->buffered);
-    state->buffered.clear();
-    state->phase = Impl::Phase::Live;
-  }
-  impl_->active_state = state;
-  impl_->subscription = std::move(subscription);
-  return Result<void>::Ok();
-}
-
-Result<void> ParamCache::AttachBase() {
-  if (!impl_) return InvalidArgument("moved-from ParamCache");
-  std::lock_guard lifecycle_lock(impl_->lifecycle_mutex);
-  if (impl_->active_state) return InvalidArgument("ParamCache is already attached");
-
-  auto state = std::make_shared<Impl::State>(impl_->config.prefix, false, "");
-  Subscription subscription;
-  auto declared = impl_->transport->DeclareSubscriber(
-      ScopeQuery(impl_->config, "base"),
-      [state](const TransportSample& sample) { OnSample(state, sample); });
-  if (!declared.IsOk()) {
-    CloseGate(state);
-    WaitForCallbacks(state);
-    return Result<void>::ErrFrom(declared);
-  }
-  subscription = std::move(declared).Value();
-  std::unordered_map<std::string, std::shared_ptr<const ParamValue>> initial;
-  auto initial_result = Fetch(state, impl_->transport, ScopeQuery(impl_->config, "base"), false,
-                              initial, impl_->config.query_timeout);
-  if (!initial_result.IsOk()) {
-    CleanupCandidate(state, subscription);
-    return initial_result;
-  }
-  {
-    std::lock_guard sequence_lock(state->sequence_mutex);
-    {
-      std::unique_lock map_lock(state->map_mutex);
-      state->effective_map = std::move(initial);
     }
     ApplyMutations(*state, state->buffered);
     state->buffered.clear();

--- a/tests/consumer/param_cache_header_compile.cpp
+++ b/tests/consumer/param_cache_header_compile.cpp
@@ -3,6 +3,13 @@
 
 #include "sitos/param_cache.hpp"
 
+template <typename T>
+concept HasAttachBase = requires(T& value) {
+  value.AttachBase();
+};
+
+static_assert(!HasAttachBase<sitos::ParamCache>);
+
 int main() {
   sitos::ClientConfig config;
   auto result = sitos::ParamCache::Open(std::shared_ptr<sitos::Transport>{}, config);

--- a/tests/integration/param_cache_attach_test.cpp
+++ b/tests/integration/param_cache_attach_test.cpp
@@ -225,13 +225,14 @@ TEST_F(ParamCacheIntegrationTest, BatchDuringAndAfterAttachIsAppliedInOrder) {
 }
 
 TEST_F(ParamCacheIntegrationTest, DetachStopsFurtherUpdates) {
-  ASSERT_TRUE(cache_->AttachBase().IsOk());
+  ASSERT_TRUE(node_.CreateSession("s1").IsOk());
+  ASSERT_TRUE(cache_->Attach("s1").IsOk());
   const auto previous = tracking_->CallbackCount();
-  ASSERT_TRUE(store_->Put("base", "before_detach", std::int64_t{1}).IsOk());
+  ASSERT_TRUE(store_->Put("session/s1", "before_detach", std::int64_t{1}).IsOk());
   tracking_->WaitForCallbackAfter(previous);
   ASSERT_TRUE(Access::Get(*cache_, "before_detach").has_value());
   cache_->Detach();
-  ASSERT_TRUE(store_->Put("base", "after_detach", std::int64_t{2}).IsOk());
+  ASSERT_TRUE(store_->Put("session/s1", "after_detach", std::int64_t{2}).IsOk());
   EXPECT_FALSE(Access::Get(*cache_, "after_detach").has_value());
 }
 

--- a/tests/package/consumer/main.cpp
+++ b/tests/package/consumer/main.cpp
@@ -1,5 +1,12 @@
 #include "sitos/sitos.hpp"
 
+template <typename T>
+concept HasAttachBase = requires(T& value) {
+  value.AttachBase();
+};
+
+static_assert(!HasAttachBase<sitos::ParamCache>);
+
 int main() {
   static_cast<void>(sitos::MakeZenohTransport());
   return 0;

--- a/tests/unit/param_cache_attach_test.cpp
+++ b/tests/unit/param_cache_attach_test.cpp
@@ -40,6 +40,11 @@ using sitos::TransportQuery;
 using sitos::TransportSample;
 using Access = sitos::param_cache_test_access::ParamCacheTestAccess;
 
+void AssignToSelf(ParamCache& cache) {
+  auto* alias = &cache;
+  cache = std::move(*alias);
+}
+
 class FakeTransport final : public Transport {
  public:
   struct Reply {
@@ -435,7 +440,7 @@ TEST(ParamCacheTest, SelfMovePreservesActiveAttachment) {
   auto cache = std::move(result).Value();
   ASSERT_TRUE(cache.Attach("s1").IsOk());
 
-  cache = std::move(cache);
+  AssignToSelf(cache);
   EXPECT_TRUE(Access::IsAttached(cache));
   EXPECT_EQ(transport->reset_count, 0);
   cache.Detach();

--- a/tests/unit/param_cache_attach_test.cpp
+++ b/tests/unit/param_cache_attach_test.cpp
@@ -733,6 +733,56 @@ TEST(ParamCacheTest, FailedAttachStagesRollbackPreservesErrorAndCanRetry) {
   }
 }
 
+TEST(ParamCacheTest, InitialReplyProtocolErrorsRollBackAndCanRetry) {
+  const auto verify = [](const std::function<void(FakeTransport&)>& configure,
+                         std::string_view expected_message) {
+    auto transport = std::make_shared<FakeTransport>();
+    configure(*transport);
+    auto result = ParamCache::Open(transport);
+    ASSERT_TRUE(result.IsOk());
+    auto cache = std::move(result).Value();
+
+    const auto failed = cache.Attach("s1");
+    ASSERT_FALSE(failed.IsOk());
+    EXPECT_EQ(failed.StatusCode(), sitos::Status::Error);
+    EXPECT_EQ(failed.Message(), expected_message);
+    EXPECT_EQ(failed.Error(), sitos::MakeErrorCode(sitos::Status::Error));
+    EXPECT_FALSE(Access::IsAttached(cache));
+    EXPECT_EQ(Access::Size(cache), 0U);
+    EXPECT_EQ(transport->reset_count, 1);
+
+    transport->replies.clear();
+    const auto retry = cache.Attach("s1");
+    ASSERT_TRUE(retry.IsOk()) << retry.Message();
+    cache.Detach();
+    EXPECT_EQ(transport->reset_count, 2);
+  };
+
+  verify(
+      [](FakeTransport& transport) {
+        transport.replies["sitos/snap/s1/**"] = {
+            {"sitos/snap/s1/malformed", {std::byte{0xff}},
+             Encoding{std::string(Encoding::kSitosV1)}}};
+      },
+      "transport returned malformed payload");
+
+  verify(
+      [](FakeTransport& transport) {
+        transport.replies["sitos/session/s1/**"] = {
+            {"sitos/snap/s1/wrong_scope", Payload(ParamValue(1)),
+             Encoding{std::string(Encoding::kSitosV1)}}};
+      },
+      "transport returned an invalid cache key");
+
+  verify(
+      [](FakeTransport& transport) {
+        transport.replies["sitos/snap/s1/**"] = {
+            {"sitos/snap/s1/value", {},
+             Encoding{std::string(Encoding::kSitosV1Batch)}}};
+      },
+      "transport returned a batch for a value query");
+}
+
 TEST(ParamCacheTest, FailedAttachPreservesTransportErrorAndCanRetry) {
   auto transport = std::make_shared<FakeTransport>();
   auto result = ParamCache::Open(transport);

--- a/tests/unit/param_cache_attach_test.cpp
+++ b/tests/unit/param_cache_attach_test.cpp
@@ -68,6 +68,11 @@ class FakeTransport final : public Transport {
     for (const auto& reply : replies_copy) {
       if (!sink(reply.key, reply.payload, reply.encoding)) break;
     }
+    {
+      std::lock_guard lock(mutex);
+      const auto result_it = get_result_factories.find(std::string(keyexpr));
+      if (result_it != get_result_factories.end()) return result_it->second();
+    }
     return get_result;
   }
 
@@ -120,6 +125,7 @@ class FakeTransport final : public Transport {
   std::mutex mutex;
   std::vector<std::string> calls;
   std::unordered_map<std::string, std::vector<Reply>> replies;
+  std::unordered_map<std::string, std::function<Result<void>()>> get_result_factories;
   std::function<void()> get_hook;
   std::function<void(const TransportSample&)> subscriber;
   Result<Subscription> declaration_result = Result<Subscription>::Ok(Subscription{});
@@ -407,6 +413,150 @@ TEST(ParamCacheTest, ActiveMoveAssignmentResetsDestinationExactlyOnce) {
   EXPECT_EQ(first_transport->reset_count, 1);
 }
 
+TEST(ParamCacheTest, AttachedMoveConstructionTransfersOwnership) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto result = ParamCache::Open(transport);
+  ASSERT_TRUE(result.IsOk());
+  auto cache = std::move(result).Value();
+  ASSERT_TRUE(cache.Attach("s1").IsOk());
+
+  auto moved = std::move(cache);
+  EXPECT_FALSE(Access::IsAttached(cache));
+  EXPECT_TRUE(Access::IsAttached(moved));
+  EXPECT_EQ(transport->reset_count, 0);
+  moved.Detach();
+  EXPECT_EQ(transport->reset_count, 1);
+}
+
+TEST(ParamCacheTest, SelfMovePreservesActiveAttachment) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto result = ParamCache::Open(transport);
+  ASSERT_TRUE(result.IsOk());
+  auto cache = std::move(result).Value();
+  ASSERT_TRUE(cache.Attach("s1").IsOk());
+
+  cache = std::move(cache);
+  EXPECT_TRUE(Access::IsAttached(cache));
+  EXPECT_EQ(transport->reset_count, 0);
+  cache.Detach();
+  EXPECT_EQ(transport->reset_count, 1);
+}
+
+TEST(ParamCacheTest, ActiveMoveAssignmentWaitsForInFlightDestinationCallback) {
+  auto source_transport = std::make_shared<FakeTransport>();
+  auto destination_transport = std::make_shared<FakeTransport>();
+  auto source_result = ParamCache::Open(source_transport);
+  auto destination_result = ParamCache::Open(destination_transport);
+  ASSERT_TRUE(source_result.IsOk());
+  ASSERT_TRUE(destination_result.IsOk());
+  auto source = std::move(source_result).Value();
+  auto destination = std::move(destination_result).Value();
+  ASSERT_TRUE(source.Attach("s1").IsOk());
+  ASSERT_TRUE(destination.Attach("s1").IsOk());
+
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool callback_entered = false;
+  bool release_callback = false;
+  bool assignment_returned = false;
+  Access::SetCallbackHook(destination, [&] {
+    std::unique_lock lock(mutex);
+    callback_entered = true;
+    condition.notify_all();
+    condition.wait(lock, [&] { return release_callback; });
+  });
+  destination_transport->reset_hook = [&] { condition.notify_all(); };
+  std::thread sample_thread([&] {
+    destination_transport->EmitOwned("sitos/session/s1/in_flight", Payload(ParamValue(1)));
+  });
+  {
+    std::unique_lock lock(mutex);
+    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(2), [&] {
+      return callback_entered;
+    }));
+  }
+
+  std::thread assignment_thread([&] {
+    destination = std::move(source);
+    std::lock_guard lock(mutex);
+    assignment_returned = true;
+    condition.notify_all();
+  });
+  {
+    std::unique_lock lock(mutex);
+    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(2), [&] {
+      return destination_transport->reset_count == 1;
+    }));
+    EXPECT_FALSE(assignment_returned);
+  }
+  {
+    std::lock_guard lock(mutex);
+    release_callback = true;
+  }
+  condition.notify_all();
+  sample_thread.join();
+  assignment_thread.join();
+
+  EXPECT_TRUE(Access::IsAttached(destination));
+  EXPECT_FALSE(Access::IsAttached(source));
+  destination.Detach();
+  EXPECT_EQ(destination_transport->reset_count, 1);
+  EXPECT_EQ(source_transport->reset_count, 1);
+}
+
+TEST(ParamCacheTest, DestructionWaitsForInFlightCallback) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto result = ParamCache::Open(transport);
+  ASSERT_TRUE(result.IsOk());
+  std::optional<ParamCache> cache(std::move(result).Value());
+  ASSERT_TRUE(cache->Attach("s1").IsOk());
+
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool callback_entered = false;
+  bool release_callback = false;
+  bool destruction_returned = false;
+  Access::SetCallbackHook(*cache, [&] {
+    std::unique_lock lock(mutex);
+    callback_entered = true;
+    condition.notify_all();
+    condition.wait(lock, [&] { return release_callback; });
+  });
+  transport->reset_hook = [&] { condition.notify_all(); };
+  std::thread sample_thread([&] {
+    transport->EmitOwned("sitos/session/s1/in_flight", Payload(ParamValue(1)));
+  });
+  {
+    std::unique_lock lock(mutex);
+    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(2), [&] {
+      return callback_entered;
+    }));
+  }
+
+  std::thread destruction_thread([&] {
+    cache.reset();
+    std::lock_guard lock(mutex);
+    destruction_returned = true;
+    condition.notify_all();
+  });
+  {
+    std::unique_lock lock(mutex);
+    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(2), [&] {
+      return transport->reset_count == 1;
+    }));
+    EXPECT_FALSE(destruction_returned);
+  }
+  {
+    std::lock_guard lock(mutex);
+    release_callback = true;
+  }
+  condition.notify_all();
+  sample_thread.join();
+  destruction_thread.join();
+  EXPECT_TRUE(destruction_returned);
+  EXPECT_FALSE(cache.has_value());
+}
+
 TEST(ParamCacheTest, DetachClearsStateAndRejectsLateSamples) {
   auto transport = std::make_shared<FakeTransport>();
   auto result = ParamCache::Open(transport);
@@ -457,6 +607,26 @@ TEST(ParamCacheTest, ForeignScopeSamplesAreIgnored) {
   EXPECT_FALSE(Access::Get(cache, "foreign_value").has_value());
 }
 
+TEST(ParamCacheTest, ForeignDeleteBatchAndMalformedSamplesDoNotMutate) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto result = ParamCache::Open(transport);
+  ASSERT_TRUE(result.IsOk());
+  auto cache = std::move(result).Value();
+  ASSERT_TRUE(cache.Attach("s1").IsOk());
+  transport->EmitOwned("sitos/session/s1/unchanged", Payload(ParamValue(7)));
+
+  transport->EmitOwned("sitos/base/unchanged", {}, "ignored", TransportSample::Kind::Delete);
+  const std::vector<BatchEntry> base_entries = {{"unchanged", ParamValue(8)}};
+  auto base_batch = sitos::EncodeBatch(base_entries);
+  transport->EmitOwned("sitos/base/:batch", std::move(base_batch),
+                       std::string(Encoding::kSitosV1Batch));
+  transport->EmitOwned("malformed-key", Payload(ParamValue(9)));
+
+  ASSERT_TRUE(Access::Get(cache, "unchanged").has_value());
+  EXPECT_EQ(Access::Get(cache, "unchanged")->As<std::int64_t>(), 7);
+  EXPECT_EQ(Access::Size(cache), 1U);
+}
+
 TEST(ParamCacheTest, UnknownEncodingUsesBytesAndMalformedKnownValueIsIgnored) {
   auto transport = std::make_shared<FakeTransport>();
   auto result = ParamCache::Open(transport);
@@ -472,27 +642,90 @@ TEST(ParamCacheTest, UnknownEncodingUsesBytesAndMalformedKnownValueIsIgnored) {
   EXPECT_FALSE(Access::Get(cache, "bad").has_value());
 }
 
-TEST(ParamCacheTest, FailedAttachRollsBackPartialRepliesAndProtocolErrors) {
-  auto transport = std::make_shared<FakeTransport>();
-  transport->replies["sitos/session/s1/**"] = {
-      {"sitos/session/s1/partial", Payload(ParamValue(1)),
-       Encoding{std::string(Encoding::kSitosV1)}}};
-  auto result = ParamCache::Open(transport);
-  ASSERT_TRUE(result.IsOk());
-  auto cache = std::move(result).Value();
-  transport->get_result = Result<void>::Err(sitos::Status::Error, "after partial reply");
-  auto failed = cache.Attach("s1");
-  ASSERT_FALSE(failed.IsOk());
-  EXPECT_FALSE(Access::IsAttached(cache));
-  EXPECT_FALSE(Access::Get(cache, "partial").has_value());
-  EXPECT_EQ(transport->reset_count, 1);
+TEST(ParamCacheTest, FailedAttachStagesRollbackPreservesErrorAndCanRetry) {
+  const auto cause = std::make_error_code(std::errc::connection_reset);
 
-  transport->get_result = Result<void>::Ok();
-  transport->replies["sitos/session/s1/**"][0].payload = {std::byte{0xff}};
-  failed = cache.Attach("s1");
-  ASSERT_FALSE(failed.IsOk());
-  EXPECT_FALSE(Access::IsAttached(cache));
-  EXPECT_EQ(transport->reset_count, 2);
+  {
+    auto transport = std::make_shared<FakeTransport>();
+    auto result = ParamCache::Open(transport);
+    ASSERT_TRUE(result.IsOk());
+    auto cache = std::move(result).Value();
+    transport->declaration_result = Result<Subscription>::Err(
+        sitos::Status::Disconnected, "declaration offline", cause);
+
+    auto failed = cache.Attach("s1");
+    ASSERT_FALSE(failed.IsOk());
+    EXPECT_EQ(failed.StatusCode(), sitos::Status::Disconnected);
+    EXPECT_EQ(failed.Message(), "declaration offline");
+    EXPECT_EQ(failed.Error(), cause);
+    EXPECT_FALSE(Access::IsAttached(cache));
+    EXPECT_EQ(transport->reset_count, 0);
+
+    transport->declaration_result = Result<Subscription>::Ok(Subscription{});
+    ASSERT_TRUE(cache.Attach("s1").IsOk());
+    cache.Detach();
+    EXPECT_EQ(transport->reset_count, 1);
+  }
+
+  {
+    auto transport = std::make_shared<FakeTransport>();
+    auto result = ParamCache::Open(transport);
+    ASSERT_TRUE(result.IsOk());
+    auto cache = std::move(result).Value();
+    transport->get_result_factories["sitos/snap/s1/**"] = [cause, first = true]() mutable {
+      if (first) {
+        first = false;
+        return Result<void>::Err(sitos::Status::Disconnected, "snapshot offline", cause);
+      }
+      return Result<void>::Ok();
+    };
+
+    auto failed = cache.Attach("s1");
+    ASSERT_FALSE(failed.IsOk());
+    EXPECT_EQ(failed.StatusCode(), sitos::Status::Disconnected);
+    EXPECT_EQ(failed.Message(), "snapshot offline");
+    EXPECT_EQ(failed.Error(), cause);
+    EXPECT_FALSE(Access::IsAttached(cache));
+    EXPECT_EQ(transport->reset_count, 1);
+    EXPECT_EQ(Access::Size(cache), 0U);
+
+    auto retry = cache.Attach("s1");
+    ASSERT_TRUE(retry.IsOk()) << static_cast<int>(retry.StatusCode()) << ": " << retry.Message();
+    cache.Detach();
+    EXPECT_EQ(transport->reset_count, 2);
+  }
+
+  {
+    auto transport = std::make_shared<FakeTransport>();
+    transport->replies["sitos/snap/s1/**"] = {
+        {"sitos/snap/s1/partial", Payload(ParamValue(1)),
+         Encoding{std::string(Encoding::kSitosV1)}}};
+    auto result = ParamCache::Open(transport);
+    ASSERT_TRUE(result.IsOk());
+    auto cache = std::move(result).Value();
+    transport->get_result_factories["sitos/session/s1/**"] = [cause, first = true]() mutable {
+      if (first) {
+        first = false;
+        return Result<void>::Err(sitos::Status::Error, "overlay invalid", cause);
+      }
+      return Result<void>::Ok();
+    };
+
+    auto failed = cache.Attach("s1");
+    ASSERT_FALSE(failed.IsOk());
+    EXPECT_EQ(failed.StatusCode(), sitos::Status::Error);
+    EXPECT_EQ(failed.Message(), "overlay invalid");
+    EXPECT_EQ(failed.Error(), cause);
+    EXPECT_FALSE(Access::IsAttached(cache));
+    EXPECT_FALSE(Access::Get(cache, "partial").has_value());
+    EXPECT_EQ(transport->reset_count, 1);
+
+    transport->get_result_factories.clear();
+    ASSERT_TRUE(cache.Attach("s1").IsOk());
+    EXPECT_EQ(Access::Get(cache, "partial")->As<std::int64_t>(), 1);
+    cache.Detach();
+    EXPECT_EQ(transport->reset_count, 2);
+  }
 }
 
 TEST(ParamCacheTest, FailedAttachPreservesTransportErrorAndCanRetry) {

--- a/tests/unit/param_cache_attach_test.cpp
+++ b/tests/unit/param_cache_attach_test.cpp
@@ -127,7 +127,7 @@ class FakeTransport final : public Transport {
   bool emit_during_declaration = false;
   std::vector<std::byte> declaration_payload;
   TransportSample declaration_sample{
-      "sitos/base/declaration", {}, Encoding{std::string(Encoding::kSitosV1)}, std::nullopt,
+      "sitos/session/s1/declaration", {}, Encoding{std::string(Encoding::kSitosV1)}, std::nullopt,
       TransportSample::Kind::Put};
   std::atomic<int> reset_count{0};
   std::function<void()> reset_hook;
@@ -189,13 +189,13 @@ TEST(ParamCacheTest, DeclarationCallbackIsBufferedBeforeInitialGet) {
   const auto payload = Payload(ParamValue(std::int64_t{9}));
   transport->declaration_payload = payload;
   transport->declaration_sample = TransportSample{
-      "sitos/base/declaration", transport->declaration_payload,
+      "sitos/session/s1/declaration", transport->declaration_payload,
       Encoding{std::string(Encoding::kSitosV1)}, std::nullopt, TransportSample::Kind::Put};
   transport->emit_during_declaration = true;
   auto result = ParamCache::Open(transport);
   ASSERT_TRUE(result.IsOk());
   auto cache = std::move(result).Value();
-  ASSERT_TRUE(cache.AttachBase().IsOk());
+  ASSERT_TRUE(cache.Attach("s1").IsOk());
   ASSERT_TRUE(Access::Get(cache, "declaration").has_value());
   EXPECT_EQ(Access::Get(cache, "declaration")->As<std::int64_t>(), 9);
 }
@@ -207,7 +207,7 @@ TEST(ParamCacheTest, AttachRejectsInvalidSidAndAlreadyAttachedWithoutWireCalls) 
   auto cache = std::move(result).Value();
   EXPECT_EQ(cache.Attach("bad sid").StatusCode(), sitos::Status::InvalidKey);
   EXPECT_TRUE(transport->calls.empty());
-  ASSERT_TRUE(cache.AttachBase().IsOk());
+  ASSERT_TRUE(cache.Attach("s1").IsOk());
   const auto call_count = transport->calls.size();
   EXPECT_EQ(cache.Attach("s1").StatusCode(), sitos::Status::InvalidArgument);
   EXPECT_EQ(transport->calls.size(), call_count);
@@ -293,7 +293,7 @@ TEST(ParamCacheTest, BatchAndOrdinarySamplesDoNotInterleave) {
   auto result = ParamCache::Open(transport);
   ASSERT_TRUE(result.IsOk());
   auto cache = std::move(result).Value();
-  ASSERT_TRUE(cache.AttachBase().IsOk());
+  ASSERT_TRUE(cache.Attach("s1").IsOk());
 
   std::mutex mutex;
   std::condition_variable condition;
@@ -310,7 +310,7 @@ TEST(ParamCacheTest, BatchAndOrdinarySamplesDoNotInterleave) {
                                             {"batch_b", ParamValue(2)}};
   auto batch = sitos::EncodeBatch(entries);
   std::thread batch_thread([&] {
-    transport->EmitOwned("sitos/base/:batch", std::move(batch),
+    transport->EmitOwned("sitos/session/s1/:batch", std::move(batch),
                          std::string(Encoding::kSitosV1Batch));
   });
   {
@@ -318,7 +318,7 @@ TEST(ParamCacheTest, BatchAndOrdinarySamplesDoNotInterleave) {
     ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(2), [&] { return first_mutation; }));
   }
   std::thread ordinary_thread([&] {
-    transport->EmitOwned("sitos/base/ordinary", Payload(ParamValue(3)));
+    transport->EmitOwned("sitos/session/s1/ordinary", Payload(ParamValue(3)));
   });
   EXPECT_FALSE(Access::Get(cache, "ordinary").has_value());
   {
@@ -338,7 +338,7 @@ TEST(ParamCacheTest, DetachWaitsForInFlightCallbackAndRejectsStaleCallback) {
   auto result = ParamCache::Open(transport);
   ASSERT_TRUE(result.IsOk());
   auto cache = std::move(result).Value();
-  ASSERT_TRUE(cache.AttachBase().IsOk());
+  ASSERT_TRUE(cache.Attach("s1").IsOk());
 
   std::mutex mutex;
   std::condition_variable condition;
@@ -352,7 +352,7 @@ TEST(ParamCacheTest, DetachWaitsForInFlightCallbackAndRejectsStaleCallback) {
     condition.wait(lock, [&] { return release_callback; });
   });
   std::thread sample_thread([&] {
-    transport->EmitOwned("sitos/base/in_flight", Payload(ParamValue(1)));
+    transport->EmitOwned("sitos/session/s1/in_flight", Payload(ParamValue(1)));
   });
   {
     std::unique_lock lock(mutex);
@@ -384,7 +384,7 @@ TEST(ParamCacheTest, DetachWaitsForInFlightCallbackAndRejectsStaleCallback) {
   detach_thread.join();
   EXPECT_FALSE(Access::IsAttached(cache));
   EXPECT_FALSE(Access::Get(cache, "in_flight").has_value());
-  transport->EmitOwned("sitos/base/stale", Payload(ParamValue(2)));
+  transport->EmitOwned("sitos/session/s1/stale", Payload(ParamValue(2)));
   EXPECT_FALSE(Access::Get(cache, "stale").has_value());
   EXPECT_EQ(transport->reset_count, 1);
 }
@@ -398,8 +398,8 @@ TEST(ParamCacheTest, ActiveMoveAssignmentResetsDestinationExactlyOnce) {
   ASSERT_TRUE(second_result.IsOk());
   auto first = std::move(first_result).Value();
   auto second = std::move(second_result).Value();
-  ASSERT_TRUE(first.AttachBase().IsOk());
-  ASSERT_TRUE(second.AttachBase().IsOk());
+  ASSERT_TRUE(first.Attach("s1").IsOk());
+  ASSERT_TRUE(second.Attach("s1").IsOk());
   second = std::move(first);
   EXPECT_EQ(second_transport->reset_count, 1);
   EXPECT_TRUE(Access::IsAttached(second));
@@ -412,29 +412,49 @@ TEST(ParamCacheTest, DetachClearsStateAndRejectsLateSamples) {
   auto result = ParamCache::Open(transport);
   ASSERT_TRUE(result.IsOk());
   auto cache = std::move(result).Value();
-  ASSERT_TRUE(cache.AttachBase().IsOk());
-  transport->EmitOwned("sitos/base/key", Payload(ParamValue(1)));
+  ASSERT_TRUE(cache.Attach("s1").IsOk());
+  transport->EmitOwned("sitos/session/s1/key", Payload(ParamValue(1)));
   ASSERT_TRUE(Access::Get(cache, "key").has_value());
   cache.Detach();
   EXPECT_FALSE(Access::IsAttached(cache));
-  transport->EmitOwned("sitos/base/key", Payload(ParamValue(2)));
+  transport->EmitOwned("sitos/session/s1/key", Payload(ParamValue(2)));
   EXPECT_FALSE(Access::Get(cache, "key").has_value());
   cache.Detach();
 }
 
-TEST(ParamCacheTest, AttachBaseUsesSubscriberFirstAndDeleteErases) {
+TEST(ParamCacheTest, SessionAttachUsesSubscriberFirstAndDeleteRestoresBaseline) {
   auto transport = std::make_shared<FakeTransport>();
-  transport->replies["sitos/base/**"] = {
-      {"sitos/base/key", Payload(ParamValue(1)), Encoding{std::string(Encoding::kSitosV1)}}};
+  transport->replies["sitos/snap/s1/**"] = {
+      {"sitos/snap/s1/key", Payload(ParamValue(1)), Encoding{std::string(Encoding::kSitosV1)}}};
   auto result = ParamCache::Open(transport);
   ASSERT_TRUE(result.IsOk());
   auto cache = std::move(result).Value();
-  ASSERT_TRUE(cache.AttachBase().IsOk());
-  ASSERT_EQ(transport->calls.size(), 2U);
-  EXPECT_TRUE(transport->calls[0].starts_with("declare:sitos/base/**"));
+  ASSERT_TRUE(cache.Attach("s1").IsOk());
+  ASSERT_EQ(transport->calls.size(), 3U);
+  EXPECT_EQ(transport->calls[0], "declare:sitos/session/s1/**");
+  EXPECT_EQ(transport->calls[1], "get:sitos/snap/s1/**");
+  EXPECT_EQ(transport->calls[2], "get:sitos/session/s1/**");
   EXPECT_EQ(Access::Get(cache, "key")->As<std::int64_t>(), 1);
-  transport->EmitOwned("sitos/base/key", {}, "ignored", TransportSample::Kind::Delete);
-  EXPECT_FALSE(Access::Get(cache, "key").has_value());
+  transport->EmitOwned("sitos/session/s1/key", Payload(ParamValue(2)));
+  EXPECT_EQ(Access::Get(cache, "key")->As<std::int64_t>(), 2);
+  transport->EmitOwned("sitos/session/s1/key", {}, "ignored", TransportSample::Kind::Delete);
+  EXPECT_EQ(Access::Get(cache, "key")->As<std::int64_t>(), 1);
+}
+
+TEST(ParamCacheTest, ForeignScopeSamplesAreIgnored) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto result = ParamCache::Open(transport);
+  ASSERT_TRUE(result.IsOk());
+  auto cache = std::move(result).Value();
+  ASSERT_TRUE(cache.Attach("s1").IsOk());
+
+  transport->EmitOwned("sitos/base/base_value", Payload(ParamValue(1)));
+  transport->EmitOwned("sitos/snap/s1/snapshot_value", Payload(ParamValue(2)));
+  transport->EmitOwned("sitos/session/s2/foreign_value", Payload(ParamValue(3)));
+
+  EXPECT_FALSE(Access::Get(cache, "base_value").has_value());
+  EXPECT_FALSE(Access::Get(cache, "snapshot_value").has_value());
+  EXPECT_FALSE(Access::Get(cache, "foreign_value").has_value());
 }
 
 TEST(ParamCacheTest, UnknownEncodingUsesBytesAndMalformedKnownValueIsIgnored) {
@@ -442,34 +462,34 @@ TEST(ParamCacheTest, UnknownEncodingUsesBytesAndMalformedKnownValueIsIgnored) {
   auto result = ParamCache::Open(transport);
   ASSERT_TRUE(result.IsOk());
   auto cache = std::move(result).Value();
-  ASSERT_TRUE(cache.AttachBase().IsOk());
-  transport->EmitOwned("sitos/base/raw", {std::byte{1}, std::byte{2}}, "application/octet-stream");
+  ASSERT_TRUE(cache.Attach("s1").IsOk());
+  transport->EmitOwned("sitos/session/s1/raw", {std::byte{1}, std::byte{2}}, "application/octet-stream");
   auto raw = Access::Get(cache, "raw");
   ASSERT_TRUE(raw.has_value());
   ASSERT_TRUE(raw->As<std::vector<std::byte>>().has_value());
   EXPECT_EQ(raw->As<std::vector<std::byte>>()->size(), 2U);
-  transport->EmitOwned("sitos/base/bad", {std::byte{0xff}}, std::string(Encoding::kSitosV1));
+  transport->EmitOwned("sitos/session/s1/bad", {std::byte{0xff}}, std::string(Encoding::kSitosV1));
   EXPECT_FALSE(Access::Get(cache, "bad").has_value());
 }
 
 TEST(ParamCacheTest, FailedAttachRollsBackPartialRepliesAndProtocolErrors) {
   auto transport = std::make_shared<FakeTransport>();
-  transport->replies["sitos/base/**"] = {
-      {"sitos/base/partial", Payload(ParamValue(1)),
+  transport->replies["sitos/session/s1/**"] = {
+      {"sitos/session/s1/partial", Payload(ParamValue(1)),
        Encoding{std::string(Encoding::kSitosV1)}}};
   auto result = ParamCache::Open(transport);
   ASSERT_TRUE(result.IsOk());
   auto cache = std::move(result).Value();
   transport->get_result = Result<void>::Err(sitos::Status::Error, "after partial reply");
-  auto failed = cache.AttachBase();
+  auto failed = cache.Attach("s1");
   ASSERT_FALSE(failed.IsOk());
   EXPECT_FALSE(Access::IsAttached(cache));
   EXPECT_FALSE(Access::Get(cache, "partial").has_value());
   EXPECT_EQ(transport->reset_count, 1);
 
   transport->get_result = Result<void>::Ok();
-  transport->replies["sitos/base/**"][0].payload = {std::byte{0xff}};
-  failed = cache.AttachBase();
+  transport->replies["sitos/session/s1/**"][0].payload = {std::byte{0xff}};
+  failed = cache.Attach("s1");
   ASSERT_FALSE(failed.IsOk());
   EXPECT_FALSE(Access::IsAttached(cache));
   EXPECT_EQ(transport->reset_count, 2);
@@ -482,7 +502,7 @@ TEST(ParamCacheTest, FailedAttachPreservesTransportErrorAndCanRetry) {
   auto cache = std::move(result).Value();
   const auto cause = std::make_error_code(std::errc::connection_reset);
   transport->get_result = Result<void>::Err(sitos::Status::Disconnected, "offline", cause);
-  auto failed = cache.AttachBase();
+  auto failed = cache.Attach("s1");
   ASSERT_FALSE(failed.IsOk());
   EXPECT_EQ(transport->reset_count, 1);
   EXPECT_EQ(failed.StatusCode(), sitos::Status::Disconnected);
@@ -490,7 +510,7 @@ TEST(ParamCacheTest, FailedAttachPreservesTransportErrorAndCanRetry) {
   EXPECT_EQ(failed.Error(), cause);
   EXPECT_FALSE(Access::IsAttached(cache));
   transport->get_result = Result<void>::Ok();
-  ASSERT_TRUE(cache.AttachBase().IsOk());
+  ASSERT_TRUE(cache.Attach("s1").IsOk());
   EXPECT_EQ(transport->reset_count, 1);
   cache.Detach();
   EXPECT_EQ(transport->reset_count, 2);


### PR DESCRIPTION
Closes #100

## Requirements

This cleanup introduces no new direct F/N/C/P/X requirement. It preserves the existing session-cache requirements: F05 (snapshot isolation), F06 (session overlay), F07 (effective snapshot-plus-overlay view), F10 (session resource release), N05 (Windows/Linux support), N07 (thread-safe lifecycle and callbacks), C01/C02 (payload-v1 and Encoding behavior), and X03 (configurable key prefix). No new Python requirement is introduced; Python bindings remain out of scope.

## Summary

- Remove the public `ParamCache::AttachBase()` API and all ParamCache base-mode production paths.
- Make ParamCache session-only with syntactically valid sid validation and no session-existence preflight.
- Preserve snapshot-baseline/session-overlay ordering, callback buffering, batch sequencing, rollback, move ownership, and Detach quiescence.
- Add defensive rejection coverage for foreign, snapshot, and base samples.
- Accept ADR-0022, `Make ParamCache session-only`.
- Update C++/Python API planning, architecture, issue breakdown, and ADR index documentation.

## Scope checklist

- [x] Remove `AttachBase()` from the public header and implementation.
- [x] Remove base-mode state, base subscriber declaration, base initial Get, and base mutation branches.
- [x] Preserve session Attach, snapshot/overlay construction, buffering, sequencing, rollback, retry, move, and quiescent Detach behavior.
- [x] Convert lifecycle tests to meaningful explicit-session paths with snapshot/overlay replies.
- [x] Add build-tree and installed-package negative API contracts proving `AttachBase()` is absent.
- [x] Preserve defensive rejection of foreign/base/snapshot samples.
- [x] Update required documentation and accept ADR-0022 after final review.
- [x] Keep StorageNode/ParamStore base routing unchanged.
- [x] Do not implement #19 or #99.

## TDD evidence

### RED

Added the negative public-header contract before removing the API and ran:

```text
powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "& 'C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/Tools/Launch-VsDevShell.ps1' -Arch amd64; Set-Location 'C:/Users/tetet/gw/sitos.tmp'; cmake -S . -B build-100-red -G Ninja -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF; cmake --build build-100-red --target sitos_param_cache_header_compile_test -j 4"
```

The pre-change tree failed at `tests/consumer/param_cache_header_compile.cpp:11` with MSVC assertion failure C2607 because `HasAttachBase<sitos::ParamCache>` was true while the test required false.

### GREEN

The same consumer target compiles after the API removal. The installed package consumer contains the equivalent negative contract and is exercised by both package-validation paths.

## Validation

- Zenoh-OFF full MSVC suite: **229/229 passed** (`build-100-off`).
- Current-head Zenoh-ON, Linux, Windows, ASan/UBSan, TSan, and package CI jobs: passed.
- Current-head package Linux/Windows jobs cover Zenoh-OFF/ON installed consumers.
- Focused current-head ASan/UBSan and TSan lifecycle/rollback selections: **4/4 passed** each; TSan used `setarch x86_64 -R` to avoid the host PIE mapping issue.
- `git diff --check`: passed.
- Secret scan: passed; no credentials or private-key material introduced.

Zenoh-ON binaries were executed under the owner-approved `C:/Users/tetet/gw/sitos.tmp/build-on/tests` directory.

## ADR

ADR-0022 is **Accepted — 2026-07-19** after final review and is indexed in `docs/adr/README.md`.

## Non-goals

- ParamCache read/write/zero-copy APIs and benchmarks (#19).
- `WaitForLocalDelivery` (#99).
- StorageNode or ParamStore base routing.
- Session-existence preflight.
- Wire/key grammar, Transport, snapshot, consistency/thread-model, acknowledgement, reconnect, or Python changes.

## Commits

- `6ae66ae test(cache): require removal of AttachBase API (#100)`
- `ca58d12 refactor(cache): make ParamCache session-only (#100)`
- `1d13322 docs(adr): document session-only ParamCache (#100)`
- `fde547c test(cache): close session-only lifecycle coverage gaps (#100)`
- `1610b20 test(cache): avoid compiler self-move warning (#100)`
- `3c2d507 test(cache): cover initial reply protocol rollback (#100)`
- `fd02098 docs(adr): accept session-only ParamCache decision (#100)`



## Review follow-up validation

- Initial-reply protocol rollback test: **1/1 passed**, repeated 10 times on MSVC and GCC 13.3.
- Focused ASan/UBSan lifecycle/rollback set: **4/4 passed**.
- Focused TSan lifecycle/rollback set: **4/4 passed** using `setarch x86_64 -R`.
- Zenoh-OFF full MSVC CTest suite: **229/229 passed** (`build-100-off`).
- No production behavior changes were required; these are deterministic coverage-only and ADR-status fixes.



