### PR TITLE
docs(roadmap): define catalog corruption policy (#108)

### DIFF
--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -283,8 +283,9 @@ so it is not a v0.2 blocker. Include it by v0.5.
 * Scope: retain and recover durable buffer sessions without making ephemeral sessions restartable.
   Retention is not a storage-wide write barrier; host applications enforce external write policy.
   Catalog corruption fails closed: sitos returns a typed catalog-unavailable error and refuses
-  catalog-dependent reads and mutations; v0.5 provides no partial service, repair, or in-process
-  recovery. The host latches readiness false and performs offline recovery
+  catalog-dependent reads and mutations; v0.5 provides no partial service and performs no
+  automatic or in-process repair or recovery. The host latches readiness false; recovery requires
+  offline maintenance and restart
 * Acceptance criteria: durable recovery, ephemeral exclusion, explicit close non-resurrection,
   degraded fail-closed handling of missing or corrupt storage, and concurrent startup/close safety
 * Depends on: #8, #12, #56, #105; requires an Accepted ADR before merge

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -281,9 +281,10 @@ so it is not a v0.2 blocker. Include it by v0.5.
 * Implementation targets: StorageNode durable-session catalog, startup recovery, and
   crash/restart integration tests
 * Scope: retain and recover durable buffer sessions without making ephemeral sessions restartable.
-  Retention is not a storage-wide write barrier; host applications enforce external write policy
+  Retention is not a storage-wide write barrier; host applications enforce external write policy.
+  Catalog corruption globally latches readiness false; v0.5 provides no partial service or repair
 * Acceptance criteria: durable recovery, ephemeral exclusion, explicit close non-resurrection,
-  missing/corrupt storage handling, and concurrent startup/close safety
+  degraded fail-closed handling of corrupt storage, and concurrent startup/close safety
 * Depends on: #8, #12, #56, #105; requires an Accepted ADR before merge
 
 ---

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -282,9 +282,11 @@ so it is not a v0.2 blocker. Include it by v0.5.
   crash/restart integration tests
 * Scope: retain and recover durable buffer sessions without making ephemeral sessions restartable.
   Retention is not a storage-wide write barrier; host applications enforce external write policy.
-  Catalog corruption globally latches readiness false; v0.5 provides no partial service or repair
+  Catalog corruption fails closed: sitos returns a typed catalog-unavailable error and refuses
+  catalog-dependent reads and mutations; v0.5 provides no partial service, repair, or in-process
+  recovery. The host latches readiness false and performs offline recovery
 * Acceptance criteria: durable recovery, ephemeral exclusion, explicit close non-resurrection,
-  degraded fail-closed handling of corrupt storage, and concurrent startup/close safety
+  degraded fail-closed handling of missing or corrupt storage, and concurrent startup/close safety
 * Depends on: #8, #12, #56, #105; requires an Accepted ADR before merge
 
 ---


### PR DESCRIPTION
## Summary

- record the selected global degraded fail-closed policy for durable Session Catalog corruption
- state that readiness remains false and v0.5 provides no partial service or automatic repair
- align the roadmap entry with the updated Issue #108 contract

## Context

This is a documentation follow-up to merged PR #110. The detailed decision and acceptance criteria are recorded in Issue #108.

Related to #108

## Verification

- `git diff --check` passes
- documentation-only change; no production-code tests required