### PR TITLE
[ADR] docs(roadmap): align v0.5 and retire gateway (#109)

### DIFF
--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -187,9 +187,10 @@ so `CloseSession` never invalidates an in-flight reply.
 
 ### 4.4 Transport Integration Pseudocode
 
-The `MetaAck` and `ack_token` lines below are planned Issue #14 branches, not current Transport
-APIs. Their token attachment and timeout semantics remain blocked on the decisions recorded in
-`docs/03_wire_protocol.md` §6; implementers must not treat the pseudocode as a finalized wire API.
+`PutOptions::ack` and `TransportSample::ack_token` already exist in the Transport API. The
+`MetaAck` route and their end-to-end attachment, token, batch-outcome, UUID, and timeout semantics
+remain planned Issue #14 work, as recorded in `docs/03_wire_protocol.md` §6. Implementers must not
+treat the pseudocode as finalized acknowledgement behavior.
 
 Pseudocode for implementers. StorageNode does not use the raw zenoh-c API directly;
 it goes through the `Transport` abstraction ([09_dependency_policy.md](09_dependency_policy.md) §3).

--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -187,6 +187,10 @@ so `CloseSession` never invalidates an in-flight reply.
 
 ### 4.4 Transport Integration Pseudocode
 
+The `MetaAck` and `ack_token` lines below are planned Issue #14 branches, not current Transport
+APIs. Their token attachment and timeout semantics remain blocked on the decisions recorded in
+`docs/03_wire_protocol.md` §6; implementers must not treat the pseudocode as a finalized wire API.
+
 Pseudocode for implementers. StorageNode does not use the raw zenoh-c API directly;
 it goes through the `Transport` abstraction ([09_dependency_policy.md](09_dependency_policy.md) §3).
 

--- a/docs/03_wire_protocol.md
+++ b/docs/03_wire_protocol.md
@@ -203,15 +203,17 @@ Repeated N times thereafter:
 
 ## 6. ack protocol (Put completion confirmation)
 
-> **Planned, not yet normative:** Issues #14 and #17 own this protocol. Before implementation,
-> #14 must define the canonical token attachment API and representation, UUID grammar, batch
-> outcome, and the ambiguous-timeout contract. No implementation may infer those details from this
+> **Planned, not yet normative:** `PutOptions::ack` and `TransportSample::ack_token` already
+> provide the Transport-level acknowledgement surface. Before implementation, Issue #14 must
+> finalize how that surface creates and attaches a caller-visible token, together with its
+> representation, UUID grammar, batch outcome, and ambiguous-timeout contract. Issue #17 owns the
+> ParamStore policy layered on that contract. No implementation may infer missing details from this
 > outline or introduce a second acknowledgement format.
 
 The planned behavior is one data submission followed by bounded polling:
 
-1. The client generates one acknowledgement token and attaches it through the canonical Transport
-   API selected by #14.
+1. The client requests acknowledgement through `PutOptions::ack`; the finalized #14 semantics
+   generate one caller-visible token and attach it through the Transport adapter.
 2. After completing the apply, StorageNode keeps a completion record in a ring buffer containing
    the most recent 4096 entries, so it can answer `<prefix>/meta/ack/<uuid>` queries.
 3. The client polls `<prefix>/meta/ack/<uuid>` with a 1-second query window for up to three

--- a/docs/03_wire_protocol.md
+++ b/docs/03_wire_protocol.md
@@ -203,16 +203,23 @@ Repeated N times thereafter:
 
 ## 6. ack protocol (Put completion confirmation)
 
-A Put with `PutOptions::ack = true` follows this procedure:
+> **Planned, not yet normative:** Issues #14 and #17 own this protocol. Before implementation,
+> #14 must define the canonical token attachment API and representation, UUID grammar, batch
+> outcome, and the ambiguous-timeout contract. No implementation may infer those details from this
+> outline or introduce a second acknowledgement format.
 
-1. The client generates an ack token (UUID) corresponding to the beginning of the put payload and
-   attaches `ack=<uuid>` to the zenoh put `attachment`
-2. After completing the apply, StorageNode keeps a completion record in a ring buffer (most recent
-   4096 entries) so it can respond to get on `<prefix>/meta/ack/<uuid>`
-3. After the put, the client performs `get("<prefix>/meta/ack/<uuid>")`; if there is a reply,
-   completion is confirmed. On timeout (default 1 s), it retries up to 3 times
+The planned behavior is one data submission followed by bounded polling:
 
-Clients that do not support attachment are treated as ack-less put clients (compatible behavior).
+1. The client generates one acknowledgement token and attaches it through the canonical Transport
+   API selected by #14.
+2. After completing the apply, StorageNode keeps a completion record in a ring buffer containing
+   the most recent 4096 entries, so it can answer `<prefix>/meta/ack/<uuid>` queries.
+3. The client polls `<prefix>/meta/ack/<uuid>` with a 1-second query window for up to three
+   attempts. It retries only the acknowledgement query and never resubmits the data write.
+
+Clients that do not attach a token remain ack-less. Exhausted polling reports Timeout, which may
+mean that the write was applied but its bounded acknowledgement record was absent or evicted; #14
+must finalize how callers observe that ambiguity.
 
 ## 7. meta keys
 

--- a/docs/05_api_python.md
+++ b/docs/05_api_python.md
@@ -65,17 +65,18 @@ exists = store.contains("base", "recon/fov")
 for key, value in store.list("base", "recon"):   # generator
     ...
 
-sub = store.subscribe("base", "recon/**", callback=lambda key, value: ...)
-sub.close()          # Or: with store.subscribe(...) as sub:
 store.close()        # Supports context manager (__enter__/__exit__)
 ```
 
 * Errors: misses do not return `None`; they raise `sitos.NotFoundError`, or
   `get(..., default=...)` returns the default value. Communication loss raises `sitos.DisconnectedError`
-* callback is called from a dedicated dispatch thread ([02] §8).
-  Long-running work inside the callback delays other notifications (warn about this in the documentation)
+* Python ParamStore subscriptions are deferred to Issue #26, which owns the dedicated
+  callback-dispatch thread and GIL/lifecycle contract. Issue #23 exposes no provisional callback path
 
 ### 2.2 ParamCache
+
+ParamCache is session-only under ADR-0022. It has no `attach_base` API. The initial Python binding
+in Issue #24 also omits stale/reconnect state, which remains Issue #20 scope.
 
 ```python
 cache = sitos.ParamCache(prefix="sitos")
@@ -90,7 +91,6 @@ assert lut.flags.writeable is False
 cache.put("recon/progress", 0.5)      # Write to overlay + distribute
 cache.contains("recon/fov")
 dict(cache.items("recon"))            # Enumerate within cache (no communication)
-cache.stale                           # True while disconnected
 cache.detach(); cache.close()
 ```
 

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -6,8 +6,7 @@
 sitos/
   CMakeLists.txt              # Top level. Options: SITOS_WITH_ROCKSDB,
                               #   SITOS_BUILD_PYTHON, SITOS_BUILD_TESTS, SITOS_BUILD_EXAMPLES,
-                              #   SITOS_BUILD_BENCHMARKS, SITOS_ENABLE_TSAN, SITOS_ENABLE_ASAN_UBSAN,
-                              #   SITOS_BUILD_GATEWAY (optional HTTP gateway, ADR-0015)
+                              #   SITOS_BUILD_BENCHMARKS, SITOS_ENABLE_TSAN, SITOS_ENABLE_ASAN_UBSAN
   cmake/                      # zenoh-c integration (FetchContent/Corrosion/find_package)
   include/sitos/              # Public headers (API from 04_api_cpp.md)
   src/                        # Implementation
@@ -43,8 +42,6 @@ sitos/
     Also provide a Corrosion (Rust) path for environments that need source builds
   - **RocksDB** (when `SITOS_WITH_ROCKSDB=ON`): `find_package(RocksDB)`.
     Supplied by vcpkg / apt / brew
-  - **cpp-httplib** (when `SITOS_BUILD_GATEWAY=ON`): header-only, MIT. Pulled only
-    for the optional `sitos-gateway` component; the core build is unaffected when OFF [ADR-0015]
   - **gtest / benchmark**: FetchContent
 * Presets: define `dev-windows`, `dev-linux`, `release`, and `python-wheel` in
   `CMakePresets.json`

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -279,7 +279,8 @@ so it is not a v0.2 blocker. Include it by v0.5.
 * References: ADR-0014, [02] §7, [10] §6
 * Implementation targets: StorageNode durable-session catalog, startup recovery, and
   crash/restart integration tests
-* Scope: retain and recover durable buffer sessions without making ephemeral sessions restartable
+* Scope: retain and recover durable buffer sessions without making ephemeral sessions restartable.
+  Retention is not a storage-wide write barrier; host applications enforce external write policy
 * Acceptance criteria: durable recovery, ephemeral exclusion, explicit close non-resurrection,
   missing/corrupt storage handling, and concurrent startup/close safety
 * Depends on: #8, #12, #56, #105; requires an Accepted ADR before merge

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -19,10 +19,11 @@ Milestone = release boundary).
 | **v0.2** | StorageNode/ParamStore/ParamCache work in C++ through same-process zenoh sessions | #2, #3, #9–#13, #15, #18, #19, #21 |
 | **v0.3** | Basic Python APIs work (InMemory, ParamStore, ParamCache, NumPy read) | #16, #22, #23, #24, #25, #27 |
 | **v0.4** | RocksDB, single-value interop, bench, examples, and session-scoped buffers are in place | #8, #29, #31, #32, #33, #56 |
-| **v1.0** | Public OSS quality. docs/release/wheels/ack/batch interop/GIL/custom engine and the optional HTTP gateway completed | #14, #17, #20, #26, #28, #30, #34, #35, #57 |
+| **v0.5** | Reliable and durable session-buffer delivery is ready for downstream application integration | #14, #17, #99, #105–#109 |
+| **v1.0** | Public OSS quality, reconnect recovery, advanced Python extensions, raw batch/ack interop, documentation, and publication readiness are complete | #20, #26, #28, #30, #34, #35 |
 
 `ack`-related work (#14, #17) is useful, but implementation is heavy relative to initial value,
-so it is not a v0.2 blocker. Include it by v1.0.
+so it is not a v0.2 blocker. Include it by v0.5.
 
 ---
 
@@ -124,6 +125,17 @@ so it is not a v0.2 blocker. Include it by v1.0.
   TakeSnapshot execution time does not depend on data size (bench)
 * Depends on: #6
 
+### #105 StorageEngine durability barrier
+* Milestone: v0.5
+* References: [02] §3, [04] §3, [10] §6
+* Implementation targets: `include/sitos/storage_engine.hpp`, InMemory/RocksDB engine sources,
+  reusable contract tests, and RocksDB integration tests
+* Scope: define an explicit storage synchronization boundary for writes completed before its
+  linearization point; keep ordinary Put operations unsynchronized
+* Acceptance criteria: InMemory no-op, RocksDB durability and injected-failure tests, concurrent
+  linearization coverage, and clear applied/persisted/synchronized documentation
+* Depends on: #8; requires an Accepted ADR before merge
+
 ---
 
 ## M2: StorageNode and zenoh integration (critical path)
@@ -185,14 +197,15 @@ so it is not a v0.2 blocker. Include it by v1.0.
 * Depends on: #11, #12
 
 ### #14 ack protocol
-* Milestone: v1.0
+* Milestone: v0.5
 * References: [03] §6, [02] §6.2
 * Implementation targets: `include/sitos/ack.hpp`, `src/ack.cpp`, `src/storage_node.cpp`,
   `tests/integration/ack_test.cpp`
-* Scope: ack ring buffer and `meta/ack/<uuid>` queryable, client retry
-* Acceptance criteria: integration tests — ack round-trip, retry on ack timeout,
-  put without attachment is treated as ack-less
-* Depends on: #11
+* Scope: ack ring buffer and `meta/ack/<uuid>` queryable plus one-submit/multiple-poll helper;
+  implementation is blocked until token attachment, batch outcome, and ambiguous Timeout are defined
+* Acceptance criteria: integration tests — ack round-trip, query-only retry, ring eviction, malformed
+  token rejection, and ack-less compatibility
+* Depends on: #11, #85, #86
 
 ### #15 ParamStore: Put/Get/List/Delete
 * Milestone: v0.2
@@ -215,13 +228,24 @@ so it is not a v0.2 blocker. Include it by v1.0.
 * Depends on: #15
 
 ### #17 ParamStore: ack/error mapping
-* Milestone: v1.0
+* Milestone: v0.5
 * References: [03] §6, [04] §2
 * Implementation targets: `include/sitos/status.hpp`, `src/param_store.cpp`,
   `tests/integration/param_store_ack_test.cpp`
 * Scope: PutOptions::ack, ack timeout/retry, detailed Status mapping
 * Acceptance criteria: integration tests — ack success/failure/timeout, Disconnected/Timeout when StorageNode is stopped
 * Depends on: #14, #15
+
+### #106 Shared same-publisher fence primitive
+* Milestone: v0.5
+* References: [02] §8, [03] §6, [10] §6
+* Implementation targets: Transport/StorageNode internal control routing and deterministic
+  fake-Transport plus Zenoh integration tests
+* Scope: define one reusable in-band token and publisher-identity ordering primitive shared by
+  ParamCache local-delivery waits and buffer-application fences
+* Acceptance criteria: prior/later write ordering, publisher isolation, duplicate/late marker
+  handling, timeout, error preservation, and callback-quiescent lifecycle tests
+* Depends on: #14; requires an Accepted ADR before merge
 
 ### #56 Session-scoped buffers
 * Milestone: v0.4
@@ -237,6 +261,28 @@ so it is not a v0.2 blocker. Include it by v1.0.
   `kEphemeral` no-store/no-get; `CloseSession` purge → not-found; ParamCache scope isolation
   (`session/**` never receives `buffers/**`); raw-zenoh interop
 * Depends on: #12 (session management), #8 (RocksDBEngine, disk-backed `kDurable`)
+
+### #107 BufferPublisher applied and synchronized fences
+* Milestone: v0.5
+* References: ADR-0014, [02] §8, [04]
+* Implementation targets: C++ BufferPublisher API and deterministic/integration tests over
+  `buffers/<sid>/**`; Python binding remains pending the Issue's owner decision
+* Scope: explicit application-controlled `Push` plus applied or synchronized `Fence`; no automatic
+  per-value fence or application-specific manifest policy; Python parity remains an owner decision
+  because advanced Python extension surfaces are assigned to v1.0
+* Acceptance criteria: applied and synchronized receipts, failure and timeout propagation,
+  publisher isolation, restart behavior, and C++ coverage; add Python coverage only if retained
+* Depends on: #56, #105, #106
+
+### #108 Restart-safe retained-session catalog
+* Milestone: v0.5
+* References: ADR-0014, [02] §7, [10] §6
+* Implementation targets: StorageNode durable-session catalog, startup recovery, and
+  crash/restart integration tests
+* Scope: retain and recover durable buffer sessions without making ephemeral sessions restartable
+* Acceptance criteria: durable recovery, ephemeral exclusion, explicit close non-resurrection,
+  missing/corrupt storage handling, and concurrent startup/close safety
+* Depends on: #8, #12, #56, #105; requires an Accepted ADR before merge
 
 ---
 
@@ -287,9 +333,21 @@ so it is not a v0.2 blocker. Include it by v1.0.
 * References: [02] §9, [01] N10
 * Implementation targets: `src/param_cache.cpp`,
   `tests/integration/reconnect_test.cpp`
-* Scope: stale flag, zenoh reconnect detection, automatic refetch
-* Acceptance criteria: integration — ParamCache recovers across StorageNode restart
-* Depends on: #18
+* Scope: stale flag, approved liveness detection, and automatic refetch; the Issue remains blocked
+  until its failure model and Transport signal are defined
+* Acceptance criteria: integration — ParamCache recovers across the approved restart/failure model
+* Depends on: #19
+
+### #99 ParamCache local-delivery fence
+* Milestone: v0.5
+* References: [02] §5, [04] §4
+* Implementation targets: `include/sitos/param_cache.hpp`, `src/param_cache.cpp`, and deterministic
+  fake-Transport plus Zenoh integration tests
+* Scope: expose `WaitForLocalDelivery(timeout)` using the shared same-publisher fence primitive;
+  wait only for the initiating cache subscriber, not peers or StorageNode acknowledgements
+* Acceptance criteria: prior local writes observed, later writes excluded, timeout/error mapping,
+  concurrent waiter isolation, and Detach/move/destruction quiescence
+* Depends on: #19, #106
 
 ### #21 SessionView (host-process facade)
 * Milestone: v0.2
@@ -324,27 +382,32 @@ so it is not a v0.2 blocker. Include it by v1.0.
 * References: [05] §2.1
 * Implementation targets: `python/bindings/param_store.cpp`, `python/sitos/store.py`,
   `tests/python/test_param_store.py`
-* Scope: Python binding for ParamStore, context manager, exception mapping
-* Acceptance criteria: pytest — Put/Get/List/Delete/Subscribe round-trip
-* Depends on: #15, #16, #22
+* Scope: non-callback Python binding for ParamStore, context manager, and exception mapping;
+  Subscribe belongs to #26 and acknowledgement options belong to #17
+* Acceptance criteria: pytest — Put/Get/List/Delete/Contains round-trip and deterministic close
+* Depends on: #15, #22
 
 ### #24 Python ParamCache
 * Milestone: v0.3
-* References: [05] §2.2
+* References: [05] §2.2, ADR-0022, ADR-0023
 * Implementation targets: `python/bindings/param_cache.cpp`, `python/sitos/cache.py`,
   `tests/python/test_param_cache.py`
-* Scope: Python binding for ParamCache, attach/detach, stale, items
-* Acceptance criteria: pytest — attach/delta-subscription scenarios equivalent to C++ ParamCache
-* Depends on: #18, #22
+* Scope: session-only Python binding for ParamCache reads/writes and attach/detach; no AttachBase or
+  stale/reconnect surface
+* Acceptance criteria: pytest — attach/concurrent-delta and peer-propagation scenarios equivalent
+  to the C++ ParamCache contract
+* Depends on: #19, #22
 
 ### #25 Python StorageNode / SessionView
 * Milestone: v0.3
-* References: [05] §2.3–2.4
+* References: [05] §2.3–2.4, ADR-0025
 * Implementation targets: `python/bindings/storage_node.cpp`, `python/bindings/session_view.cpp`,
   `python/sitos/node.py`, `tests/python/test_storage_node.py`
-* Scope: Python bindings for StorageNode, InMemoryEngine, SessionView
-* Acceptance criteria: pytest — create_session/close_session, session_view overlay→snapshot resolution
-* Depends on: #12, #21, #22
+* Scope: Python bindings for StorageNode, InMemoryEngine, and read-only SessionView; implementation
+  is blocked until a supported pure-Python process/session topology is selected
+* Acceptance criteria: pytest — create_session/close_session, read-only SessionView
+  overlay-over-snapshot resolution, and deterministic cross-component synchronization
+* Depends on: #21, #22, #23, #24
 
 ### #26 Python callback / GIL dispatch
 * Milestone: v1.0
@@ -363,7 +426,7 @@ so it is not a v0.2 blocker. Include it by v1.0.
 * Scope: `get_array(dtype)` (buffer protocol, writeable=False, keepalive),
   ndarray put, `.pyi` stubs
 * Acceptance criteria: pytest — verify base-buffer identity (no copy), mypy green
-* Depends on: #24
+* Depends on: #23, #24, #25
 
 ### #28 Python custom engine
 * Milestone: v1.0
@@ -439,36 +502,31 @@ so it is not a v0.2 blocker. Include it by v1.0.
 * Acceptance criteria: All checklist items completed, dry-run publish to TestPyPI succeeds
 * Depends on: M4 completed, #34
 
----
-
-## M6: Optional HTTP gateway (optional component)
-
-### #57 Optional HTTP gateway component
-* Milestone: v1.0 (earliest v0.4)
-* References: ADR-0015, ADR-0003, ADR-0007, ADR-0014, [09]
-* Implementation targets: `sitos-gateway` library + thin binary (cpp-httplib),
-  CMake option `SITOS_BUILD_GATEWAY` (default OFF)
-* Scope: params/sessions/buffers routes typed over `sitos.v1`; SSE session deltas;
-  loopback-default bind + pluggable auth; `Router` extension point for host routes.
-  Core build unaffected when the option is OFF (cpp-httplib not fetched)
-* Acceptance criteria: OFF build unaffected; typed param round-trip; prefix List;
-  buffer GET (durable) / not-found (ephemeral); SSE observable with `curl -N`;
-  host route served on the same port; loopback-default + auth hook invoked
-* Depends on: #15/#16 (ParamStore), #18/#19 (ParamCache), #12 (sessions), #56 (buffers)
+### #109 Align the roadmap and retire the optional HTTP gateway
+* Milestone: v0.5
+* References: ADR-0015, ADR-0027, [06], [10]
+* Implementation targets: ADR index and release/build/issue-breakdown documentation
+* Scope: record host ownership of HTTP control planes, supersede ADR-0015 without rewriting its
+  history, remove the planned gateway build surface, and align the v0.5 roadmap with GitHub
+* Acceptance criteria: ADR-0027 is Accepted, live documentation has no planned sitos gateway, and
+  the release boundaries and dependencies match the GitHub issues and milestones
+* Depends on: none
 
 ---
 
 ## Recommended implementation order (parallel lanes)
 
 ```
-Lane A (core):      #1 → #4 → #6 → #7 → #8
-Lane B (zenoh):     #2 → #3 → #9 → #10 → #11 → #12 → #18 → #19/#20
-                                            ├→ #13 → #15/#16
-                                            ├→ #14 → #17 (also needs #15)
-                                            └→ #56 (also needs #8 from Lane A)
-Lane C (Python):    #22 (any time after #4) → #23/#24/#25 → #26 → #27/#28
-Lane D (quality):   #29/#30, #31/#32, #33, #34/#35 (as dependencies complete)
-Lane E (optional):  #57 HTTP gateway (after #56, #16, #19; see M6)
+Lane A (core):       #1 → #4 → #6 → #7 → #8 → #105
+Lane B (zenoh):      #2 → #3 → #9 → #10 → #11 → #12 → #18 → #19/#20
+                                             ├→ #13 → #15/#16
+                                             ├→ #14 → #17
+                                             │       └→ #106 → #99
+                                             └→ #56 → #107/#108
+Lane C (Python):     #22 (any time after #4) → #23/#24/#25 → #27
+                     Advanced callbacks/engines: #26/#28 (v1.0)
+Lane D (quality):    #29/#30, #31/#32, #33, #34/#35 (as dependencies complete)
+Lane E (roadmap):    #109 first; host applications own HTTP control planes under ADR-0027
 ```
 
 Each Issue is assumed to correspond to one PR. The PR must describe the corresponding requirement IDs

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -517,7 +517,7 @@ so it is not a v0.2 blocker. Include it by v0.5.
 
 ## Recommended implementation order (parallel lanes)
 
-```
+```text
 Lane A (core):       #1 → #4 → #6 → #7 → #8 → #105
 Lane B (zenoh):      #2 → #3 → #9 → #10 → #11 → #12 → #18 → #19/#20
                                              ├→ #13 → #15/#16

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -265,14 +265,15 @@ so it is not a v0.2 blocker. Include it by v0.5.
 ### #107 BufferPublisher applied and synchronized fences
 * Milestone: v0.5
 * References: ADR-0014, [02] §8, [04]
-* Implementation targets: C++ BufferPublisher API and deterministic/integration tests over
-  `buffers/<sid>/**`; Python binding remains pending the Issue's owner decision
+* Implementation targets: C++ and Python BufferPublisher APIs plus deterministic/integration tests
+  over `buffers/<sid>/**`
 * Scope: explicit application-controlled `Push` plus applied or synchronized `Fence`; no automatic
-  per-value fence or application-specific manifest policy; Python parity remains an owner decision
-  because advanced Python extension surfaces are assigned to v1.0
+  per-value fence or application-specific manifest policy; Python parity is mandatory v0.5 scope
+  because Python Holoscan/CuPy Workers require the same terminal manifest-and-fence sequence
 * Acceptance criteria: applied and synchronized receipts, failure and timeout propagation,
-  publisher isolation, restart behavior, and C++ coverage; add Python coverage only if retained
-* Depends on: #56, #105, #106
+  publisher isolation, restart behavior, C++/Python API parity, contiguous NumPy input, and payload
+  lifetime safety
+* Depends on: #27, #56, #105, #106
 
 ### #108 Restart-safe retained-session catalog
 * Milestone: v0.5

--- a/docs/adr/0014-session-scoped-buffers.md
+++ b/docs/adr/0014-session-scoped-buffers.md
@@ -5,7 +5,7 @@
 Accepted — 2026-07-09
 
 > **Current HTTP boundary proposal:** Issue #57 closed the planned sitos-owned gateway as
-> not planned. ADR-0027 proposes that host applications provide any HTTP facade over the native
+> not planned. ADR-0027 assigns any HTTP facade over the native
 > sitos APIs; the gateway reference below is retained as historical context.
 
 ## Context

--- a/docs/adr/0014-session-scoped-buffers.md
+++ b/docs/adr/0014-session-scoped-buffers.md
@@ -4,6 +4,10 @@
 
 Accepted — 2026-07-09
 
+> **Current HTTP boundary proposal:** Issue #57 closed the planned sitos-owned gateway as
+> not planned. ADR-0027 proposes that host applications provide any HTTP facade over the native
+> sitos APIs; the gateway reference below is retained as historical context.
+
 ## Context
 
 Some workloads need to move **large binary values** (from hundreds of kilobytes

--- a/docs/adr/0015-optional-http-gateway-component.md
+++ b/docs/adr/0015-optional-http-gateway-component.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted — 2026-07-09
+Superseded by ADR-0027 — 2026-07-21
 
 ## Context
 

--- a/docs/adr/0020-synchronously-complete-transport-get.md
+++ b/docs/adr/0020-synchronously-complete-transport-get.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed — 2026-07-16
+Accepted — 2026-07-17
 
 ## Context
 

--- a/docs/adr/0021-resolve-installed-zenoh-dependency.md
+++ b/docs/adr/0021-resolve-installed-zenoh-dependency.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed — 2026-07-18
+Accepted — 2026-07-18
 
 ## Context
 

--- a/docs/adr/0027-keep-http-control-planes-in-host-applications.md
+++ b/docs/adr/0027-keep-http-control-planes-in-host-applications.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed — 2026-07-21
+Accepted — 2026-07-21
 
 ## Context
 
@@ -52,5 +52,5 @@ as a separate package or repository.
 * Issue #109
 * Issue #57 and its
   [architecture-decision timeline comment](https://github.com/tetsuh/sitos/issues/57#issuecomment-5024834430)
-* Proposed replacement for: ADR-0015
+* Supersedes: ADR-0015
 * Related: ADR-0014

--- a/docs/adr/0027-keep-http-control-planes-in-host-applications.md
+++ b/docs/adr/0027-keep-http-control-planes-in-host-applications.md
@@ -17,7 +17,8 @@ without an identified production consumer.
 
 We will not ship `sitos-gateway` or the `SITOS_BUILD_GATEWAY` build option.
 Host applications and orchestrators will provide HTTP control planes by calling
-the native sitos APIs; sitometron is the initial host implementation. Any future
+the native sitos APIs; sitometron, the external host orchestrator application,
+is the initial host implementation. Any future
 standalone gateway requires concrete demand and a new ADR and may be delivered
 as a separate package or repository.
 
@@ -51,5 +52,5 @@ as a separate package or repository.
 * Issue #109
 * Issue #57 and its
   [architecture-decision timeline comment](https://github.com/tetsuh/sitos/issues/57#issuecomment-5024834430)
-* Supersedes: ADR-0015
+* Proposed replacement for: ADR-0015
 * Related: ADR-0014

--- a/docs/adr/0027-keep-http-control-planes-in-host-applications.md
+++ b/docs/adr/0027-keep-http-control-planes-in-host-applications.md
@@ -1,0 +1,55 @@
+# ADR-0027: Keep HTTP control planes in host applications
+
+## Status
+
+Proposed — 2026-07-21
+
+## Context
+
+sitos was previously expected to ship an optional HTTP gateway under ADR-0015.
+The initial production integration instead has a host orchestrator that already
+owns HTTP routing, authorization, access policy, audit, and lifecycle control.
+A second sitos-owned HTTP surface would duplicate those responsibilities and
+create an independent security, dependency, CI, and compatibility boundary
+without an identified production consumer.
+
+## Decision
+
+We will not ship `sitos-gateway` or the `SITOS_BUILD_GATEWAY` build option.
+Host applications and orchestrators will provide HTTP control planes by calling
+the native sitos APIs; sitometron is the initial host implementation. Any future
+standalone gateway requires concrete demand and a new ADR and may be delivered
+as a separate package or repository.
+
+## Consequences
+
+* Good: sitos remains focused on its Zenoh-based parameter, session, and buffer
+  data plane.
+* Good: host authorization, audit, and lifecycle policy cannot be bypassed by a
+  parallel sitos-owned HTTP surface.
+* Good: cpp-httplib and gateway-specific build, security, and compatibility
+  maintenance are removed from the planned sitos scope.
+* Neutral: hosts that need HTTP access must provide a facade over the native
+  C++ or Python APIs.
+* Neutral: native APIs, Zenoh tooling, and the `sitobolon` development
+  executable remain available for inspection and integration.
+* Trade-off: sitos does not provide a standalone browser or `curl` endpoint.
+
+## Options Considered
+
+* **Keep the optional in-repository gateway from ADR-0015** — rejected because
+  it duplicates the host control plane and has no identified production
+  consumer.
+* **Ship only a standalone gateway process** — rejected because it still adds a
+  second policy and maintenance boundary.
+* **Let host applications own HTTP and reconsider a separate package later** —
+  selected because it keeps policy in one place and preserves a future option
+  when concrete demand exists.
+
+## References
+
+* Issue #109
+* Issue #57 and its
+  [architecture-decision timeline comment](https://github.com/tetsuh/sitos/issues/57#issuecomment-5024834430)
+* Supersedes: ADR-0015
+* Related: ADR-0014

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,7 +19,7 @@ See [docs/10_adr_process.md](../10_adr_process.md) for the process.
 | [0012](0012-google-cpp-style-with-100-column-limit.md) | Google C++ style with 100-column limit |
 | [0013](0013-default-to-zenoh-scouting-with-explicit-endpoint-override.md) | Default to zenoh scouting with explicit endpoint override |
 | [0014](0014-session-scoped-buffers.md) | Add a session-scoped, disk-backed buffers key space |
-| [0015](0015-optional-http-gateway-component.md) | Ship an optional HTTP gateway component on cpp-httplib |
+| [0015](0015-optional-http-gateway-component.md) | Ship an optional HTTP gateway component on cpp-httplib *(superseded by ADR-0027)* |
 | [0016](0016-use-canonical-zenoh-bytes-encodings.md) | Use canonical zenoh bytes encodings |
 | [0017](0017-atomic-storage-node-lifecycle.md) | Use atomic, quiescent StorageNode lifecycle transitions |
 | [0018](0018-use-zenoh-valid-batch-key-segment.md) | Use a zenoh-valid batch key segment |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,3 +30,5 @@ See [docs/10_adr_process.md](../10_adr_process.md) for the process.
 | [0023](0023-param-cache-consistency-and-lifetime.md) | Define ParamCache consistency and lifetime boundary |
 | [0024](0024-opt-in-google-benchmark-build-boundary.md) | Keep Google Benchmark opt-in and outside installed packages |
 | [0025](0025-session-view-lifetime-and-composite-read-consistency.md) | Define SessionView lifetime and composite-read consistency |
+| [0026](0026-python-wheel-build-and-native-runtime.md) | Define the Python wheel build and bundled native-runtime boundary |
+| [0027](0027-keep-http-control-planes-in-host-applications.md) | Keep HTTP control planes in host applications |


### PR DESCRIPTION
## Summary

- add Proposed ADR-0027 to keep HTTP control planes in host applications
- retire the planned `sitos-gateway`, `SITOS_BUILD_GATEWAY`, and cpp-httplib build surface
- add the v0.5 release boundary and Issues #99/#105–#109 to the documented roadmap
- align remaining Python, acknowledgement, reconnect, fence, durability, and catalog issue contracts
- register ADR-0026 and correct stale merge-time statuses for ADR-0020 and ADR-0021

Closes #109

## Architecture decision

- [x] ADR required: ADR-0027 supersedes ADR-0015 after owner acceptance
- [x] ADR-0027 accepted with owner approval in 6768777
- [x] ADR-0015 marked Superseded by ADR-0027 without rewriting its historical decision

## Acceptance verification

- [x] ADR-0027 uses the next available number after ADR-0026
- [x] ADR index includes ADR-0026 and ADR-0027
- [x] v0.5 contains #14, #17, #99, and #105–#109
- [x] #57 and the optional gateway lane are absent from required v1.0 work
- [x] live build and roadmap docs no longer plan `sitos-gateway`, `SITOS_BUILD_GATEWAY`, or cpp-httplib
- [x] Python wheel documentation remains aligned with Issue #22 / ADR-0026
- [x] Issue #57 decision provenance is linked from ADR-0027
- [x] relative Markdown links resolve after excluding fenced code examples
- [x] `git diff --check` passes
- [x] secret scan passes

## Review disposition

- [x] CodeRabbit: all three inline findings fixed in 6c03a36, individually answered, and resolved
- [x] Fable: Approve; undefined host terminology fixed and M5 placement retained with rationale
- [x] final owner gate: ADR-0027 accepted and ADR-0015 superseded in 6768777

## RED / TDD

This is documentation and roadmap work, which is exempt from production-code TDD under
`docs/development_workflow.md` §3. The pre-change consistency audit correctly found the stale v1.0
gateway requirement, missing v0.5 boundary, missing ADR-0026 index entry, stale ADR-0020/0021
statuses, and planned gateway build option. No behavioral RED evidence is claimed.

## Related Wave 0 administration

Outside the repository diff, the v0.2 milestone was closed after all 23 assigned Issues were
complete, and the blocking contracts in Issues #14, #20, #23–#25, #30, #56, #99, and #105–#108
were aligned or explicitly marked as requiring a decision before implementation.


