### PR TITLE
feat(view): add read-only SessionView [ADR] (#21)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           UBSAN_OPTIONS: halt_on_error=1
         run: >-
           ctest --test-dir build/sanitizer-${{ matrix.name }}
-          --output-on-failure -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|TransportGetCompletionTest|ParamCacheTest|ParamCacheReadTest'
+          --output-on-failure -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|TransportGetCompletionTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
 
   build-windows:
     runs-on: windows-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ add_library(sitos STATIC
   src/in_memory_engine.cpp
   src/logging.cpp
   src/storage_node.cpp
+  src/session_view.cpp
   src/transport/get_completion.cpp
   src/transport/declaration_handle_lifecycle.cpp
 )

--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -316,11 +316,12 @@ active session overlay before its immutable snapshot. A snapshot value is used o
 overlay does not contain the key; malformed selected payloads fail with `Status::Error` rather than
 falling back.
 
-Each operation captures the node State under `lifecycle_mutex_`, enters the existing callback gate,
-and copies the session reader pair under `session_mutex`. The view stores only weak State and weak
-overlay-owner identities, so Stop, CloseSession, and same-id recreation cannot leave a dangling or
-resource-pinning view. C++ shared-owner identity, not raw pointer addresses, distinguishes session
-generations.
+`Open` captures the node State under `lifecycle_mutex_`, releases that mutex, and enters the
+captured State's existing callback gate before inspecting session tables. Each later operation locks
+its weak State, enters that gate, and copies the session reader pair under `session_mutex`. The view
+stores only weak State and weak overlay-owner identities, so Stop, CloseSession, and same-id
+recreation cannot leave a dangling or resource-pinning view. C++ shared-owner identity, not raw
+pointer addresses, distinguishes session generations.
 
 `Get` returns an owned `ParamValue`; typed `Get`, `GetOr`, `Contains`, and `List` follow the same
 Result/Status conventions as the client APIs. `List` materializes and validates the complete merged

--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -41,7 +41,7 @@ Requirement IDs ([01_requirements.md](01_requirements.md)) are referenced as [F.
 | `ParamStore` | Client API: typed Put/Get/List/Delete/Subscribe. Wraps a zenoh session | zenoh |
 | `ParamCache` | Subscriber-side read cache. Initial fetch + delta subscription + zero-copy Get | zenoh |
 | `SessionController` | Session creation, snapshot registration, and destruction (inside the process that owns StorageNode) | StorageNode |
-| `SessionView` | Logical view that resolves overlay → snapshot (thin facade over ParamStore/ParamCache) | ParamStore or ParamCache |
+| `SessionView` | Host-process read-only view that resolves session overlay → snapshot | StorageNode |
 
 **Design principle**: `engine/` does not know about zenoh. `ParamStore`/`ParamCache` do not
 know about engine. Direct dependencies on the zenoh-c API are confined to the
@@ -308,7 +308,29 @@ In session mode, a DELETE removes the overlay and restores the snapshot baseline
 Base reads and writes use ParamStore's explicit `"base"` scope; ParamCache does not subscribe to
 or query `base/**`.
 
-## 6. ParamStore (Writes and Ad Hoc Reads)
+## 6. SessionView (Host-Process Composite Read)
+
+`SessionView` is a move-only, read-only in-process facade opened with
+`SessionView::Open(const StorageNode&, sid)`. It performs no Transport operations and resolves the
+active session overlay before its immutable snapshot. A snapshot value is used only when the
+overlay does not contain the key; malformed selected payloads fail with `Status::Error` rather than
+falling back.
+
+Each operation captures the node State under `lifecycle_mutex_`, enters the existing callback gate,
+and copies the session reader pair under `session_mutex`. The view stores only weak State and weak
+overlay-owner identities, so Stop, CloseSession, and same-id recreation cannot leave a dangling or
+resource-pinning view. C++ shared-owner identity, not raw pointer addresses, distinguishes session
+generations.
+
+`Get` returns an owned `ParamValue`; typed `Get`, `GetOr`, `Contains`, and `List` follow the same
+Result/Status conventions as the client APIs. `List` materializes and validates the complete merged
+set, applies raw-prefix semantics and lexical ordering, then releases the gate and engine locks
+before invoking the caller sink. Sink false is a successful early stop and sink exceptions propagate
+on the caller thread. `GetShared`, `GetSpan`, and all writes are intentionally absent. Large images
+and compute artifacts belong to the disk-backed `buffers/<sid>/**` scope (ADR-0014), not the session
+overlay or ParamCache.
+
+## 7. ParamStore (Writes and Ad Hoc Reads)
 
 ### 6.1 API Semantics
 
@@ -325,7 +347,7 @@ ParamStore write success means only that Transport accepted/submitted the operat
 not confirm StorageNode application, durability, or cache visibility. Acknowledged writes and
 retry policy belong to Issues #14 and #17; this API does not add a `put_ack` configuration field.
 
-## 7. Session Lifecycle (Overall Sequence)
+## 8. Session Lifecycle (Overall Sequence)
 
 ```
 External client        Controller(StorageNode)          Calc(ParamCache)
@@ -348,7 +370,7 @@ External client        Controller(StorageNode)          Calc(ParamCache)
      │                      │   delete snapshots/overlays [F10]│
 ```
 
-## 8. Thread Model
+## 9. Thread Model
 
 | Component | Threads |
 |---|---|
@@ -359,7 +381,7 @@ External client        Controller(StorageNode)          Calc(ParamCache)
 | ParamCache writes | Caller thread; submission occurs without lifecycle or map locks, then local sequencing |
 | Python callbacks | Dedicated dispatch thread + queue (the GIL is not acquired on zenoh threads) [P04] |
 
-## 9. Error Handling Policy
+## 10. Error Handling Policy
 
 * APIs return `bool` / `std::optional` / `sitos::Result<T>` (error code +
   message). Exceptions are used only for unrecoverable cases such as constructor failure
@@ -368,7 +390,7 @@ External client        Controller(StorageNode)          Calc(ParamCache)
 * Type-mismatched Get: arithmetic casts are allowed among numeric types (BOOL/S64/DP) [C05];
   all other cases return failure
 
-## 10. Configuration (Config)
+## 11. Configuration (Config)
 
 ```cpp
 struct ClientConfig {

--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -332,7 +332,7 @@ overlay or ParamCache.
 
 ## 7. ParamStore (Writes and Ad Hoc Reads)
 
-### 6.1 API Semantics
+### 7.1 API Semantics
 
 * `Put(key, value)` / `PutBatch(entries)` — a batch is one `:batch` wire put
   (multi-entry format in the payload, [03](03_wire_protocol.md) §5) [F09]
@@ -341,7 +341,7 @@ overlay or ParamCache.
 * `List(prefix, sink)` — synchronous zenoh get using the narrowest safe chunk-boundary
   selector, followed by client-side raw-prefix filtering and lexical sorting.
 
-### 6.2 Put Completion Guarantee
+### 7.2 Put Completion Guarantee
 
 ParamStore write success means only that Transport accepted/submitted the operation. It does
 not confirm StorageNode application, durability, or cache visibility. Acknowledged writes and

--- a/docs/04_api_cpp.md
+++ b/docs/04_api_cpp.md
@@ -305,6 +305,7 @@ Large binary values belong to the disk-backed `buffers/<sid>/**` scope described
 | `ParamStore` | All methods may be called concurrently |
 | `ParamCache` | Attach/Detach and local write sequencing are synchronized internally. Local reads are cache-only; stale/reconnect behavior is future #20 behavior |
 | `StorageNode` | All methods may be called concurrently |
+| `SessionView` | All methods may be called concurrently. List callbacks run on the caller thread outside internal locks; re-entry and Stop from inside a sink are safe |
 | callback | Called from zenoh threads. Blocking is prohibited. From inside a callback, only Get-style APIs on the same object may be called |
 
 (END OF DOCUMENT)

--- a/docs/04_api_cpp.md
+++ b/docs/04_api_cpp.md
@@ -273,19 +273,29 @@ ordering across caches. `PutBatch` preserves caller order and duplicate keys in 
 message, and is not reader-visible transaction isolation, so concurrent readers may observe
 partial application. All APIs use the Result/Status model; `GetOr` substitutes only `NotFound`.
 `WaitForLocalDelivery` is deferred to #99, and stale/reconnect behavior is future #20 behavior.
-## 5. SessionView — Composite View (Optional Use)
+## 5. SessionView — Read-Only Composite View
 
-A facade for the host process side that handles overlay → snapshot resolution through one read
-interface.
+`SessionView` is the host-process facade for an active session. It is opened through the Result-based
+factory and does not perform Transport operations or writes.
 
 ```cpp
 class SessionView {
-public:
-    SessionView(const StorageNode& node, std::string_view sid);
-    // Get/GetOr/GetSpan/Contains/List with the same shape as ParamCache (in-process resolution)
-    // Put writes to the overlay + distributes via zenoh
+ public:
+  static Result<SessionView> Open(const StorageNode& node, std::string_view sid);
+
+  Result<ParamValue> Get(std::string_view key) const;
+  template <SupportedParamType T> Result<T> Get(std::string_view key) const;
+  template <SupportedParamType T> Result<T> GetOr(std::string_view key, T default_value) const;
+  Result<bool> Contains(std::string_view key) const;
+  Result<void> List(std::string_view prefix, const ListSink& sink) const;
 };
 ```
+
+Reads resolve overlay before snapshot and fall back only when the overlay key is absent. A malformed
+selected payload returns `Status::Error`. `List` materializes and validates the merged set, sorts
+keys lexically using raw-prefix matching, releases internal synchronization, and then invokes the
+caller sink. `GetShared`, `GetSpan`, `Put`, `PutBatch`, and `Delete` are intentionally absent.
+Large binary values belong to the disk-backed `buffers/<sid>/**` scope described by ADR-0014.
 
 ## 6. Thread-Safety Contract
 

--- a/docs/05_api_python.md
+++ b/docs/05_api_python.md
@@ -87,14 +87,19 @@ node.stop()
 
 ### 2.4 SessionView
 
-API for using the composite view of snapshot + overlay directly from Python inside the process
-that owns StorageNode. It has the same semantics as C++ `SessionView`.
+The future Python binding will expose the same read-only semantics as C++ `SessionView` for the
+process that owns StorageNode. Python binding work belongs to Issue #25; this section is a plan,
+not an implemented API.
 
 ```python
-view = node.session_view(sid)
-fov = view.get("recon/fov", default=240.0)      # Resolve in overlay → snapshot order
-view.put("recon/progress", 0.5)                 # Write to overlay + distribute
+view = node.session_view(sid)  # Future Issue #25 binding
+fov = view.get("recon/fov", default=240.0)  # Future read-only composite view
+keys = view.list("recon/")
 ```
+
+The view resolves overlay before snapshot and performs no writes. `put`, `put_batch`, and `delete`
+are intentionally not part of SessionView. Large binary values use the disk-backed buffers API,
+not the session overlay or ParamCache.
 
 Custom engines [X01] can also be defined in Python
 (subclass `sitos.StorageEngine` and implement `put/get/list/delete`.

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -127,8 +127,8 @@ major behaviors.
 
 ## 5.2 Lifecycle sanitizer runs
 
-Issue #11 lifecycle tests, Issue #13 batch sequencing tests, and Issue #18 ParamCache
-fake-Transport lifecycle tests have reproducible sanitizer configurations. TSan runs the
+Issue #11 lifecycle tests, Issue #13 batch sequencing tests, Issue #18 ParamCache, and Issue #21
+SessionView lifecycle/concurrency tests have reproducible sanitizer configurations. TSan runs the
 zenoh-independent fake-Transport paths; ASan/UBSan runs the same paths separately:
 
 ```sh
@@ -136,13 +136,13 @@ cmake -S . -B build/tsan -G Ninja -DCMAKE_BUILD_TYPE=Debug \
   -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF -DSITOS_ENABLE_TSAN=ON
 cmake --build build/tsan
 ctest --test-dir build/tsan --output-on-failure \
-  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|ParamCacheTest|ParamCacheReadTest'
+  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
 
 cmake -S . -B build/asan -G Ninja -DCMAKE_BUILD_TYPE=Debug \
   -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF -DSITOS_ENABLE_ASAN_UBSAN=ON
 cmake --build build/asan
 ctest --test-dir build/asan --output-on-failure \
-  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|ParamCacheTest|ParamCacheReadTest'
+  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
 ```
 
 For a platform where the zenoh-c standalone runtime supports sanitizer instrumentation,

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -296,8 +296,10 @@ so it is not a v0.2 blocker. Include it by v1.0.
 * References: [04] §5
 * Implementation targets: `include/sitos/session_view.hpp`, `src/session_view.cpp`,
   `tests/unit/session_view_test.cpp`
-* Scope: in-process resolving read from overlay → snapshot, Put delivery
-* Acceptance criteria: unit + integration — resolution order, consistency with direct engine reference
+* Scope: move-only read-only in-process resolving reads from overlay → snapshot; Result-bearing
+  Get/GetOr/Contains/List, lifecycle and composite-read consistency, ADR-0025
+* Acceptance criteria: unit + integration — resolution order, malformed-payload behavior, lexical
+  materialized List, lifecycle/ownership/Stop safety, and synchronized consistency with ParamCache
 * Depends on: #12
 
 ---

--- a/docs/adr/0025-session-view-lifetime-and-composite-read-consistency.md
+++ b/docs/adr/0025-session-view-lifetime-and-composite-read-consistency.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed — 2026-07-20
+Accepted — 2026-07-20
 
 ## Context
 

--- a/docs/adr/0025-session-view-lifetime-and-composite-read-consistency.md
+++ b/docs/adr/0025-session-view-lifetime-and-composite-read-consistency.md
@@ -1,0 +1,53 @@
+# ADR-0025: Define SessionView lifetime and composite-read consistency
+
+## Status
+
+Proposed — 2026-07-20
+
+## Context
+
+SessionView is an in-process facade that composes one active session overlay over its immutable
+snapshot. StorageNode readers expose callback-scoped byte views, while node Stop and session Close
+may run concurrently with view operations. The public API therefore needs explicit ownership,
+lifetime, and callback consistency rules without changing the wire protocol or StorageEngine API.
+
+## Decision
+
+We will provide a move-only, read-only `SessionView::Open` facade that binds to a session generation
+using weak StorageNode State and weak overlay owner identity. Each operation enters the node gate,
+copies the current reader pair under the session mutex, resolves overlay before snapshot, and
+materializes and validates List results before releasing internal synchronization and invoking the
+user sink.
+
+## Consequences
+
+* Good: Views cannot retain StorageNode, base engine, snapshot, or overlay resources after their
+  owning lifecycle ends.
+* Good: Overlay replacement, malformed selected payloads, Stop, and session recreation have
+  deterministic Result/Status behavior.
+* Good: List callbacks receive owned values outside internal locks and may re-enter the node or call
+  Stop without a gate deadlock.
+* Bad: SessionView reads copy selected payloads and List materializes the matching parameter set.
+* Bad: There is no cross-operation transaction or reader-visible batch isolation; existing
+  StorageNode consistency rules remain in force.
+* Neutral: Large image and compute-artifact storage remains in the disk-backed `buffers/<sid>/**`
+  scope defined by ADR-0014, not in SessionView or ParamCache.
+
+## Options Considered
+
+* **Retain a strong StorageNode State or reader pair** — rejected because a surviving view would
+  keep node and session resources alive after Stop or CloseSession.
+* **Add a numeric generation counter to StorageNode** — rejected because fresh overlay ownership
+  control blocks already provide an ABA-safe generation identity without changing Issue #12 state.
+* **Return callback-scoped StorageEngine spans from SessionView** — rejected because the spans
+  would dangle after the StorageReader callback returns; zero-copy reads remain ParamCache's role.
+* **Invoke List sinks while holding the gate or engine locks** — rejected because sink re-entry
+  and sink-triggered Stop could deadlock, and callback views would not have independent ownership.
+
+## References
+
+* Issue #21 / PR #103
+* ADR-0014: Session-scoped, disk-backed buffers
+* ADR-0017: Atomic StorageNode lifecycle
+* ADR-0023: ParamCache consistency and lifetime
+* [StorageEngine API](../04_api_cpp.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,3 +29,4 @@ See [docs/10_adr_process.md](../10_adr_process.md) for the process.
 | [0022](0022-make-param-cache-session-only.md) | Make ParamCache session-only |
 | [0023](0023-param-cache-consistency-and-lifetime.md) | Define ParamCache consistency and lifetime boundary |
 | [0024](0024-opt-in-google-benchmark-build-boundary.md) | Keep Google Benchmark opt-in and outside installed packages |
+| [0025](0025-session-view-lifetime-and-composite-read-consistency.md) | Define SessionView lifetime and composite-read consistency |

--- a/include/sitos/param_cache.hpp
+++ b/include/sitos/param_cache.hpp
@@ -58,11 +58,7 @@ class ParamCache {
   Result<T> Get(std::string_view key) const {
     auto shared = GetShared(key);
     if (!shared.IsOk()) return Result<T>::ErrFrom(shared);
-    auto converted = shared.Value()->template As<T>();
-    if (!converted.has_value()) {
-      return Result<T>::Err(Status::TypeMismatch, "parameter value type mismatch");
-    }
-    return Result<T>::Ok(std::move(*converted));
+    return param_detail::ConvertParamValue<T>(*shared.Value());
   }
 
   template <SupportedParamType T>

--- a/include/sitos/param_concepts.hpp
+++ b/include/sitos/param_concepts.hpp
@@ -46,6 +46,15 @@ concept ParamSpanElement = std::is_object_v<std::remove_cv_t<T>> &&
 
 namespace param_detail {
 
+template <SupportedParamType T>
+Result<T> ConvertParamValue(const ParamValue& value) {
+  auto converted = value.template As<T>();
+  if (!converted.has_value()) {
+    return Result<T>::Err(Status::TypeMismatch, "parameter value type mismatch");
+  }
+  return Result<T>::Ok(std::move(*converted));
+}
+
 template <ParamInput T>
 Result<ParamValue> MakeParamValue(T&& value) {
   using D = std::decay_t<T>;

--- a/include/sitos/session_view.hpp
+++ b/include/sitos/session_view.hpp
@@ -55,6 +55,7 @@ class SessionView {
   struct Readers;
   explicit SessionView(std::unique_ptr<Impl> impl) noexcept;
   Result<Readers> AcquireReaders() const;
+  Result<ParamValue> Read(const Readers& readers, std::string_view key) const;
   std::unique_ptr<Impl> impl_;
 };
 

--- a/include/sitos/session_view.hpp
+++ b/include/sitos/session_view.hpp
@@ -37,11 +37,7 @@ class SessionView {
   Result<T> Get(std::string_view key) const {
     auto value = Get(key);
     if (!value.IsOk()) return Result<T>::ErrFrom(value);
-    auto converted = value.Value().template As<T>();
-    if (!converted.has_value()) {
-      return Result<T>::Err(Status::TypeMismatch, "parameter value type mismatch");
-    }
-    return Result<T>::Ok(std::move(*converted));
+    return param_detail::ConvertParamValue<T>(value.Value());
   }
 
   template <SupportedParamType T>

--- a/include/sitos/session_view.hpp
+++ b/include/sitos/session_view.hpp
@@ -56,7 +56,9 @@ class SessionView {
 
  private:
   struct Impl;
+  struct Readers;
   explicit SessionView(std::unique_ptr<Impl> impl) noexcept;
+  Result<Readers> AcquireReaders() const;
   std::unique_ptr<Impl> impl_;
 };
 

--- a/include/sitos/session_view.hpp
+++ b/include/sitos/session_view.hpp
@@ -1,0 +1,65 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// In-process read-only composite view over a session overlay and snapshot.
+
+#ifndef SITOS_SESSION_VIEW_HPP
+#define SITOS_SESSION_VIEW_HPP
+
+#include <memory>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+#include "sitos/list_sink.hpp"
+#include "sitos/param_concepts.hpp"
+#include "sitos/param_value.hpp"
+#include "sitos/result.hpp"
+
+namespace sitos {
+
+class StorageNode;
+
+/// Read-only host-process view resolving an overlay over a session snapshot.
+class SessionView {
+ public:
+  static Result<SessionView> Open(const StorageNode& node, std::string_view sid);
+
+  ~SessionView();
+  SessionView(const SessionView&) = delete;
+  SessionView& operator=(const SessionView&) = delete;
+  SessionView(SessionView&&) noexcept;
+  SessionView& operator=(SessionView&&) noexcept;
+
+  Result<ParamValue> Get(std::string_view key) const;
+
+  template <SupportedParamType T>
+  Result<T> Get(std::string_view key) const {
+    auto value = Get(key);
+    if (!value.IsOk()) return Result<T>::ErrFrom(value);
+    auto converted = value.Value().template As<T>();
+    if (!converted.has_value()) {
+      return Result<T>::Err(Status::TypeMismatch, "parameter value type mismatch");
+    }
+    return Result<T>::Ok(std::move(*converted));
+  }
+
+  template <SupportedParamType T>
+  Result<T> GetOr(std::string_view key, T default_value) const {
+    auto result = Get<T>(key);
+    if (result.IsOk() || result.StatusCode() != Status::NotFound) return result;
+    return Result<T>::Ok(std::move(default_value));
+  }
+
+  Result<bool> Contains(std::string_view key) const;
+  Result<void> List(std::string_view prefix, const ListSink& sink) const;
+
+ private:
+  struct Impl;
+  explicit SessionView(std::unique_ptr<Impl> impl) noexcept;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace sitos
+
+#endif  // SITOS_SESSION_VIEW_HPP

--- a/include/sitos/sitos.hpp
+++ b/include/sitos/sitos.hpp
@@ -16,6 +16,7 @@
 #include "sitos/param_value.hpp"
 #include "sitos/result.hpp"
 #include "sitos/session.hpp"
+#include "sitos/session_view.hpp"
 #include "sitos/status.hpp"
 #include "sitos/storage_engine.hpp"
 #include "sitos/storage_node.hpp"

--- a/include/sitos/storage_node.hpp
+++ b/include/sitos/storage_node.hpp
@@ -47,6 +47,8 @@ struct StorageNodeConfig {
 };
 
 /// Serves base-scope Get/List queries and base writes through Transport declarations.
+class SessionView;
+
 class StorageNode {
  public:
   using Config = StorageNodeConfig;
@@ -93,6 +95,8 @@ class StorageNode {
   bool IsStarted() const noexcept;
 
  private:
+  friend class SessionView;
+
   struct State {
     State(std::shared_ptr<StorageEngine> storage, std::string key_prefix,
           std::shared_ptr<LogSink> diagnostics)

--- a/include/sitos/storage_node.hpp
+++ b/include/sitos/storage_node.hpp
@@ -46,9 +46,9 @@ struct StorageNodeConfig {
   std::shared_ptr<LogSink> log_sink = DefaultLogSink();
 };
 
-/// Serves base-scope Get/List queries and base writes through Transport declarations.
 class SessionView;
 
+/// Serves base-scope Get/List queries and base writes through Transport declarations.
 class StorageNode {
  public:
   using Config = StorageNodeConfig;

--- a/src/list_prefix_validation.hpp
+++ b/src/list_prefix_validation.hpp
@@ -1,0 +1,54 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SITOS_LIST_PREFIX_VALIDATION_HPP
+#define SITOS_LIST_PREFIX_VALIDATION_HPP
+
+#include <cctype>
+#include <string>
+#include <string_view>
+
+#include "sitos/key.hpp"
+#include "sitos/result.hpp"
+
+namespace sitos::param_detail {
+
+inline bool ContainsWhitespaceOrWildcard(std::string_view value) {
+  for (char c : value) {
+    const auto byte = static_cast<unsigned char>(c);
+    if (std::isspace(byte) != 0 || c == '*' || c == '?') return true;
+  }
+  return false;
+}
+
+inline bool ContainsBatchSegment(std::string_view value) {
+  std::size_t start = 0;
+  while (start <= value.size()) {
+    const std::size_t end = value.find('/', start);
+    const std::size_t length = end == std::string_view::npos ? value.size() - start : end - start;
+    if (value.substr(start, length) == ":batch") return true;
+    if (end == std::string_view::npos) break;
+    start = end + 1;
+  }
+  return false;
+}
+
+inline Result<void> ValidateListPrefix(std::string_view prefix) {
+  if (prefix.empty()) return Result<void>::Ok();
+  if (prefix.front() == '/' || prefix.find("//") != std::string_view::npos ||
+      ContainsWhitespaceOrWildcard(prefix) || ContainsBatchSegment(prefix)) {
+    return Result<void>::Err(Status::InvalidKey, "invalid list prefix");
+  }
+  if (prefix.back() == '/') {
+    if (prefix.size() == 1 || !IsValidPrefix(prefix.substr(0, prefix.size() - 1))) {
+      return Result<void>::Err(Status::InvalidKey, "invalid list prefix");
+    }
+    return Result<void>::Ok();
+  }
+  if (!IsValidKey(prefix)) return Result<void>::Err(Status::InvalidKey, "invalid list prefix");
+  return Result<void>::Ok();
+}
+
+}  // namespace sitos::param_detail
+
+#endif  // SITOS_LIST_PREFIX_VALIDATION_HPP

--- a/src/param_store.cpp
+++ b/src/param_store.cpp
@@ -5,8 +5,9 @@
 
 #include "sitos/param_store.hpp"
 
+#include "list_prefix_validation.hpp"
+
 #include <algorithm>
-#include <cctype>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -36,25 +37,6 @@ std::string ScopePath(const Scope& scope) {
       return "snap/" + scope.sid;
   }
   return {};
-}
-
-bool ContainsWhitespaceOrWildcard(std::string_view value) {
-  for (char c : value) {
-    if (std::isspace(static_cast<unsigned char>(c)) || c == '*' || c == '?') return true;
-  }
-  return false;
-}
-
-bool ContainsBatchSegment(std::string_view value) {
-  std::size_t start = 0;
-  while (start <= value.size()) {
-    const std::size_t end = value.find('/', start);
-    const std::size_t length = end == std::string_view::npos ? value.size() - start : end - start;
-    if (value.substr(start, length) == ":batch") return true;
-    if (end == std::string_view::npos) break;
-    start = end + 1;
-  }
-  return false;
 }
 
 std::string BuildScopeQuery(std::string_view prefix, std::string_view scope_path,
@@ -189,19 +171,7 @@ Result<void> ParamStore::ValidateUserKey(std::string_view key) {
 }
 
 Result<void> ParamStore::ValidateListPrefix(std::string_view prefix) {
-  if (prefix.empty()) return Result<void>::Ok();
-  if (prefix.front() == '/' || prefix.find("//") != std::string_view::npos ||
-      ContainsWhitespaceOrWildcard(prefix) || ContainsBatchSegment(prefix)) {
-    return InvalidKey("invalid list prefix");
-  }
-  if (prefix.back() == '/') {
-    if (prefix.size() == 1 || !IsValidPrefix(prefix.substr(0, prefix.size() - 1))) {
-      return InvalidKey("invalid list prefix");
-    }
-    return Result<void>::Ok();
-  }
-  if (!IsValidKey(prefix)) return InvalidKey("invalid list prefix");
-  return Result<void>::Ok();
+  return param_detail::ValidateListPrefix(prefix);
 }
 
 Result<void> ParamStore::Put(std::string_view scope, std::string_view key,

--- a/src/session_view.cpp
+++ b/src/session_view.cpp
@@ -6,7 +6,6 @@
 #include "sitos/session_view.hpp"
 
 #include <algorithm>
-#include <cctype>
 #include <cstddef>
 #include <memory>
 #include <mutex>
@@ -18,15 +17,12 @@
 #include <utility>
 #include <vector>
 
+#include "list_prefix_validation.hpp"
 #include "sitos/key.hpp"
 #include "sitos/storage_node.hpp"
 
 namespace sitos {
 namespace {
-
-Result<void> InvalidKey(std::string_view message) {
-  return Result<void>::Err(Status::InvalidKey, std::string(message));
-}
 
 Result<void> InvalidArgument(std::string_view message) {
   return Result<void>::Err(Status::InvalidArgument, std::string(message));
@@ -48,42 +44,6 @@ bool SameOwner(const std::weak_ptr<void>& expected,
                const std::shared_ptr<const StorageEngine>& actual) {
   if (expected.expired()) return false;
   return !expected.owner_before(actual) && !actual.owner_before(expected);
-}
-
-bool ContainsWhitespaceOrWildcard(std::string_view value) {
-  for (char c : value) {
-    const auto byte = static_cast<unsigned char>(c);
-    if (std::isspace(byte) != 0 || c == '*' || c == '?') return true;
-  }
-  return false;
-}
-
-bool ContainsBatchSegment(std::string_view value) {
-  std::size_t start = 0;
-  while (start <= value.size()) {
-    const std::size_t end = value.find('/', start);
-    const std::size_t length = end == std::string_view::npos ? value.size() - start : end - start;
-    if (value.substr(start, length) == ":batch") return true;
-    if (end == std::string_view::npos) break;
-    start = end + 1;
-  }
-  return false;
-}
-
-Result<void> ValidateListPrefix(std::string_view prefix) {
-  if (prefix.empty()) return Result<void>::Ok();
-  if (prefix.front() == '/' || prefix.find("//") != std::string_view::npos ||
-      ContainsWhitespaceOrWildcard(prefix) || ContainsBatchSegment(prefix)) {
-    return InvalidKey("invalid list prefix");
-  }
-  if (prefix.back() == '/') {
-    if (prefix.size() == 1 || !IsValidPrefix(prefix.substr(0, prefix.size() - 1))) {
-      return InvalidKey("invalid list prefix");
-    }
-    return Result<void>::Ok();
-  }
-  if (!IsValidKey(prefix)) return InvalidKey("invalid list prefix");
-  return Result<void>::Ok();
 }
 
 struct ListItem {
@@ -229,7 +189,7 @@ Result<bool> SessionView::Contains(std::string_view key) const {
 }
 
 Result<void> SessionView::List(std::string_view prefix, const ListSink& sink) const {
-  auto prefix_result = ValidateListPrefix(prefix);
+  auto prefix_result = param_detail::ValidateListPrefix(prefix);
   if (!prefix_result.IsOk()) return prefix_result;
   if (!sink) return InvalidArgument("null List sink");
   auto acquired = AcquireReaders();

--- a/src/session_view.cpp
+++ b/src/session_view.cpp
@@ -99,6 +99,13 @@ struct SessionView::Impl {
   std::string sid;
 };
 
+struct SessionView::Readers {
+  std::shared_ptr<void> state_owner;
+  std::optional<StorageNode::State::CallbackLease> lease;
+  std::shared_ptr<StorageEngine> overlay;
+  std::shared_ptr<const StorageReader> snapshot;
+};
+
 SessionView::SessionView(std::unique_ptr<Impl> impl) noexcept : impl_(std::move(impl)) {}
 
 SessionView::~SessionView() = default;
@@ -148,37 +155,43 @@ Result<SessionView> SessionView::Open(const StorageNode& node, std::string_view 
   return Result<SessionView>::Ok(SessionView(std::move(impl)));
 }
 
-Result<ParamValue> SessionView::Get(std::string_view key) const {
-  if (!IsValidKey(key)) return Result<ParamValue>::Err(Status::InvalidKey, "invalid key");
-  if (!impl_) return Result<ParamValue>::Err(Status::InvalidArgument, "moved-from SessionView");
+Result<SessionView::Readers> SessionView::AcquireReaders() const {
+  if (!impl_) return Result<Readers>::Err(Status::InvalidArgument, "moved-from SessionView");
 
   auto opaque_state = impl_->state.lock();
-  if (!opaque_state) return Result<ParamValue>::ErrFrom(Disconnected());
+  if (!opaque_state) return Result<Readers>::ErrFrom(Disconnected());
   auto state = std::static_pointer_cast<StorageNode::State>(opaque_state);
   auto lease = state->Enter();
-  if (!lease) return Result<ParamValue>::ErrFrom(Disconnected());
+  if (!lease) return Result<Readers>::ErrFrom(Disconnected());
 
-  std::shared_ptr<StorageEngine> overlay;
-  std::shared_ptr<const StorageReader> snapshot;
+  Readers readers;
+  readers.state_owner = opaque_state;
+  readers.lease = std::move(lease);
   {
     std::shared_lock lock(state->session_mutex);
-    if (!state->sessions.contains(impl_->sid)) {
-      return Result<ParamValue>::ErrFrom(NotFound());
-    }
+    if (!state->sessions.contains(impl_->sid)) return Result<Readers>::ErrFrom(NotFound());
     auto overlay_it = state->overlays.find(impl_->sid);
     auto snapshot_it = state->snapshots.find(impl_->sid);
     if (overlay_it == state->overlays.end() || snapshot_it == state->snapshots.end() ||
         !SameOwner(impl_->overlay_owner, overlay_it->second)) {
-      return Result<ParamValue>::ErrFrom(NotFound());
+      return Result<Readers>::ErrFrom(NotFound());
     }
-    overlay = overlay_it->second;
-    snapshot = snapshot_it->second;
+    readers.overlay = overlay_it->second;
+    readers.snapshot = snapshot_it->second;
   }
+  return Result<Readers>::Ok(std::move(readers));
+}
+
+Result<ParamValue> SessionView::Get(std::string_view key) const {
+  if (!IsValidKey(key)) return Result<ParamValue>::Err(Status::InvalidKey, "invalid key");
+  auto acquired = AcquireReaders();
+  if (!acquired.IsOk()) return Result<ParamValue>::ErrFrom(acquired);
+  auto readers = std::move(acquired).Value();
 
   std::optional<ParamValue> value;
   bool found = false;
   try {
-    found = overlay->Get(key, [&](std::string_view, Bytes bytes) {
+    found = readers.overlay->Get(key, [&value](std::string_view, Bytes bytes) {
       value = ParamValue::Decode(bytes);
       return true;
     });
@@ -194,7 +207,7 @@ Result<ParamValue> SessionView::Get(std::string_view key) const {
 
   value.reset();
   try {
-    found = snapshot->Get(key, [&](std::string_view, Bytes bytes) {
+    found = readers.snapshot->Get(key, [&value](std::string_view, Bytes bytes) {
       value = ParamValue::Decode(bytes);
       return true;
     });
@@ -219,41 +232,23 @@ Result<void> SessionView::List(std::string_view prefix, const ListSink& sink) co
   auto prefix_result = ValidateListPrefix(prefix);
   if (!prefix_result.IsOk()) return prefix_result;
   if (!sink) return InvalidArgument("null List sink");
-  if (!impl_) return InvalidArgument("moved-from SessionView");
-
-  auto opaque_state = impl_->state.lock();
-  if (!opaque_state) return Disconnected();
-  auto state = std::static_pointer_cast<StorageNode::State>(opaque_state);
-  auto lease = state->Enter();
-  if (!lease) return Disconnected();
-
-  std::shared_ptr<StorageEngine> overlay;
-  std::shared_ptr<const StorageReader> snapshot;
-  {
-    std::shared_lock lock(state->session_mutex);
-    if (!state->sessions.contains(impl_->sid)) return NotFound();
-    auto overlay_it = state->overlays.find(impl_->sid);
-    auto snapshot_it = state->snapshots.find(impl_->sid);
-    if (overlay_it == state->overlays.end() || snapshot_it == state->snapshots.end() ||
-        !SameOwner(impl_->overlay_owner, overlay_it->second)) {
-      return NotFound();
-    }
-    overlay = overlay_it->second;
-    snapshot = snapshot_it->second;
-  }
+  auto acquired = AcquireReaders();
+  if (!acquired.IsOk()) return Result<void>::ErrFrom(acquired);
+  auto readers = std::move(acquired).Value();
 
   std::vector<ListItem> values;
   std::unordered_set<std::string> overlay_keys;
   std::optional<Result<void>> decode_error;
   try {
-    const bool overlay_completed = overlay->List(prefix, [&](std::string_view key, Bytes bytes) {
+    const bool overlay_completed = readers.overlay->List(prefix, [&decode_error, &overlay_keys, &values](
+        std::string_view key, Bytes bytes) {
       auto decoded = ParamValue::Decode(bytes);
       if (!decoded.has_value()) {
         decode_error = StorageError("malformed parameter payload");
         return false;
       }
       overlay_keys.emplace(key);
-      values.push_back({std::string(key), std::move(*decoded)});
+      values.emplace_back(std::string(key), std::move(*decoded));
       return true;
     });
     if (!overlay_completed && !decode_error.has_value()) {
@@ -261,14 +256,15 @@ Result<void> SessionView::List(std::string_view prefix, const ListSink& sink) co
     }
     if (decode_error.has_value()) return *decode_error;
 
-    const bool snapshot_completed = snapshot->List(prefix, [&](std::string_view key, Bytes bytes) {
+    const bool snapshot_completed = readers.snapshot->List(prefix, [&decode_error, &overlay_keys, &values](
+        std::string_view key, Bytes bytes) {
       if (overlay_keys.contains(std::string(key))) return true;
       auto decoded = ParamValue::Decode(bytes);
       if (!decoded.has_value()) {
         decode_error = StorageError("malformed parameter payload");
         return false;
       }
-      values.push_back({std::string(key), std::move(*decoded)});
+      values.emplace_back(std::string(key), std::move(*decoded));
       return true;
     });
     if (!snapshot_completed && !decode_error.has_value()) {
@@ -279,16 +275,14 @@ Result<void> SessionView::List(std::string_view prefix, const ListSink& sink) co
   }
   if (decode_error.has_value()) return *decode_error;
 
-  std::sort(values.begin(), values.end(),
-            [](const ListItem& left, const ListItem& right) { return left.key < right.key; });
+  std::ranges::sort(values, [](const ListItem& left, const ListItem& right) {
+    return left.key < right.key;
+  });
 
-  lease.reset();
-  try {
-    for (const auto& item : values) {
-      if (!sink(item.key, item.value)) break;
-    }
-  } catch (...) {
-    throw;
+  readers.lease.reset();
+  readers.state_owner.reset();
+  for (const auto& item : values) {
+    if (!sink(item.key, item.value)) break;
   }
   return Result<void>::Ok();
 }

--- a/src/session_view.cpp
+++ b/src/session_view.cpp
@@ -1,0 +1,296 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// In-process read-only composite view over a session overlay and snapshot.
+
+#include "sitos/session_view.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <shared_mutex>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "sitos/key.hpp"
+#include "sitos/storage_node.hpp"
+
+namespace sitos {
+namespace {
+
+Result<void> InvalidKey(std::string_view message) {
+  return Result<void>::Err(Status::InvalidKey, std::string(message));
+}
+
+Result<void> InvalidArgument(std::string_view message) {
+  return Result<void>::Err(Status::InvalidArgument, std::string(message));
+}
+
+Result<void> Disconnected() {
+  return Result<void>::Err(Status::Disconnected, "StorageNode is stopped");
+}
+
+Result<void> NotFound() {
+  return Result<void>::Err(Status::NotFound, "session or parameter not found");
+}
+
+Result<void> StorageError(std::string_view message) {
+  return Result<void>::Err(Status::Error, std::string(message));
+}
+
+bool SameOwner(const std::weak_ptr<void>& expected,
+               const std::shared_ptr<const StorageEngine>& actual) {
+  if (expected.expired()) return false;
+  return !expected.owner_before(actual) && !actual.owner_before(expected);
+}
+
+bool ContainsWhitespaceOrWildcard(std::string_view value) {
+  for (char c : value) {
+    const auto byte = static_cast<unsigned char>(c);
+    if (std::isspace(byte) != 0 || c == '*' || c == '?') return true;
+  }
+  return false;
+}
+
+bool ContainsBatchSegment(std::string_view value) {
+  std::size_t start = 0;
+  while (start <= value.size()) {
+    const std::size_t end = value.find('/', start);
+    const std::size_t length = end == std::string_view::npos ? value.size() - start : end - start;
+    if (value.substr(start, length) == ":batch") return true;
+    if (end == std::string_view::npos) break;
+    start = end + 1;
+  }
+  return false;
+}
+
+Result<void> ValidateListPrefix(std::string_view prefix) {
+  if (prefix.empty()) return Result<void>::Ok();
+  if (prefix.front() == '/' || prefix.find("//") != std::string_view::npos ||
+      ContainsWhitespaceOrWildcard(prefix) || ContainsBatchSegment(prefix)) {
+    return InvalidKey("invalid list prefix");
+  }
+  if (prefix.back() == '/') {
+    if (prefix.size() == 1 || !IsValidPrefix(prefix.substr(0, prefix.size() - 1))) {
+      return InvalidKey("invalid list prefix");
+    }
+    return Result<void>::Ok();
+  }
+  if (!IsValidKey(prefix)) return InvalidKey("invalid list prefix");
+  return Result<void>::Ok();
+}
+
+struct ListItem {
+  std::string key;
+  ParamValue value;
+};
+
+}  // namespace
+
+struct SessionView::Impl {
+  std::weak_ptr<void> state;
+  std::weak_ptr<void> overlay_owner;
+  std::string sid;
+};
+
+SessionView::SessionView(std::unique_ptr<Impl> impl) noexcept : impl_(std::move(impl)) {}
+
+SessionView::~SessionView() = default;
+
+SessionView::SessionView(SessionView&&) noexcept = default;
+
+SessionView& SessionView::operator=(SessionView&& other) noexcept {
+  if (this != &other) impl_ = std::move(other.impl_);
+  return *this;
+}
+
+Result<SessionView> SessionView::Open(const StorageNode& node, std::string_view sid) {
+  if (!IsValidSessionId(sid)) {
+    return Result<SessionView>::Err(Status::InvalidKey, "invalid session id");
+  }
+
+  std::shared_ptr<StorageNode::State> state;
+  {
+    std::scoped_lock lock(node.lifecycle_mutex_);
+    state = node.state_;
+  }
+  if (!state) {
+    return Result<SessionView>::Err(Status::Disconnected, "StorageNode is stopped");
+  }
+
+  auto lease = state->Enter();
+  if (!lease) return Result<SessionView>::Err(Status::Disconnected, "StorageNode is stopped");
+
+  std::shared_ptr<StorageEngine> overlay;
+  {
+    std::shared_lock lock(state->session_mutex);
+    const std::string key(sid);
+    if (!state->sessions.contains(key)) {
+      return Result<SessionView>::Err(Status::NotFound, "session not found");
+    }
+    auto it = state->overlays.find(key);
+    if (it == state->overlays.end()) {
+      return Result<SessionView>::Err(Status::NotFound, "session not found");
+    }
+    overlay = it->second;
+  }
+
+  auto impl = std::make_unique<Impl>();
+  impl->state = state;
+  impl->overlay_owner = overlay;
+  impl->sid = std::string(sid);
+  return Result<SessionView>::Ok(SessionView(std::move(impl)));
+}
+
+Result<ParamValue> SessionView::Get(std::string_view key) const {
+  if (!IsValidKey(key)) return Result<ParamValue>::Err(Status::InvalidKey, "invalid key");
+  if (!impl_) return Result<ParamValue>::Err(Status::InvalidArgument, "moved-from SessionView");
+
+  auto opaque_state = impl_->state.lock();
+  if (!opaque_state) return Result<ParamValue>::ErrFrom(Disconnected());
+  auto state = std::static_pointer_cast<StorageNode::State>(opaque_state);
+  auto lease = state->Enter();
+  if (!lease) return Result<ParamValue>::ErrFrom(Disconnected());
+
+  std::shared_ptr<StorageEngine> overlay;
+  std::shared_ptr<const StorageReader> snapshot;
+  {
+    std::shared_lock lock(state->session_mutex);
+    if (!state->sessions.contains(impl_->sid)) {
+      return Result<ParamValue>::ErrFrom(NotFound());
+    }
+    auto overlay_it = state->overlays.find(impl_->sid);
+    auto snapshot_it = state->snapshots.find(impl_->sid);
+    if (overlay_it == state->overlays.end() || snapshot_it == state->snapshots.end() ||
+        !SameOwner(impl_->overlay_owner, overlay_it->second)) {
+      return Result<ParamValue>::ErrFrom(NotFound());
+    }
+    overlay = overlay_it->second;
+    snapshot = snapshot_it->second;
+  }
+
+  std::optional<ParamValue> value;
+  bool found = false;
+  try {
+    found = overlay->Get(key, [&](std::string_view, Bytes bytes) {
+      value = ParamValue::Decode(bytes);
+      return true;
+    });
+  } catch (...) {
+    return Result<ParamValue>::Err(Status::Error, "storage reader threw during Get");
+  }
+  if (found) {
+    if (!value.has_value()) {
+      return Result<ParamValue>::Err(Status::Error, "malformed parameter payload");
+    }
+    return Result<ParamValue>::Ok(std::move(*value));
+  }
+
+  value.reset();
+  try {
+    found = snapshot->Get(key, [&](std::string_view, Bytes bytes) {
+      value = ParamValue::Decode(bytes);
+      return true;
+    });
+  } catch (...) {
+    return Result<ParamValue>::Err(Status::Error, "storage reader threw during Get");
+  }
+  if (!found) return Result<ParamValue>::ErrFrom(NotFound());
+  if (!value.has_value()) {
+    return Result<ParamValue>::Err(Status::Error, "malformed parameter payload");
+  }
+  return Result<ParamValue>::Ok(std::move(*value));
+}
+
+Result<bool> SessionView::Contains(std::string_view key) const {
+  auto value = Get(key);
+  if (value.IsOk()) return Result<bool>::Ok(true);
+  if (value.StatusCode() == Status::NotFound) return Result<bool>::Ok(false);
+  return Result<bool>::ErrFrom(value);
+}
+
+Result<void> SessionView::List(std::string_view prefix, const ListSink& sink) const {
+  auto prefix_result = ValidateListPrefix(prefix);
+  if (!prefix_result.IsOk()) return prefix_result;
+  if (!sink) return InvalidArgument("null List sink");
+  if (!impl_) return InvalidArgument("moved-from SessionView");
+
+  auto opaque_state = impl_->state.lock();
+  if (!opaque_state) return Disconnected();
+  auto state = std::static_pointer_cast<StorageNode::State>(opaque_state);
+  auto lease = state->Enter();
+  if (!lease) return Disconnected();
+
+  std::shared_ptr<StorageEngine> overlay;
+  std::shared_ptr<const StorageReader> snapshot;
+  {
+    std::shared_lock lock(state->session_mutex);
+    if (!state->sessions.contains(impl_->sid)) return NotFound();
+    auto overlay_it = state->overlays.find(impl_->sid);
+    auto snapshot_it = state->snapshots.find(impl_->sid);
+    if (overlay_it == state->overlays.end() || snapshot_it == state->snapshots.end() ||
+        !SameOwner(impl_->overlay_owner, overlay_it->second)) {
+      return NotFound();
+    }
+    overlay = overlay_it->second;
+    snapshot = snapshot_it->second;
+  }
+
+  std::vector<ListItem> values;
+  std::unordered_set<std::string> overlay_keys;
+  std::optional<Result<void>> decode_error;
+  try {
+    const bool overlay_completed = overlay->List(prefix, [&](std::string_view key, Bytes bytes) {
+      auto decoded = ParamValue::Decode(bytes);
+      if (!decoded.has_value()) {
+        decode_error = StorageError("malformed parameter payload");
+        return false;
+      }
+      overlay_keys.emplace(key);
+      values.push_back({std::string(key), std::move(*decoded)});
+      return true;
+    });
+    if (!overlay_completed && !decode_error.has_value()) {
+      return StorageError("storage reader stopped List unexpectedly");
+    }
+    if (decode_error.has_value()) return *decode_error;
+
+    const bool snapshot_completed = snapshot->List(prefix, [&](std::string_view key, Bytes bytes) {
+      if (overlay_keys.contains(std::string(key))) return true;
+      auto decoded = ParamValue::Decode(bytes);
+      if (!decoded.has_value()) {
+        decode_error = StorageError("malformed parameter payload");
+        return false;
+      }
+      values.push_back({std::string(key), std::move(*decoded)});
+      return true;
+    });
+    if (!snapshot_completed && !decode_error.has_value()) {
+      return StorageError("storage reader stopped List unexpectedly");
+    }
+  } catch (...) {
+    return StorageError("storage reader threw during List");
+  }
+  if (decode_error.has_value()) return *decode_error;
+
+  std::sort(values.begin(), values.end(),
+            [](const ListItem& left, const ListItem& right) { return left.key < right.key; });
+
+  lease.reset();
+  try {
+    for (const auto& item : values) {
+      if (!sink(item.key, item.value)) break;
+    }
+  } catch (...) {
+    throw;
+  }
+  return Result<void>::Ok();
+}
+
+}  // namespace sitos

--- a/src/session_view.cpp
+++ b/src/session_view.cpp
@@ -149,12 +149,7 @@ Result<SessionView::Readers> SessionView::AcquireReaders() const {
   return Result<Readers>::Ok(std::move(readers));
 }
 
-Result<ParamValue> SessionView::Get(std::string_view key) const {
-  if (!IsValidKey(key)) return Result<ParamValue>::Err(Status::InvalidKey, "invalid key");
-  auto acquired = AcquireReaders();
-  if (!acquired.IsOk()) return Result<ParamValue>::ErrFrom(acquired);
-  auto readers = std::move(acquired).Value();
-
+Result<ParamValue> SessionView::Read(const Readers& readers, std::string_view key) const {
   std::optional<ParamValue> value;
   bool found = false;
   try {
@@ -188,14 +183,27 @@ Result<ParamValue> SessionView::Get(std::string_view key) const {
   return Result<ParamValue>::Ok(std::move(*value));
 }
 
+Result<ParamValue> SessionView::Get(std::string_view key) const {
+  if (!impl_) return Result<ParamValue>::Err(Status::InvalidArgument, "moved-from SessionView");
+  if (!IsValidKey(key)) return Result<ParamValue>::Err(Status::InvalidKey, "invalid key");
+  auto acquired = AcquireReaders();
+  if (!acquired.IsOk()) return Result<ParamValue>::ErrFrom(acquired);
+  return Read(acquired.Value(), key);
+}
+
 Result<bool> SessionView::Contains(std::string_view key) const {
-  auto value = Get(key);
+  if (!impl_) return Result<bool>::Err(Status::InvalidArgument, "moved-from SessionView");
+  if (!IsValidKey(key)) return Result<bool>::Err(Status::InvalidKey, "invalid key");
+  auto acquired = AcquireReaders();
+  if (!acquired.IsOk()) return Result<bool>::ErrFrom(acquired);
+  auto value = Read(acquired.Value(), key);
   if (value.IsOk()) return Result<bool>::Ok(true);
   if (value.StatusCode() == Status::NotFound) return Result<bool>::Ok(false);
   return Result<bool>::ErrFrom(value);
 }
 
 Result<void> SessionView::List(std::string_view prefix, const ListSink& sink) const {
+  if (!impl_) return InvalidArgument("moved-from SessionView");
   auto prefix_result = param_detail::ValidateListPrefix(prefix);
   if (!prefix_result.IsOk()) return prefix_result;
   if (!sink) return InvalidArgument("null List sink");

--- a/src/session_view.cpp
+++ b/src/session_view.cpp
@@ -46,6 +46,14 @@ bool SameOwner(const std::weak_ptr<void>& expected,
   return !expected.owner_before(actual) && !actual.owner_before(expected);
 }
 
+struct TransparentStringHash {
+  using is_transparent = void;
+
+  std::size_t operator()(std::string_view value) const noexcept {
+    return std::hash<std::string_view>{}(value);
+  }
+};
+
 struct ListItem {
   std::string key;
   ParamValue value;
@@ -196,7 +204,7 @@ Result<void> SessionView::List(std::string_view prefix, const ListSink& sink) co
   auto readers = std::move(acquired).Value();
 
   std::vector<ListItem> values;
-  std::unordered_set<std::string> overlay_keys;
+  std::unordered_set<std::string, TransparentStringHash, std::equal_to<>> overlay_keys;
   std::optional<Result<void>> decode_error;
   try {
     const bool overlay_completed = readers.overlay->List(prefix, [&decode_error, &overlay_keys, &values](
@@ -217,7 +225,7 @@ Result<void> SessionView::List(std::string_view prefix, const ListSink& sink) co
 
     const bool snapshot_completed = readers.snapshot->List(prefix, [&decode_error, &overlay_keys, &values](
         std::string_view key, Bytes bytes) {
-      if (overlay_keys.contains(std::string(key))) return true;
+      if (overlay_keys.contains(key)) return true;
       auto decoded = ParamValue::Decode(bytes);
       if (!decoded.has_value()) {
         decode_error = StorageError("malformed parameter payload");
@@ -238,6 +246,8 @@ Result<void> SessionView::List(std::string_view prefix, const ListSink& sink) co
     return left.key < right.key;
   });
 
+  readers.overlay.reset();
+  readers.snapshot.reset();
   readers.lease.reset();
   readers.state_owner.reset();
   for (const auto& item : values) {

--- a/src/session_view.cpp
+++ b/src/session_view.cpp
@@ -54,7 +54,7 @@ struct ListItem {
 }  // namespace
 
 struct SessionView::Impl {
-  std::weak_ptr<void> state;
+  std::weak_ptr<StorageNode::State> state;
   std::weak_ptr<void> overlay_owner;
   std::string sid;
 };
@@ -118,14 +118,13 @@ Result<SessionView> SessionView::Open(const StorageNode& node, std::string_view 
 Result<SessionView::Readers> SessionView::AcquireReaders() const {
   if (!impl_) return Result<Readers>::Err(Status::InvalidArgument, "moved-from SessionView");
 
-  auto opaque_state = impl_->state.lock();
-  if (!opaque_state) return Result<Readers>::ErrFrom(Disconnected());
-  auto state = std::static_pointer_cast<StorageNode::State>(opaque_state);
+  auto state = impl_->state.lock();
+  if (!state) return Result<Readers>::ErrFrom(Disconnected());
   auto lease = state->Enter();
   if (!lease) return Result<Readers>::ErrFrom(Disconnected());
 
   Readers readers;
-  readers.state_owner = opaque_state;
+  readers.state_owner = state;
   readers.lease = std::move(lease);
   {
     std::shared_lock lock(state->session_mutex);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,11 +37,14 @@ add_sitos_public_header_compile_test(
   sitos_param_concepts_header_compile_test consumer/param_concepts_header_compile.cpp)
 add_sitos_public_header_compile_test(
   sitos_list_sink_header_compile_test consumer/list_sink_header_compile.cpp)
+add_sitos_public_header_compile_test(
+  sitos_session_view_header_compile_test consumer/session_view_header_compile.cpp)
 if(SITOS_WITH_ZENOH)
   sitos_copy_zenohc(sitos_param_store_header_compile_test)
   sitos_copy_zenohc(sitos_param_cache_header_compile_test)
   sitos_copy_zenohc(sitos_param_concepts_header_compile_test)
   sitos_copy_zenohc(sitos_list_sink_header_compile_test)
+  sitos_copy_zenohc(sitos_session_view_header_compile_test)
 endif()
 
 add_executable(sitos_bootstrap_test unit/bootstrap_test.cpp)
@@ -160,6 +163,17 @@ if(SITOS_WITH_ZENOH)
 endif()
 gtest_add_tests(TARGET sitos_storage_node_test SOURCES unit/storage_node_test.cpp)
 
+add_executable(sitos_session_view_test
+  unit/session_view_test.cpp)
+target_link_libraries(sitos_session_view_test
+  PRIVATE GTest::gtest_main sitos::sitos)
+target_include_directories(sitos_session_view_test PRIVATE ${PROJECT_SOURCE_DIR}/src)
+sitos_enable_warnings(sitos_session_view_test)
+if(SITOS_WITH_ZENOH)
+  sitos_copy_zenohc(sitos_session_view_test)
+endif()
+gtest_add_tests(TARGET sitos_session_view_test SOURCES unit/session_view_test.cpp)
+
 # --- Zenoh smoke test (integration) ---
 if(SITOS_WITH_ZENOH)
   add_executable(sitos_zenoh_smoke_test
@@ -239,6 +253,16 @@ if(SITOS_WITH_ZENOH)
   gtest_add_tests(
     TARGET sitos_param_store_integration_test
     SOURCES integration/param_store_test.cpp)
+
+  add_executable(sitos_session_view_integration_test
+    integration/session_view_test.cpp)
+  target_link_libraries(sitos_session_view_integration_test
+    PRIVATE GTest::gtest_main sitos::sitos)
+  sitos_enable_warnings(sitos_session_view_integration_test)
+  sitos_copy_zenohc(sitos_session_view_integration_test)
+  gtest_add_tests(
+    TARGET sitos_session_view_integration_test
+    SOURCES integration/session_view_test.cpp)
 
   add_executable(sitos_param_cache_integration_test
     integration/param_cache_attach_test.cpp)

--- a/tests/consumer/session_view_header_compile.cpp
+++ b/tests/consumer/session_view_header_compile.cpp
@@ -1,0 +1,16 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/session_view.hpp"
+
+template <typename T>
+concept HasPut = requires(T& value) {
+  value.Put("key", sitos::ParamValue(std::int64_t{1}));
+};
+template <typename T>
+concept HasDelete = requires(T& value) { value.Delete("key"); };
+
+static_assert(!HasPut<sitos::SessionView>);
+static_assert(!HasDelete<sitos::SessionView>);
+
+int main() { return 0; }

--- a/tests/integration/session_view_test.cpp
+++ b/tests/integration/session_view_test.cpp
@@ -1,0 +1,122 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/session_view.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <thread>
+
+#include "sitos/in_memory_engine.hpp"
+#include "sitos/param_cache.hpp"
+#include "sitos/param_store.hpp"
+#include "sitos/storage_node.hpp"
+
+namespace {
+
+using namespace std::chrono_literals;
+
+class CallbackTrackingTransport final : public sitos::Transport {
+ public:
+  explicit CallbackTrackingTransport(std::shared_ptr<sitos::Transport> inner)
+      : inner_(std::move(inner)) {}
+
+  sitos::Result<void> Put(std::string_view key, std::span<const std::byte> payload,
+                          sitos::Encoding encoding, sitos::PutOptions options) override {
+    return inner_->Put(key, payload, std::move(encoding), options);
+  }
+
+  sitos::Result<void> Delete(std::string_view key, sitos::PutOptions options) override {
+    return inner_->Delete(key, options);
+  }
+
+  sitos::Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
+                          std::chrono::milliseconds timeout) override {
+    return inner_->Get(keyexpr, sink, timeout);
+  }
+
+  sitos::Result<sitos::Subscription> DeclareSubscriber(
+      std::string_view keyexpr,
+      std::function<void(const sitos::TransportSample&)> callback) override {
+    auto wrapped = [this, callback = std::move(callback)](
+                       const sitos::TransportSample& sample) {
+      callback(sample);
+      std::lock_guard lock(mutex_);
+      ++callback_count_;
+      callback_cv_.notify_all();
+    };
+    return inner_->DeclareSubscriber(keyexpr, std::move(wrapped));
+  }
+
+  sitos::Result<sitos::Queryable> DeclareQueryable(
+      std::string_view keyexpr,
+      std::function<void(sitos::TransportQuery&)> callback) override {
+    return inner_->DeclareQueryable(keyexpr, std::move(callback));
+  }
+
+  std::size_t CallbackCount() const {
+    std::lock_guard lock(mutex_);
+    return callback_count_;
+  }
+
+  void WaitForCallbackAfter(std::size_t previous) {
+    std::unique_lock lock(mutex_);
+    ASSERT_TRUE(callback_cv_.wait_for(lock, 5s, [this, previous] {
+      return callback_count_ > previous;
+    }));
+  }
+
+ private:
+  std::shared_ptr<sitos::Transport> inner_;
+  mutable std::mutex mutex_;
+  std::condition_variable callback_cv_;
+  std::size_t callback_count_ = 0;
+};
+
+TEST(SessionViewIntegrationTest, MatchesParamCacheAfterObservedSessionDelivery) {
+  auto transport = std::shared_ptr<sitos::Transport>(sitos::MakeZenohTransport().release());
+  ASSERT_TRUE(transport);
+  auto tracking = std::make_shared<CallbackTrackingTransport>(transport);
+  auto engine = std::make_shared<sitos::InMemoryEngine>();
+  sitos::StorageNode node;
+  ASSERT_TRUE(node.Start(engine, *transport, {.prefix = "sitos/session_view_test"}).IsOk());
+
+  sitos::ClientConfig config;
+  config.prefix = "sitos/session_view_test";
+  config.query_timeout = 1000ms;
+  auto store_result = sitos::ParamStore::Open(transport, config);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  ASSERT_TRUE(store.Put("base", "inherited", std::int64_t{1}).IsOk());
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+
+  auto cache_result = sitos::ParamCache::Open(tracking, config);
+  ASSERT_TRUE(cache_result.IsOk());
+  auto cache = std::move(cache_result).Value();
+  ASSERT_TRUE(cache.Attach("s1").IsOk());
+  auto view_result = sitos::SessionView::Open(node, "s1");
+  ASSERT_TRUE(view_result.IsOk());
+  auto view = std::move(view_result).Value();
+  EXPECT_EQ(view.Get<std::int64_t>("inherited").Value(), 1);
+  EXPECT_EQ(cache.Get<std::int64_t>("inherited").Value(), 1);
+
+  const auto previous = tracking->CallbackCount();
+  ASSERT_TRUE(store.Put("session/s1", "result", std::int64_t{42}).IsOk());
+  tracking->WaitForCallbackAfter(previous);
+  ASSERT_EQ(view.Get<std::int64_t>("result").Value(), 42);
+  ASSERT_EQ(cache.Get<std::int64_t>("result").Value(), 42);
+
+  cache.Detach();
+  node.Stop();
+}
+
+}  // namespace

--- a/tests/integration/session_view_test.cpp
+++ b/tests/integration/session_view_test.cpp
@@ -85,10 +85,11 @@ class CallbackTrackingTransport final : public sitos::Transport {
 TEST(SessionViewIntegrationTest, MatchesParamCacheAfterObservedSessionDelivery) {
   auto transport = std::shared_ptr<sitos::Transport>(sitos::MakeZenohTransport().release());
   ASSERT_TRUE(transport);
-  auto tracking = std::make_shared<CallbackTrackingTransport>(transport);
+  auto node_tracking = std::make_shared<CallbackTrackingTransport>(transport);
+  auto cache_tracking = std::make_shared<CallbackTrackingTransport>(transport);
   auto engine = std::make_shared<sitos::InMemoryEngine>();
   sitos::StorageNode node;
-  ASSERT_TRUE(node.Start(engine, *transport, {.prefix = "sitos/session_view_test"}).IsOk());
+  ASSERT_TRUE(node.Start(engine, *node_tracking, {.prefix = "sitos/session_view_test"}).IsOk());
 
   sitos::ClientConfig config;
   config.prefix = "sitos/session_view_test";
@@ -96,10 +97,12 @@ TEST(SessionViewIntegrationTest, MatchesParamCacheAfterObservedSessionDelivery) 
   auto store_result = sitos::ParamStore::Open(transport, config);
   ASSERT_TRUE(store_result.IsOk());
   auto store = std::move(store_result).Value();
+  const auto node_before_base = node_tracking->CallbackCount();
   ASSERT_TRUE(store.Put("base", "inherited", std::int64_t{1}).IsOk());
+  node_tracking->WaitForCallbackAfter(node_before_base);
   ASSERT_TRUE(node.CreateSession("s1").IsOk());
 
-  auto cache_result = sitos::ParamCache::Open(tracking, config);
+  auto cache_result = sitos::ParamCache::Open(cache_tracking, config);
   ASSERT_TRUE(cache_result.IsOk());
   auto cache = std::move(cache_result).Value();
   ASSERT_TRUE(cache.Attach("s1").IsOk());
@@ -109,9 +112,11 @@ TEST(SessionViewIntegrationTest, MatchesParamCacheAfterObservedSessionDelivery) 
   EXPECT_EQ(view.Get<std::int64_t>("inherited").Value(), 1);
   EXPECT_EQ(cache.Get<std::int64_t>("inherited").Value(), 1);
 
-  const auto previous = tracking->CallbackCount();
+  const auto node_before_session = node_tracking->CallbackCount();
+  const auto cache_before_session = cache_tracking->CallbackCount();
   ASSERT_TRUE(store.Put("session/s1", "result", std::int64_t{42}).IsOk());
-  tracking->WaitForCallbackAfter(previous);
+  node_tracking->WaitForCallbackAfter(node_before_session);
+  cache_tracking->WaitForCallbackAfter(cache_before_session);
   ASSERT_EQ(view.Get<std::int64_t>("result").Value(), 42);
   ASSERT_EQ(cache.Get<std::int64_t>("result").Value(), 42);
 

--- a/tests/package/consumer/main.cpp
+++ b/tests/package/consumer/main.cpp
@@ -3,6 +3,7 @@
 
 #include "sitos/list_sink.hpp"
 #include "sitos/param_concepts.hpp"
+#include "sitos/session_view.hpp"
 #include "sitos/sitos.hpp"
 
 static_assert(sitos::ParamInput<std::int64_t>);
@@ -15,6 +16,12 @@ concept HasAttachBase = requires(T& value) {
 };
 
 static_assert(!HasAttachBase<sitos::ParamCache>);
+
+template <typename T>
+concept HasSessionViewPut = requires(T& value) {
+  value.Put("key", sitos::ParamValue(std::int64_t{1}));
+};
+static_assert(!HasSessionViewPut<sitos::SessionView>);
 
 int main() {
   static_cast<void>(sitos::MakeZenohTransport());

--- a/tests/unit/session_view_test.cpp
+++ b/tests/unit/session_view_test.cpp
@@ -1,0 +1,303 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/session_view.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "sitos/batch.hpp"
+#include "sitos/in_memory_engine.hpp"
+#include "sitos/storage_node.hpp"
+#include "sitos/param_value.hpp"
+#include "transport/declaration_handle_test_access.hpp"
+
+namespace sitos {
+namespace {
+
+static_assert(!std::is_copy_constructible_v<SessionView>);
+static_assert(!std::is_copy_assignable_v<SessionView>);
+static_assert(std::is_move_constructible_v<SessionView>);
+static_assert(std::is_move_assignable_v<SessionView>);
+template <typename T>
+concept HasPut = requires(T& value) { value.Put("key", ParamValue(std::int64_t{1})); };
+template <typename T>
+concept HasPutBatch = requires(T& value) { value.PutBatch(std::span<const BatchEntry>{}); };
+template <typename T>
+concept HasDelete = requires(T& value) { value.Delete("key"); };
+template <typename T>
+concept HasGetShared = requires(const T& value) { value.GetShared("key"); };
+template <typename T>
+concept HasGetSpan = requires(const T& value) { value.template GetSpan<std::byte>("key"); };
+static_assert(!HasPut<SessionView>);
+static_assert(!HasPutBatch<SessionView>);
+static_assert(!HasDelete<SessionView>);
+static_assert(!HasGetShared<SessionView>);
+static_assert(!HasGetSpan<SessionView>);
+
+class TestTransport final : public Transport {
+ public:
+  Result<void> Put(std::string_view, std::span<const std::byte>, Encoding,
+                   PutOptions) override {
+    return Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
+  }
+
+  Result<void> Delete(std::string_view, PutOptions) override {
+    return Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
+  }
+
+  Result<void> Get(std::string_view, const QueryResultSink&, std::chrono::milliseconds) override {
+    ++get_count;
+    return Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
+  }
+
+  Result<Subscription> DeclareSubscriber(
+      std::string_view keyexpr,
+      std::function<void(const TransportSample&)> callback) override {
+    subscriber_keyexpr = std::string(keyexpr);
+    subscriber = std::move(callback);
+    return Result<Subscription>::Ok(
+        transport_test_access::DeclarationHandleTestAccess::MakeSubscription([this] {
+          subscriber = {};
+        }));
+  }
+
+  Result<Queryable> DeclareQueryable(
+      std::string_view keyexpr,
+      std::function<void(TransportQuery&)> callback) override {
+    queryable_keyexpr = std::string(keyexpr);
+    queryable = std::move(callback);
+    return Result<Queryable>::Ok(
+        transport_test_access::DeclarationHandleTestAccess::MakeQueryable([this] {
+          queryable = {};
+        }));
+  }
+
+  void Publish(std::string key, std::span<const std::byte> payload, Encoding encoding,
+               TransportSample::Kind kind = TransportSample::Kind::Put) {
+    if (!subscriber) return;
+    subscriber(TransportSample{std::move(key), payload, std::move(encoding), std::nullopt, kind});
+  }
+
+  int get_count = 0;
+  std::string subscriber_keyexpr;
+  std::string queryable_keyexpr;
+  std::function<void(const TransportSample&)> subscriber;
+  std::function<void(TransportQuery&)> queryable;
+};
+
+class SessionViewFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    node = std::make_unique<StorageNode>(transport);
+    ASSERT_TRUE(node->Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+    ASSERT_TRUE(node->CreateSession("s1").IsOk());
+  }
+
+  void TearDown() override { node.reset(); }
+
+  void PublishValue(std::string_view key, const ParamValue& value) {
+    auto payload = value.Encode();
+    transport.Publish("sitos/session/s1/" + std::string(key), payload,
+                      Encoding{std::string(Encoding::kSitosV1)});
+  }
+
+  void PublishDelete(std::string_view key) {
+    const std::vector<std::byte> empty;
+    transport.Publish("sitos/session/s1/" + std::string(key), empty,
+                      Encoding{std::string(Encoding::kSitosV1)}, TransportSample::Kind::Delete);
+  }
+
+  TestTransport transport;
+  std::shared_ptr<InMemoryEngine> engine = std::make_shared<InMemoryEngine>();
+  std::unique_ptr<StorageNode> node;
+};
+
+TEST_F(SessionViewFixture, ResolvesOverlayThenSnapshotAndContainsUsesResult) {
+  ASSERT_TRUE(engine->Put("base", ParamValue(std::int64_t{7}).Encode()));
+  node->Stop();
+  ASSERT_TRUE(node->Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  ASSERT_TRUE(node->CreateSession("s1").IsOk());
+  auto view = SessionView::Open(*node, "s1");
+  ASSERT_TRUE(view.IsOk());
+  EXPECT_EQ(view.Value().Get<std::int64_t>("base").Value(), 7);
+  PublishValue("base", ParamValue(std::int64_t{9}));
+  EXPECT_EQ(view.Value().Get<std::int64_t>("base").Value(), 9);
+  EXPECT_TRUE(view.Value().Contains("base").Value());
+  EXPECT_FALSE(view.Value().Contains("missing").Value());
+}
+
+TEST_F(SessionViewFixture, ListMergesRawPrefixAndSorts) {
+  ASSERT_TRUE(engine->Put("foo/base", ParamValue(std::int64_t{1}).Encode()));
+  node->Stop();
+  ASSERT_TRUE(node->Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  ASSERT_TRUE(node->CreateSession("s1").IsOk());
+  PublishValue("foo/base", ParamValue(std::int64_t{2}));
+  PublishValue("foobar", ParamValue(std::int64_t{3}));
+  auto view = SessionView::Open(*node, "s1");
+  ASSERT_TRUE(view.IsOk());
+  std::vector<std::string> keys;
+  auto listed = view.Value().List("foo", [&](std::string_view key, const ParamValue&) {
+    keys.emplace_back(key);
+    return true;
+  });
+  ASSERT_TRUE(listed.IsOk());
+  EXPECT_EQ(keys, (std::vector<std::string>{"foo/base", "foobar"}));
+  EXPECT_EQ(transport.get_count, 0);
+}
+
+TEST_F(SessionViewFixture, MalformedOverlayDoesNotFallbackAndListDoesNotPartiallyCallback) {
+  ASSERT_TRUE(engine->Put("bad", ParamValue(std::int64_t{1}).Encode()));
+  node->Stop();
+  ASSERT_TRUE(node->Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  ASSERT_TRUE(node->CreateSession("s1").IsOk());
+  const std::vector<std::byte> malformed{std::byte{0xff}};
+  transport.Publish("sitos/session/s1/bad", malformed,
+                    Encoding{std::string(Encoding::kSitosV1)});
+  auto view = SessionView::Open(*node, "s1");
+  ASSERT_TRUE(view.IsOk());
+  EXPECT_EQ(view.Value().Get("bad").StatusCode(), Status::Error);
+  int callbacks = 0;
+  EXPECT_EQ(view.Value().List("", [&](std::string_view, const ParamValue&) {
+    ++callbacks;
+    return true;
+  }).StatusCode(), Status::Error);
+  EXPECT_EQ(callbacks, 0);
+}
+
+TEST_F(SessionViewFixture, GetOrOnlySubstitutesNotFoundAndSinkCanStop) {
+  PublishValue("value", ParamValue(std::int64_t{9}));
+  auto view = SessionView::Open(*node, "s1");
+  ASSERT_TRUE(view.IsOk());
+  EXPECT_EQ(view.Value().GetOr<std::int64_t>("missing", 42).Value(), 42);
+  EXPECT_EQ(view.Value().GetOr<std::int64_t>("missing", 42).StatusCode(), Status::Ok);
+  EXPECT_EQ(view.Value().GetOr<std::string>("value", "fallback").StatusCode(),
+            Status::TypeMismatch);
+
+  auto listed = view.Value().List("", [&](std::string_view, const ParamValue&) {
+    node->Stop();
+    return false;
+  });
+  EXPECT_TRUE(listed.IsOk());
+}
+
+TEST_F(SessionViewFixture, DeleteRestoresSnapshotAndListCallbacksAreOwnedAndReentrant) {
+  ASSERT_TRUE(engine->Put("restore", ParamValue(std::int64_t{4}).Encode()));
+  node->Stop();
+  ASSERT_TRUE(node->Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  ASSERT_TRUE(node->CreateSession("s1").IsOk());
+  PublishValue("restore", ParamValue(std::int64_t{8}));
+  auto view = SessionView::Open(*node, "s1");
+  ASSERT_TRUE(view.IsOk());
+  PublishDelete("restore");
+  EXPECT_EQ(view.Value().Get<std::int64_t>("restore").Value(), 4);
+
+  PublishValue("a", ParamValue(std::int64_t{1}));
+  PublishValue("b", ParamValue(std::int64_t{2}));
+  int callbacks = 0;
+  auto listed = view.Value().List("", [&](std::string_view key, const ParamValue&) {
+    ++callbacks;
+    EXPECT_TRUE(view.Value().Contains(key).IsOk());
+    return false;
+  });
+  EXPECT_TRUE(listed.IsOk());
+  EXPECT_EQ(callbacks, 1);
+}
+
+TEST_F(SessionViewFixture, ListFalseAndExceptionHaveCallerThreadSemantics) {
+  PublishValue("entry", ParamValue(std::int64_t{1}));
+  auto view = SessionView::Open(*node, "s1");
+  ASSERT_TRUE(view.IsOk());
+  std::thread::id callback_thread;
+  auto listed = view.Value().List("", [&](std::string_view, const ParamValue&) {
+    callback_thread = std::this_thread::get_id();
+    return false;
+  });
+  EXPECT_TRUE(listed.IsOk());
+  EXPECT_EQ(callback_thread, std::this_thread::get_id());
+  EXPECT_THROW(view.Value().List("", [&](std::string_view, const ParamValue&) -> bool {
+    throw std::runtime_error("sink failure");
+  }), std::runtime_error);
+}
+
+TEST(SessionViewTest, MalformedSnapshotIsErrorAndHiddenSnapshotIsNotDecoded) {
+  TestTransport transport;
+  auto engine = std::make_shared<InMemoryEngine>();
+  const std::vector<std::byte> malformed{std::byte{0xff}};
+  ASSERT_TRUE(engine->Put("bad", malformed));
+  ASSERT_TRUE(engine->Put("hidden", malformed));
+  StorageNode node(transport);
+  ASSERT_TRUE(node.Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+  auto view = SessionView::Open(node, "s1");
+  ASSERT_TRUE(view.IsOk());
+  EXPECT_EQ(view.Value().Get("bad").StatusCode(), Status::Error);
+  transport.Publish("sitos/session/s1/hidden", ParamValue(std::int64_t{3}).Encode(),
+                    Encoding{std::string(Encoding::kSitosV1)});
+  EXPECT_EQ(view.Value().Get<std::int64_t>("hidden").Value(), 3);
+}
+
+TEST(SessionViewTest, MoveAndInvalidArgumentsAreDeterministic) {
+  TestTransport transport;
+  StorageNode node(transport);
+  auto engine = std::make_shared<InMemoryEngine>();
+  ASSERT_TRUE(node.Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+  auto source = SessionView::Open(node, "s1");
+  ASSERT_TRUE(source.IsOk());
+  SessionView moved(std::move(source).Value());
+  EXPECT_EQ(source.Value().Get("key").StatusCode(), Status::InvalidArgument);
+  SessionView assigned = std::move(moved);
+  EXPECT_EQ(moved.Get("key").StatusCode(), Status::InvalidArgument);
+  assigned = std::move(assigned);
+  EXPECT_EQ(assigned.Get("key").StatusCode(), Status::NotFound);
+}
+
+TEST_F(SessionViewFixture, ClosedAndRecreatedSessionExpiresOldView) {
+  auto view = SessionView::Open(*node, "s1");
+  ASSERT_TRUE(view.IsOk());
+  ASSERT_TRUE(node->CloseSession("s1").IsOk());
+  EXPECT_EQ(view.Value().Get("key").StatusCode(), Status::NotFound);
+  ASSERT_TRUE(node->CreateSession("s1").IsOk());
+  EXPECT_EQ(view.Value().Get("key").StatusCode(), Status::NotFound);
+}
+
+TEST(SessionViewTest, OpenRejectsInvalidAndUnknownSession) {
+  TestTransport transport;
+  StorageNode node(transport);
+  auto engine = std::make_shared<InMemoryEngine>();
+  EXPECT_TRUE(node.Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  EXPECT_EQ(SessionView::Open(node, "bad/id").StatusCode(), Status::InvalidKey);
+  EXPECT_EQ(SessionView::Open(node, "missing").StatusCode(), Status::NotFound);
+  node.Stop();
+  EXPECT_EQ(SessionView::Open(node, "s1").StatusCode(), Status::Disconnected);
+}
+
+TEST(SessionViewTest, OutlivesNodeWithoutRetainingState) {
+  TestTransport transport;
+  auto engine = std::make_shared<InMemoryEngine>();
+  auto view = [&] {
+    auto node = std::make_unique<StorageNode>(transport);
+    EXPECT_TRUE(node->Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+    EXPECT_TRUE(node->CreateSession("s1").IsOk());
+    return SessionView::Open(*node, "s1");
+  }();
+  ASSERT_TRUE(view.IsOk());
+  EXPECT_EQ(view.Value().Get("key").StatusCode(), Status::Disconnected);
+}
+
+}  // namespace
+}  // namespace sitos

--- a/tests/unit/session_view_test.cpp
+++ b/tests/unit/session_view_test.cpp
@@ -394,6 +394,7 @@ TEST_F(SessionViewFixture, ClosedAndRecreatedSessionExpiresOldView) {
   ASSERT_TRUE(node->CloseSession("s1").IsOk());
   EXPECT_EQ(view.Value().Get("key").StatusCode(), Status::NotFound);
   ASSERT_TRUE(node->CreateSession("s1").IsOk());
+  PublishValue("key", ParamValue(std::int64_t{9}));
   EXPECT_EQ(view.Value().Get("key").StatusCode(), Status::NotFound);
 }
 

--- a/tests/unit/session_view_test.cpp
+++ b/tests/unit/session_view_test.cpp
@@ -99,6 +99,11 @@ class TestTransport final : public Transport {
   std::function<void(TransportQuery&)> queryable;
 };
 
+void AssignToSelf(SessionView& view) {
+  auto* alias = &view;
+  view = std::move(*alias);
+}
+
 class SessionViewFixture : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -262,7 +267,7 @@ TEST(SessionViewTest, MoveAndInvalidArgumentsAreDeterministic) {
   EXPECT_EQ(source.Value().Get("key").StatusCode(), Status::InvalidArgument);
   SessionView assigned = std::move(moved);
   EXPECT_EQ(moved.Get("key").StatusCode(), Status::InvalidArgument);
-  assigned = std::move(assigned);
+  AssignToSelf(assigned);
   EXPECT_EQ(assigned.Get("key").StatusCode(), Status::NotFound);
 }
 

--- a/tests/unit/session_view_test.cpp
+++ b/tests/unit/session_view_test.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <barrier>
 #include <chrono>
 #include <condition_variable>
 #include <functional>
@@ -103,6 +104,100 @@ void AssignToSelf(SessionView& view) {
   auto* alias = &view;
   view = std::move(*alias);
 }
+
+struct BlockingReadControl {
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool entered = false;
+  bool released = false;
+
+  void Enter() {
+    std::unique_lock lock(mutex);
+    entered = true;
+    cv.notify_all();
+    cv.wait(lock, [this] { return released; });
+  }
+
+  void WaitUntilEntered() {
+    std::unique_lock lock(mutex);
+    cv.wait(lock, [this] { return entered; });
+  }
+
+  void Release() {
+    {
+      std::scoped_lock lock(mutex);
+      released = true;
+    }
+    cv.notify_all();
+  }
+};
+
+class BlockingSnapshotReader final : public StorageReader {
+ public:
+  BlockingSnapshotReader(std::shared_ptr<const StorageReader> inner,
+                         std::shared_ptr<BlockingReadControl> control)
+      : inner_(std::move(inner)), control_(std::move(control)) {}
+
+  bool Get(std::string_view key, const EntrySink& sink) const override {
+    control_->Enter();
+    return inner_->Get(key, sink);
+  }
+
+  bool List(std::string_view prefix, const EntrySink& sink) const override {
+    return inner_->List(prefix, sink);
+  }
+
+ private:
+  std::shared_ptr<const StorageReader> inner_;
+  std::shared_ptr<BlockingReadControl> control_;
+};
+
+class BlockingSnapshotEngine final : public InMemoryEngine {
+ public:
+  explicit BlockingSnapshotEngine(std::shared_ptr<BlockingReadControl> control)
+      : control_(std::move(control)) {}
+
+  std::shared_ptr<const StorageReader> TakeSnapshot() const override {
+    return std::make_shared<BlockingSnapshotReader>(InMemoryEngine::TakeSnapshot(), control_);
+  }
+
+ private:
+  std::shared_ptr<BlockingReadControl> control_;
+};
+
+class TrackingSnapshotReader final : public StorageReader {
+ public:
+  TrackingSnapshotReader(std::shared_ptr<const StorageReader> inner,
+                         std::shared_ptr<int> token)
+      : inner_(std::move(inner)), token_(std::move(token)) {}
+
+  bool Get(std::string_view key, const EntrySink& sink) const override {
+    return inner_->Get(key, sink);
+  }
+
+  bool List(std::string_view prefix, const EntrySink& sink) const override {
+    return inner_->List(prefix, sink);
+  }
+
+ private:
+  std::shared_ptr<const StorageReader> inner_;
+  std::shared_ptr<int> token_;
+};
+
+class TrackingSnapshotEngine final : public InMemoryEngine {
+ public:
+  std::shared_ptr<const StorageReader> TakeSnapshot() const override {
+    auto token = std::make_shared<int>(0);
+    snapshot_token_ = token;
+    return std::make_shared<TrackingSnapshotReader>(InMemoryEngine::TakeSnapshot(),
+                                                    std::move(token));
+  }
+
+  std::weak_ptr<int> SnapshotToken() const { return snapshot_token_; }
+
+ private:
+  mutable std::weak_ptr<int> snapshot_token_;
+};
 
 class SessionViewFixture : public ::testing::Test {
  protected:
@@ -294,6 +389,7 @@ TEST(SessionViewTest, OpenRejectsInvalidAndUnknownSession) {
 TEST(SessionViewTest, OutlivesNodeWithoutRetainingState) {
   TestTransport transport;
   auto engine = std::make_shared<InMemoryEngine>();
+  std::weak_ptr<InMemoryEngine> weak_engine = engine;
   auto view = [&] {
     auto node = std::make_unique<StorageNode>(transport);
     EXPECT_TRUE(node->Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
@@ -301,7 +397,134 @@ TEST(SessionViewTest, OutlivesNodeWithoutRetainingState) {
     return SessionView::Open(*node, "s1");
   }();
   ASSERT_TRUE(view.IsOk());
+  engine.reset();
+  EXPECT_TRUE(weak_engine.expired());
   EXPECT_EQ(view.Value().Get("key").StatusCode(), Status::Disconnected);
+}
+
+TEST(SessionViewTest, ListReleasesSnapshotBeforeSink) {
+  TestTransport transport;
+  auto engine = std::make_shared<TrackingSnapshotEngine>();
+  ASSERT_TRUE(engine->Put("key", ParamValue(std::int64_t{1}).Encode()));
+  StorageNode node(transport);
+  ASSERT_TRUE(node.Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+  auto snapshot_token = engine->SnapshotToken();
+  auto view = SessionView::Open(node, "s1");
+  ASSERT_TRUE(view.IsOk());
+  ASSERT_FALSE(snapshot_token.expired());
+  auto listed = view.Value().List("", [&](std::string_view, const ParamValue&) {
+    auto close = node.CloseSession("s1");
+    EXPECT_TRUE(close.IsOk());
+    EXPECT_TRUE(snapshot_token.expired());
+    return true;
+  });
+  EXPECT_TRUE(listed.IsOk());
+}
+
+TEST(SessionViewTest, CapturedReadCompletesAcrossClose) {
+  TestTransport transport;
+  auto control = std::make_shared<BlockingReadControl>();
+  auto engine = std::make_shared<BlockingSnapshotEngine>(control);
+  ASSERT_TRUE(engine->Put("key", ParamValue(std::int64_t{1}).Encode()));
+  StorageNode node(transport);
+  ASSERT_TRUE(node.Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+  auto view = SessionView::Open(node, "s1");
+  ASSERT_TRUE(view.IsOk());
+
+  Result<ParamValue> read = Result<ParamValue>::Err(Status::Error, "not started");
+  std::thread reader([&] { read = view.Value().Get("key"); });
+  control->WaitUntilEntered();
+  ASSERT_TRUE(node.CloseSession("s1").IsOk());
+  EXPECT_EQ(view.Value().Get("key").StatusCode(), Status::NotFound);
+  control->Release();
+  reader.join();
+  ASSERT_TRUE(read.IsOk());
+  auto value = read.Value().As<std::int64_t>();
+  ASSERT_TRUE(value.has_value());
+  EXPECT_EQ(*value, 1);
+}
+
+TEST(SessionViewTest, StopWaitsForCapturedReadAndClosesAdmission) {
+  TestTransport transport;
+  auto control = std::make_shared<BlockingReadControl>();
+  auto engine = std::make_shared<BlockingSnapshotEngine>(control);
+  ASSERT_TRUE(engine->Put("key", ParamValue(std::int64_t{1}).Encode()));
+  StorageNode node(transport);
+  ASSERT_TRUE(node.Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+  auto view = SessionView::Open(node, "s1");
+  ASSERT_TRUE(view.IsOk());
+  const auto quick_payload = ParamValue(std::int64_t{2}).Encode();
+  transport.Publish("sitos/session/s1/quick", quick_payload,
+                    Encoding{std::string(Encoding::kSitosV1)});
+
+  std::thread reader([&] { EXPECT_TRUE(view.Value().Get("key").IsOk()); });
+  control->WaitUntilEntered();
+  std::atomic<bool> stop_started = false;
+  std::thread stopper([&] {
+    stop_started = true;
+    node.Stop();
+  });
+  while (!stop_started.load()) std::this_thread::yield();
+  while (view.Value().Get("quick").StatusCode() != Status::Disconnected) {
+    std::this_thread::yield();
+  }
+  control->Release();
+  reader.join();
+  stopper.join();
+}
+
+TEST(SessionViewTest, ConcurrentReadsAndOverlayWritesAreSynchronized) {
+  TestTransport transport;
+  auto engine = std::make_shared<InMemoryEngine>();
+  StorageNode node(transport);
+  ASSERT_TRUE(node.Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+  auto view = SessionView::Open(node, "s1");
+  ASSERT_TRUE(view.IsOk());
+  std::barrier start(3);
+  std::atomic<bool> failed = false;
+  auto reader = [&] {
+    start.arrive_and_wait();
+    for (int i = 0; i < 200; ++i) {
+      auto result = view.Value().Get("key");
+      if (!result.IsOk() && result.StatusCode() != Status::NotFound) failed = true;
+      auto listed = view.Value().List("", [](std::string_view, const ParamValue&) { return true; });
+      if (!listed.IsOk()) failed = true;
+    }
+  };
+  std::thread get_reader(reader);
+  std::thread list_reader(reader);
+  start.arrive_and_wait();
+  for (int i = 0; i < 200; ++i) {
+    auto payload = ParamValue(std::int64_t{i}).Encode();
+    transport.Publish("sitos/session/s1/key", payload,
+                      Encoding{std::string(Encoding::kSitosV1)});
+  }
+  get_reader.join();
+  list_reader.join();
+  EXPECT_FALSE(failed.load());
+}
+
+TEST(SessionViewTest, ListRejectsMalformedNonShadowedSnapshot) {
+  TestTransport transport;
+  auto engine = std::make_shared<InMemoryEngine>();
+  ASSERT_TRUE(engine->Put("valid", ParamValue(std::int64_t{1}).Encode()));
+  ASSERT_TRUE(engine->Put("bad", std::vector<std::byte>{std::byte{0xff}}));
+  StorageNode node(transport);
+  ASSERT_TRUE(node.Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+  auto view = SessionView::Open(node, "s1");
+  ASSERT_TRUE(view.IsOk());
+  int callbacks = 0;
+  auto listed = view.Value().List("", [&](std::string_view, const ParamValue&) {
+    ++callbacks;
+    return true;
+  });
+  EXPECT_EQ(listed.StatusCode(), Status::Error);
+  EXPECT_EQ(callbacks, 0);
 }
 
 }  // namespace

--- a/tests/unit/session_view_test.cpp
+++ b/tests/unit/session_view_test.cpp
@@ -260,16 +260,18 @@ TEST_F(SessionViewFixture, ListMergesRawPrefixAndSorts) {
 }
 
 TEST_F(SessionViewFixture, MalformedOverlayDoesNotFallbackAndListDoesNotPartiallyCallback) {
-  ASSERT_TRUE(engine->Put("bad", ParamValue(std::int64_t{1}).Encode()));
+  ASSERT_TRUE(engine->Put("hidden", std::vector<std::byte>{std::byte{0xff}}));
   node->Stop();
   ASSERT_TRUE(node->Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
   ASSERT_TRUE(node->CreateSession("s1").IsOk());
   const std::vector<std::byte> malformed{std::byte{0xff}};
-  transport.Publish("sitos/session/s1/bad", malformed,
+  PublishValue("aaa-valid", ParamValue(std::int64_t{1}));
+  PublishValue("hidden", ParamValue(std::int64_t{2}));
+  transport.Publish("sitos/session/s1/zzz-malformed", malformed,
                     Encoding{std::string(Encoding::kSitosV1)});
   auto view = SessionView::Open(*node, "s1");
   ASSERT_TRUE(view.IsOk());
-  EXPECT_EQ(view.Value().Get("bad").StatusCode(), Status::Error);
+  EXPECT_EQ(view.Value().Get<std::int64_t>("hidden").Value(), 2);
   int callbacks = 0;
   EXPECT_EQ(view.Value().List("", [&](std::string_view, const ParamValue&) {
     ++callbacks;
@@ -348,6 +350,26 @@ TEST(SessionViewTest, MalformedSnapshotIsErrorAndHiddenSnapshotIsNotDecoded) {
   transport.Publish("sitos/session/s1/hidden", ParamValue(std::int64_t{3}).Encode(),
                     Encoding{std::string(Encoding::kSitosV1)});
   EXPECT_EQ(view.Value().Get<std::int64_t>("hidden").Value(), 3);
+}
+
+TEST(SessionViewTest, ValidOverlayHidesMalformedSnapshotDuringList) {
+  TestTransport transport;
+  auto engine = std::make_shared<InMemoryEngine>();
+  ASSERT_TRUE(engine->Put("shared", std::vector<std::byte>{std::byte{0xff}}));
+  StorageNode node(transport);
+  ASSERT_TRUE(node.Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+  const auto overlay = ParamValue(std::int64_t{7}).Encode();
+  transport.Publish("sitos/session/s1/shared", overlay, Encoding{std::string(Encoding::kSitosV1)});
+  auto view = SessionView::Open(node, "s1");
+  ASSERT_TRUE(view.IsOk());
+  std::vector<std::string> keys;
+  EXPECT_TRUE(view.Value().List("", [&](std::string_view key, const ParamValue& value) {
+    keys.emplace_back(key);
+    EXPECT_EQ(value.As<std::int64_t>(), std::optional<std::int64_t>{7});
+    return true;
+  }).IsOk());
+  EXPECT_EQ(keys, (std::vector<std::string>{"shared"}));
 }
 
 TEST(SessionViewTest, MoveAndInvalidArgumentsAreDeterministic) {
@@ -463,17 +485,21 @@ TEST(SessionViewTest, StopWaitsForCapturedReadAndClosesAdmission) {
   std::thread reader([&] { EXPECT_TRUE(view.Value().Get("key").IsOk()); });
   control->WaitUntilEntered();
   std::atomic<bool> stop_started = false;
+  std::atomic<bool> stop_returned = false;
   std::thread stopper([&] {
     stop_started = true;
     node.Stop();
+    stop_returned = true;
   });
   while (!stop_started.load()) std::this_thread::yield();
   while (view.Value().Get("quick").StatusCode() != Status::Disconnected) {
     std::this_thread::yield();
   }
+  EXPECT_FALSE(stop_returned.load());
   control->Release();
   reader.join();
   stopper.join();
+  EXPECT_TRUE(stop_returned.load());
 }
 
 TEST(SessionViewTest, ConcurrentReadsAndOverlayWritesAreSynchronized) {
@@ -511,8 +537,8 @@ TEST(SessionViewTest, ConcurrentReadsAndOverlayWritesAreSynchronized) {
 TEST(SessionViewTest, ListRejectsMalformedNonShadowedSnapshot) {
   TestTransport transport;
   auto engine = std::make_shared<InMemoryEngine>();
-  ASSERT_TRUE(engine->Put("valid", ParamValue(std::int64_t{1}).Encode()));
-  ASSERT_TRUE(engine->Put("bad", std::vector<std::byte>{std::byte{0xff}}));
+  ASSERT_TRUE(engine->Put("aaa-valid", ParamValue(std::int64_t{1}).Encode()));
+  ASSERT_TRUE(engine->Put("zzz-malformed", std::vector<std::byte>{std::byte{0xff}}));
   StorageNode node(transport);
   ASSERT_TRUE(node.Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
   ASSERT_TRUE(node.CreateSession("s1").IsOk());
@@ -525,6 +551,142 @@ TEST(SessionViewTest, ListRejectsMalformedNonShadowedSnapshot) {
   });
   EXPECT_EQ(listed.StatusCode(), Status::Error);
   EXPECT_EQ(callbacks, 0);
+}
+
+TEST_F(SessionViewFixture, ListRawPrefixMatrixUsesOverlayPriorityAndLexicalOrder) {
+  ASSERT_TRUE(engine->Put("foo", ParamValue(std::int64_t{1}).Encode()));
+  ASSERT_TRUE(engine->Put("foo/bar", ParamValue(std::int64_t{2}).Encode()));
+  ASSERT_TRUE(engine->Put("foo/bar/baz", ParamValue(std::int64_t{3}).Encode()));
+  ASSERT_TRUE(engine->Put("foobar", ParamValue(std::int64_t{4}).Encode()));
+  ASSERT_TRUE(engine->Put("unrelated", ParamValue(std::int64_t{5}).Encode()));
+  node->Stop();
+  ASSERT_TRUE(node->Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  ASSERT_TRUE(node->CreateSession("s1").IsOk());
+  PublishValue("foo", ParamValue(std::int64_t{10}));
+  PublishValue("foo/bar", ParamValue(std::int64_t{20}));
+  PublishValue("foo/qux", ParamValue(std::int64_t{30}));
+  auto view = SessionView::Open(*node, "s1");
+  ASSERT_TRUE(view.IsOk());
+
+  const auto collect = [&](std::string_view prefix) {
+    std::vector<std::pair<std::string, std::int64_t>> entries;
+    auto listed = view.Value().List(prefix, [&](std::string_view key, const ParamValue& value) {
+      const auto number = value.As<std::int64_t>();
+      EXPECT_TRUE(number.has_value());
+      entries.emplace_back(key, *number);
+      return true;
+    });
+    EXPECT_TRUE(listed.IsOk());
+    return entries;
+  };
+
+  EXPECT_EQ(collect(""), (std::vector<std::pair<std::string, std::int64_t>>{
+                             {"foo", 10}, {"foo/bar", 20}, {"foo/bar/baz", 3},
+                             {"foo/qux", 30}, {"foobar", 4}, {"unrelated", 5}}));
+  EXPECT_EQ(collect("foo"), (std::vector<std::pair<std::string, std::int64_t>>{
+                                {"foo", 10}, {"foo/bar", 20}, {"foo/bar/baz", 3},
+                                {"foo/qux", 30}, {"foobar", 4}}));
+  EXPECT_EQ(collect("foo/"), (std::vector<std::pair<std::string, std::int64_t>>{
+                                 {"foo/bar", 20}, {"foo/bar/baz", 3}, {"foo/qux", 30}}));
+  EXPECT_EQ(collect("foo/bar"), (std::vector<std::pair<std::string, std::int64_t>>{
+                                    {"foo/bar", 20}, {"foo/bar/baz", 3}}));
+  EXPECT_EQ(collect("foobar"),
+            (std::vector<std::pair<std::string, std::int64_t>>{{"foobar", 4}}));
+
+  int callbacks = 0;
+  EXPECT_TRUE(view.Value().List("foo", [&](std::string_view key, const ParamValue&) {
+    ++callbacks;
+    EXPECT_EQ(key, "foo");
+    return false;
+  }).IsOk());
+  EXPECT_EQ(callbacks, 1);
+}
+
+TEST_F(SessionViewFixture, ContainsPreservesSessionLifecycleNotFound) {
+  auto view = SessionView::Open(*node, "s1");
+  ASSERT_TRUE(view.IsOk());
+  EXPECT_FALSE(view.Value().Contains("missing").Value());
+  ASSERT_TRUE(node->CloseSession("s1").IsOk());
+  EXPECT_EQ(view.Value().Contains("missing").StatusCode(), Status::NotFound);
+  ASSERT_TRUE(node->CreateSession("s1").IsOk());
+  EXPECT_EQ(view.Value().Contains("missing").StatusCode(), Status::NotFound);
+}
+
+TEST_F(SessionViewFixture, NullSinkAndMovedFromOperationsHaveInvalidArgumentPrecedence) {
+  auto opened = SessionView::Open(*node, "s1");
+  ASSERT_TRUE(opened.IsOk());
+  SessionView source = std::move(opened).Value();
+  SessionView moved(std::move(source));
+
+  EXPECT_EQ(source.Get("bad/key").StatusCode(), Status::InvalidArgument);
+  EXPECT_EQ(source.Get<std::int64_t>("bad/key").StatusCode(), Status::InvalidArgument);
+  EXPECT_EQ(source.GetOr<std::int64_t>("bad/key", 1).StatusCode(), Status::InvalidArgument);
+  EXPECT_EQ(source.Contains("bad/key").StatusCode(), Status::InvalidArgument);
+  EXPECT_EQ(source.List("bad//prefix", {}).StatusCode(), Status::InvalidArgument);
+  EXPECT_EQ(moved.List("", {}).StatusCode(), Status::InvalidArgument);
+
+  auto destination_result = SessionView::Open(*node, "s1");
+  ASSERT_TRUE(destination_result.IsOk());
+  SessionView destination = std::move(destination_result).Value();
+  destination = std::move(moved);
+  EXPECT_EQ(moved.Get("key").StatusCode(), Status::InvalidArgument);
+  EXPECT_EQ(destination.Get("missing").StatusCode(), Status::NotFound);
+  AssignToSelf(destination);
+  EXPECT_EQ(destination.Get("missing").StatusCode(), Status::NotFound);
+}
+
+TEST(SessionViewTest, OpenRacingStopHasOnlyAdmissibleOutcomes) {
+  TestTransport transport;
+  auto engine = std::make_shared<InMemoryEngine>();
+  StorageNode node(transport);
+  ASSERT_TRUE(node.Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+  std::barrier start(3);
+  Result<SessionView> opened = Result<SessionView>::Err(Status::Error, "not started");
+  std::thread opener([&] {
+    start.arrive_and_wait();
+    opened = SessionView::Open(node, "s1");
+  });
+  std::thread stopper([&] {
+    start.arrive_and_wait();
+    node.Stop();
+  });
+  start.arrive_and_wait();
+  opener.join();
+  stopper.join();
+  EXPECT_TRUE(opened.IsOk() || opened.StatusCode() == Status::Disconnected);
+  if (opened.IsOk()) {
+    EXPECT_EQ(opened.Value().Get("key").StatusCode(), Status::Disconnected);
+  }
+}
+
+TEST(SessionViewTest, ConcurrentReaderAndSessionReplacementHaveSafeOutcomes) {
+  TestTransport transport;
+  auto engine = std::make_shared<InMemoryEngine>();
+  StorageNode node(transport);
+  ASSERT_TRUE(node.Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+  auto view = SessionView::Open(node, "s1");
+  ASSERT_TRUE(view.IsOk());
+  std::barrier start(2);
+  std::atomic<bool> failed = false;
+  std::thread reader([&] {
+    start.arrive_and_wait();
+    for (int i = 0; i < 200; ++i) {
+      const auto get = view.Value().Get("key");
+      if (!get.IsOk() && get.StatusCode() != Status::NotFound) failed = true;
+      const auto list = view.Value().List("", [](std::string_view, const ParamValue&) {
+        return true;
+      });
+      if (!list.IsOk() && list.StatusCode() != Status::NotFound) failed = true;
+    }
+  });
+  start.arrive_and_wait();
+  ASSERT_TRUE(node.CloseSession("s1").IsOk());
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+  reader.join();
+  EXPECT_FALSE(failed.load());
+  EXPECT_EQ(view.Value().Get("key").StatusCode(), Status::NotFound);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Closes #21

This PR implements the host-process `SessionView` facade as a move-only, read-only composite view
that resolves one active session overlay before its immutable snapshot. It does not use Transport,
retain StorageNode/session resources between operations, or expose writes and zero-copy cache APIs.

## Scope checklist

- [x] `SessionView::Open(const StorageNode&, sid)` returns `Result<SessionView>`.
- [x] Move-only lifecycle with self-move-safe assignment and moved-from errors.
- [x] Owned `Get`, typed `Get`, `GetOr`, `Contains`, and materialized lexical `List`.
- [x] Overlay-first resolution with absence-only snapshot fallback.
- [x] Malformed selected overlay/snapshot payloads fail closed with `Status::Error`.
- [x] Weak node-State ownership and weak overlay owner identity for session generations.
- [x] Lifecycle-safe Stop, CloseSession, same-sid recreation, and node-destruction behavior.
- [x] List callbacks run after internal gate/session/engine synchronization is released.
- [x] Public umbrella, direct header, installed package, and write/API absence coverage.
- [x] Synchronized same-native-session Zenoh comparison with ParamCache.
- [x] ADR-0025 added as Proposed; acceptance is a pre-merge step.
- [x] Large image/compute-artifact scope remains in disk-backed `buffers/<sid>/**` (ADR-0014).

## Requirement disposition

- F07: satisfied by overlay-over-snapshot SessionView reads.
- F05/F06/F10/N07: satisfied through existing snapshot, overlay, lifecycle, and engine contracts.
- N01/zero-copy cache reads: unchanged and remain ParamCache responsibilities.
- Wire protocol, Transport completion, ParamStore, ParamCache, and buffer/image behavior: unchanged.
- Python implementation: deferred to Issue #25; only the Python API plan was corrected.

## TDD evidence and process disposition

The initial public-header RED was genuinely observed before the implementation existed in commit
`ebc26da`. From the Windows MSVC DevShell, the following command failed because
`sitos/session_view.hpp` was absent:

```text
cmake --build build-21-red --target sitos_session_view_test -- -j 4
```

Representative failure:

```text
fatal error C1083: include file cannot be opened: 'sitos/session_view.hpp': No such file or directory
ninja: build stopped: subcommand failed.
```

No history was rewritten to manufacture that evidence. The lifecycle, malformed-List, prefix,
move-precedence, and concurrent replacement regressions in `10cca3d` and `548e352` were added
following implementation during review; they are not represented as pre-implementation RED
artifacts. Owner disposition (2026-07-20): the owner accepts this review-driven test-order deviation.
The initial public API RED was genuine, while additional lifecycle and concurrency
regressions were added after implementation in response to independent review. No history
was rewritten and no retrospective RED evidence was fabricated.

## Implementation commits

- `ebc26da` test(view): define SessionView acceptance coverage (#21)
- `47ce5d2` feat(view): add read-only SessionView (#21)
- `7f66b6e` docs(view): document SessionView contract (#21)
- `8e8940a` fix(view): consolidate SessionView read acquisition (#21)
- `9746a6a` refactor(view): share list prefix validation (#21)
- `43db868` refactor(api): share typed value conversion helpers (#21)
- `632f888` refactor(api): use shared SessionView conversion helper (#21)
- `ce25f56` docs(view): clarify SessionView thread safety (#21)
- `10cca3d` fix(view): release readers and harden lifecycle tests (#21)
- `f71d7ea` docs(ci): cover SessionView lifecycle validation (#21)
- `72459c8` fix(view): preserve lifecycle read errors (#21)
- `548e352` test(view): harden lifecycle contracts (#21)
- `8354387` test(view): reject replacement overlay access (#21)
- `e3d24ea` test(view): synchronize subscriber integration (#21)
- `218a4cc` docs(adr): accept SessionView consistency decision (#21)

## Validation

Windows/MSVC, Zenoh OFF (`build-verify-off`):

- Full suite: 275/275 passed.
- Focused SessionView suite: 22/22 passed.
- Seven deterministic lifecycle/concurrency/prefix/move tests passed in 10 consecutive runs.

Windows/MSVC, Zenoh ON (`C:/Users/tetet/gw/sitos.tmp/build-on`):

- Full suite at the preceding production head: 322/322 passed.
- The synchronized SessionView integration test passed 10/10 at the current head after waiting for
  both node-side and cache-side subscriber application.
- This uses the approved build-on directory and the established one-session integration setup.

Linux/GCC 13.3, Zenoh OFF:

- Focused SessionView suite: 22/22 passed with TSan (`setarch x86_64 -R`).
- Focused SessionView suite: 22/22 passed with ASan/UBSan.

Package and public headers:

- Windows installed-package validation passed, including the direct SessionView header consumer.
- `git diff --check` passed.
- The sanitizer CI regex explicitly includes `SessionViewTest|SessionViewFixture`.

The updated exact head is `218a4cc95a89edf89ebcc55585e639cfe8450e0f`. Exact-head GitHub Actions, CodeQL, SonarCloud, package, sanitizer, isolation, and CodeRabbit checks are the final automated validation gate.

## ADR and acceptance gate

ADR-0025 is **Accepted — 2026-07-20** following final independent review and explicit owner approval.

## Residual risks

- SessionView materializes/copies parameter payloads by design; it is not a zero-copy image API.
- Large images and compute artifacts require the disk-backed buffer work in Issue #56 and HTTP
delivery in Issue #57.
- Cross-operation transactions and reader-visible batch isolation remain outside this issue.
- A view has no strong ownership of the opaque private overlay. Semantic close/recreate tests prove
it cannot access a replacement overlay; directly observing private overlay destruction would require
a forbidden public test seam or StorageNode API expansion.
- The 11 current SonarCloud findings have been judged unnecessary and remain unchanged pending the
post-fix scan and individual Accepted dispositions.







