### PR TITLE
feat(python): bind session ParamCache (#24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,15 +86,20 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug
           cmake --build build/python --parallel 2
 
-      - name: Run Python ParamStore tests
+      - name: Run Python client tests
         run: |
           extension="$(find build/python -maxdepth 1 -name '_sitos*.so' -print -quit)"
           test -n "$extension"
           cp "$extension" python/sitos/
           export LD_LIBRARY_PATH="$PWD/build/python/_deps/zenohc-src/lib:${LD_LIBRARY_PATH:-}"
           export PYTHONPATH="$PWD/python"
+          export SITOS_PYTHON_CACHE_FIXTURE="$PWD/build/python/tests/sitos_python_param_cache_fixture"
           export SITOS_PYTHON_FIXTURE="$PWD/build/python/tests/sitos_python_param_store_fixture"
-          python3 -m pytest tests/python/test_param_store.py -q
+          python3 -m pytest \
+            tests/python/test_param_value.py \
+            tests/python/test_param_store.py \
+            tests/python/test_param_cache.py \
+            tests/python/test_param_cache_live.py -q
           rm -f python/sitos/_sitos*.so
 
   lifecycle-sanitizers:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,9 @@ endif()
 
 if(SITOS_BUILD_PYTHON)
   nanobind_add_module(_sitos MODULE
+    python/bindings/client_binding.cpp
     python/bindings/module.cpp
+    python/bindings/param_cache.cpp
     python/bindings/param_store.cpp
     python/bindings/param_value_conversion.cpp)
   target_link_libraries(_sitos PRIVATE sitos::sitos)
@@ -137,6 +139,7 @@ if(SITOS_BUILD_PYTHON)
     ARCHIVE DESTINATION sitos COMPONENT python)
   install(FILES
     python/sitos/__init__.py
+    python/sitos/cache.py
     python/sitos/store.py
     DESTINATION sitos COMPONENT python)
 endif()

--- a/docs/05_api_python.md
+++ b/docs/05_api_python.md
@@ -101,8 +101,10 @@ with sitos.ParamCache(prefix="sitos", zenoh_config_json=None,
 `put_batch` accepts either a Mapping in iteration order or an iterable of two-item pairs. Pair
 iterables preserve order and duplicate keys; every entry is materialized and validated before one
 canonical `:batch` submission. Successful non-empty writes submit first and then immediately apply
-to the initiating cache. Peer delivery is asynchronous, and success is not an Issue #99 delivery
-barrier. Empty batches succeed without submission.
+to the initiating cache. For duplicate keys, the last value serialized through each cache's local
+sequencing path wins independently in the initiating cache and asynchronously updated peers. There
+is no global publisher order or self-echo deduplication. Peer delivery is asynchronous, and success
+is not an Issue #99 delivery barrier. Empty batches succeed without submission.
 
 Reads and `items` are cache-local and perform no wire request. `items` uses raw-prefix matching,
 lexical ordering, and returns an iterator over an eager owned snapshot that remains usable after
@@ -172,9 +174,10 @@ class MyEngine(sitos.StorageEngine):
 * In a StorageNode that uses a Python engine (§2.3), zenoh threads call into Python,
   so GIL acquisition occurs. State explicitly that C++ engines are recommended for production use
 
-## 4. Type Stubs and Documentation
+## 4. Future Type Stubs and Documentation
 
-* Include type stubs under `sitos/*.pyi` and verify them with mypy/pyright
+* Issue #27 will add type stubs under `sitos/*.pyi` and verify them with mypy/pyright; type stubs are
+  not part of the current Issue #24 release
 * docstrings must match the content of the C++ Doxygen comments
 * Include an interoperability example in README for “talking to sitos with zenoh-python only” [C03]:
 

--- a/docs/05_api_python.md
+++ b/docs/05_api_python.md
@@ -14,11 +14,12 @@ pythonic layer [P01].
 | S64 | `int` | `int` (`OverflowError` if outside the 64-bit range) |
 | DP | `float` | `float` |
 | STR | `str` | `str` |
-| BYTES | `bytes` / `numpy.ndarray` (when dtype is specified) | `bytes`, `bytearray`, `memoryview`, C-contiguous `numpy.ndarray` |
+| BYTES | `bytes` | `bytes` |
 
-* Put of `numpy.ndarray` performs one copy through the buffer protocol (during encoding)
-* dtype/shape metadata is not included in the v1 payload ([03] §2.1).
-  The reader specifies the dtype
+Issue #27 will add buffer-protocol and NumPy conversion, zero-copy array reads, and type stubs.
+Until then, the public conversion, ParamStore, and ParamCache APIs reject `bytearray`, `memoryview`,
+NumPy arrays, general buffer objects, sequences, and arbitrary conversion protocols. Payload v1 does
+not carry dtype or shape metadata ([03] §2.1); the future reader API will supply that information.
 
 ## 2. API
 
@@ -79,24 +80,42 @@ Subscriptions and acknowledgements remain outside Issue #23.
 
 ### 2.2 ParamCache
 
-ParamCache is session-only under ADR-0022. It has no `attach_base` API. The initial Python binding
-in Issue #24 also omits stale/reconnect state, which remains Issue #20 scope.
+Issue #24 provides a non-callback, session-only Python facade over C++ ParamCache under ADR-0022 and
+ADR-0023. Each instance opens and owns its Transport/session from `zenoh_config_json`; it has no
+`attach_base` or raw Transport-injection API. `query_timeout_ms` is a positive integer used by the
+initial snapshot and overlay fetches.
 
 ```python
-cache = sitos.ParamCache(prefix="sitos")
-cache.attach(sid)                     # Fetch snapshot + overlay
-
-fov  = cache.get("recon/fov", default=240.0)
-lut  = cache.get_array("recon/bhc/lut", dtype="float32")   # -> numpy.ndarray
-# get_array is zero-copy [P02]: a read-only ndarray pointing to the internal buffer.
-# While the ndarray is alive, the underlying buffer is not released (keepalive).
-assert lut.flags.writeable is False
-
-cache.put("recon/progress", 0.5)      # Write to overlay + distribute
-cache.contains("recon/fov")
-dict(cache.items("recon"))            # Enumerate within cache (no communication)
-cache.detach(); cache.close()
+with sitos.ParamCache(prefix="sitos", zenoh_config_json=None,
+                      query_timeout_ms=5000) as cache:
+    cache.attach(sid)                              # Fetch snapshot + overlay
+    fov = cache.get("recon/fov", default=240.0)
+    count = cache.get("recon/count", type=int)    # C05 numeric conversion
+    cache.put("recon/progress", 0.5)
+    cache.put_batch([("recon/a", 1), ("recon/a", 2)])
+    exists = cache.contains("recon/fov")
+    rows = list(cache.items("recon"))             # Eager owned local snapshot
+    cache.detach()                                 # Re-attach remains possible
 ```
+
+`put_batch` accepts either a Mapping in iteration order or an iterable of two-item pairs. Pair
+iterables preserve order and duplicate keys; every entry is materialized and validated before one
+canonical `:batch` submission. Successful non-empty writes submit first and then immediately apply
+to the initiating cache. Peer delivery is asynchronous, and success is not an Issue #99 delivery
+barrier. Empty batches succeed without submission.
+
+Reads and `items` are cache-local and perform no wire request. `items` uses raw-prefix matching,
+lexical ordering, and returns an iterator over an eager owned snapshot that remains usable after
+detach or close. Missing values, typed conversion, and Status exceptions use the same contract and
+exception classes as ParamStore.
+
+`detach` is idempotent and native-quiescent while leaving the object reusable. `close` is idempotent,
+terminal, stops new operation admission, waits for already-admitted binding operations, and returns
+only after owned native resources are released. Operations after close raise
+`ValueError("ParamCache is closed")`; a harmless repeated `detach` is permitted.
+
+Stale/reconnect state, Python callbacks, `get_array`, buffer-protocol or NumPy inputs, type stubs, and
+`WaitForLocalDelivery` remain deferred to Issues #20, #26, #27, and #99.
 
 ### 2.3 StorageNode / Engines
 
@@ -145,8 +164,11 @@ class MyEngine(sitos.StorageEngine):
 * zenoh threads in the C++ core do not acquire the GIL
 * Notifications to Python callbacks are one-way: “C++-side queue → dedicated Python dispatch
   thread (acquires the GIL)”. zenoh threads never block waiting for the GIL
-* `get`/`get_array` use only a C++-side shared lock. They keep holding the GIL
-  (because there is no I/O, it is not released)
+* ParamCache `get`, `contains`, and `items` are local C++ reads and keep the GIL. `items`
+  materializes into C++-owned storage before constructing Python tuples
+* Client Open, Attach, Detach, terminal Close/destruction, Put, and PutBatch release the GIL while
+  native work may block. Python input conversion and result construction occur with the GIL held
+* Future zero-copy `get_array` ownership and GIL behavior belong to Issue #27
 * In a StorageNode that uses a Python engine (§2.3), zenoh threads call into Python,
   so GIL acquisition occurs. State explicitly that C++ engines are recommended for production use
 

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -397,12 +397,14 @@ so it is not a v0.2 blocker. Include it by v0.5.
 * Milestone: v0.3
 * References: [05] §2.2, ADR-0022, ADR-0023
 * Implementation targets: `python/bindings/param_cache.cpp`, `python/sitos/cache.py`,
-  `tests/python/test_param_cache.py`
-* Scope: session-only Python binding for ParamCache reads/writes and attach/detach; no AttachBase or
-  stale/reconnect surface
-* Acceptance criteria: pytest — attach/concurrent-delta and peer-propagation scenarios equivalent
-  to the C++ ParamCache contract
-* Depends on: #19, #22
+  `tests/python/test_param_cache.py`, `tests/python/test_param_cache_live.py`
+* Scope: session-only Python binding for ParamCache reads/writes, attach/detach, terminal quiescent
+  close, and the shared Issue #23 exception/conversion boundary; no AttachBase, stale/reconnect,
+  callback, NumPy, buffer-protocol, or delivery-barrier surface
+* Acceptance criteria: fixture-free repaired-wheel pytest plus source-only deterministic
+  attach/concurrent-delta, peer-propagation, GIL-progress, and close-quiescence scenarios using one
+  non-installed C++ fixture process
+* Depends on: #19, #22, #23
 
 ### #25 Python StorageNode / SessionView
 * Milestone: v0.3

--- a/python/bindings/client_binding.cpp
+++ b/python/bindings/client_binding.cpp
@@ -4,6 +4,7 @@
 #include "client_binding.hpp"
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
 
 #include <cstdint>
 #include <exception>
@@ -11,6 +12,7 @@
 #include <string_view>
 #include <vector>
 
+#include "param_value_conversion.hpp"
 #include "sitos/status.hpp"
 #include "status_translation.hpp"
 
@@ -67,6 +69,26 @@ std::int64_t GetTimeout(const nb::handle& value) {
   }
   if (converted <= 0) throw nb::value_error("query_timeout_ms must be positive");
   return converted;
+}
+
+std::vector<BatchEntry> MaterializeBatchEntries(const nb::handle& entries) {
+  std::vector<BatchEntry> materialized;
+  const auto append_pair = [&materialized](const nb::handle& item) {
+    if (!nb::isinstance<nb::tuple>(item) && !nb::isinstance<nb::list>(item)) {
+      throw nb::type_error("put_batch entries must be two-item pairs");
+    }
+    if (nb::len(item) != 2) {
+      throw nb::value_error("put_batch entries must have two items");
+    }
+    materialized.push_back({nb::cast<std::string>(item[0]), ParamValueFromPython(item[1])});
+  };
+  if (nb::hasattr(entries, "items")) {
+    nb::object items = entries.attr("items")();
+    for (nb::handle item : nb::iter(items)) append_pair(item);
+  } else {
+    for (nb::handle item : nb::iter(entries)) append_pair(item);
+  }
+  return materialized;
 }
 
 ParamValue ConvertTyped(const ParamValue& value, const nb::object& type) {

--- a/python/bindings/client_binding.cpp
+++ b/python/bindings/client_binding.cpp
@@ -1,0 +1,103 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "client_binding.hpp"
+
+#include <nanobind/nanobind.h>
+
+#include <cstdint>
+#include <exception>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "sitos/status.hpp"
+#include "status_translation.hpp"
+
+namespace nb = nanobind;
+
+namespace sitos::python::detail {
+
+void RegisterClientExceptions(nb::module_& python_module) {
+  static nb::exception<SitosError> base(python_module, "SitosError", PyExc_RuntimeError);
+  static nb::exception<NotFoundError> not_found(python_module, "NotFoundError", base);
+  static nb::exception<TypeMismatchError> mismatch(python_module, "TypeMismatchError", base);
+  static nb::exception<TimeoutError> timeout(python_module, "TimeoutError", base);
+  static nb::exception<DisconnectedError> disconnected(python_module, "DisconnectedError", base);
+  static nb::exception<ReadOnlyError> readonly(python_module, "ReadOnlyError", base);
+  python_module.attr("SitosError") = base;
+  python_module.attr("NotFoundError") = not_found;
+  python_module.attr("TypeMismatchError") = mismatch;
+  python_module.attr("TimeoutError") = timeout;
+  python_module.attr("DisconnectedError") = disconnected;
+  python_module.attr("ReadOnlyError") = readonly;
+}
+
+[[noreturn]] void ThrowStatus(Status status, std::string_view message) {
+  const std::string fallback = MakeErrorCode(status).message();
+  const std::string text = message.empty() ? fallback : std::string(message);
+  switch (StatusToPythonError(status)) {
+    case PythonErrorKind::kValueError:
+      throw nb::value_error(text.c_str());
+    case PythonErrorKind::kNotFound:
+      throw NotFoundError(text);
+    case PythonErrorKind::kTypeMismatch:
+      throw TypeMismatchError(text);
+    case PythonErrorKind::kTimeout:
+      throw TimeoutError(text);
+    case PythonErrorKind::kDisconnected:
+      throw DisconnectedError(text);
+    case PythonErrorKind::kReadOnly:
+      throw ReadOnlyError(text);
+    case PythonErrorKind::kSitosError:
+      throw SitosError(text);
+  }
+  throw SitosError(text);
+}
+
+std::int64_t GetTimeout(const nb::handle& value) {
+  if (!nb::isinstance<nb::int_>(value) || nb::isinstance<nb::bool_>(value)) {
+    throw nb::type_error("query_timeout_ms must be a positive int");
+  }
+  std::int64_t converted = 0;
+  try {
+    converted = nb::cast<std::int64_t>(value);
+  } catch (const std::exception&) {
+    throw nb::value_error("query_timeout_ms is outside the C++ millisecond range");
+  }
+  if (converted <= 0) throw nb::value_error("query_timeout_ms must be positive");
+  return converted;
+}
+
+ParamValue ConvertTyped(const ParamValue& value, const nb::object& type) {
+  if (type.is_none()) return value;
+  const auto builtins = nb::module_::import_("builtins");
+  if (type.ptr() == builtins.attr("bool").ptr()) {
+    auto converted = value.As<bool>();
+    if (!converted.has_value()) ThrowStatus(Status::TypeMismatch, "parameter value type mismatch");
+    return ParamValue(*converted);
+  }
+  if (type.ptr() == builtins.attr("int").ptr()) {
+    auto converted = value.As<std::int64_t>();
+    if (!converted.has_value()) ThrowStatus(Status::TypeMismatch, "parameter value type mismatch");
+    return ParamValue(*converted);
+  }
+  if (type.ptr() == builtins.attr("float").ptr()) {
+    auto converted = value.As<double>();
+    if (!converted.has_value()) ThrowStatus(Status::TypeMismatch, "parameter value type mismatch");
+    return ParamValue(*converted);
+  }
+  if (type.ptr() == builtins.attr("str").ptr()) {
+    auto converted = value.As<std::string>();
+    if (!converted.has_value()) ThrowStatus(Status::TypeMismatch, "parameter value type mismatch");
+    return ParamValue(std::move(*converted));
+  }
+  if (type.ptr() == builtins.attr("bytes").ptr()) {
+    auto converted = value.As<std::vector<std::byte>>();
+    if (!converted.has_value()) ThrowStatus(Status::TypeMismatch, "parameter value type mismatch");
+    return ParamValue(std::move(*converted));
+  }
+  throw nb::type_error("type must be None, bool, int, float, str, or bytes");
+}
+
+}  // namespace sitos::python::detail

--- a/python/bindings/client_binding.cpp
+++ b/python/bindings/client_binding.cpp
@@ -64,7 +64,7 @@ std::int64_t GetTimeout(const nb::handle& value) {
   std::int64_t converted = 0;
   try {
     converted = nb::cast<std::int64_t>(value);
-  } catch (const std::exception&) {
+  } catch (const nb::cast_error&) {
     throw nb::value_error("query_timeout_ms is outside the C++ millisecond range");
   }
   if (converted <= 0) throw nb::value_error("query_timeout_ms must be positive");

--- a/python/bindings/client_binding.hpp
+++ b/python/bindings/client_binding.hpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <stdexcept>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -47,12 +48,13 @@ void RegisterClientExceptions(nanobind::module_& python_module);
 [[noreturn]] void ThrowStatus(Status status, std::string_view message);
 
 template <typename T>
+  requires(!std::is_void_v<T>)
 T Take(Result<T>&& result) {
   if (!result.IsOk()) ThrowStatus(result.StatusCode(), result.Message());
   return std::move(result).Value();
 }
 
-inline void Take(Result<void>&& result) {
+inline void Take(const Result<void>& result) {
   if (!result.IsOk()) ThrowStatus(result.StatusCode(), result.Message());
 }
 

--- a/python/bindings/client_binding.hpp
+++ b/python/bindings/client_binding.hpp
@@ -1,0 +1,62 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SITOS_PYTHON_BINDINGS_CLIENT_BINDING_HPP_
+#define SITOS_PYTHON_BINDINGS_CLIENT_BINDING_HPP_
+
+#include <nanobind/nanobind.h>
+
+#include <cstdint>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+
+#include "sitos/param_value.hpp"
+#include "sitos/result.hpp"
+
+namespace sitos::python::detail {
+
+class SitosError : public std::runtime_error {
+ public:
+  using std::runtime_error::runtime_error;
+};
+class NotFoundError : public SitosError {
+ public:
+  using SitosError::SitosError;
+};
+class TypeMismatchError : public SitosError {
+ public:
+  using SitosError::SitosError;
+};
+class TimeoutError : public SitosError {
+ public:
+  using SitosError::SitosError;
+};
+class DisconnectedError : public SitosError {
+ public:
+  using SitosError::SitosError;
+};
+class ReadOnlyError : public SitosError {
+ public:
+  using SitosError::SitosError;
+};
+
+void RegisterClientExceptions(nanobind::module_& python_module);
+[[noreturn]] void ThrowStatus(Status status, std::string_view message);
+
+template <typename T>
+T Take(Result<T>&& result) {
+  if (!result.IsOk()) ThrowStatus(result.StatusCode(), result.Message());
+  return std::move(result).Value();
+}
+
+inline void Take(Result<void>&& result) {
+  if (!result.IsOk()) ThrowStatus(result.StatusCode(), result.Message());
+}
+
+std::int64_t GetTimeout(const nanobind::handle& value);
+ParamValue ConvertTyped(const ParamValue& value, const nanobind::object& type);
+
+}  // namespace sitos::python::detail
+
+#endif  // SITOS_PYTHON_BINDINGS_CLIENT_BINDING_HPP_

--- a/python/bindings/client_binding.hpp
+++ b/python/bindings/client_binding.hpp
@@ -10,7 +10,9 @@
 #include <stdexcept>
 #include <string_view>
 #include <utility>
+#include <vector>
 
+#include "sitos/batch.hpp"
 #include "sitos/param_value.hpp"
 #include "sitos/result.hpp"
 
@@ -56,6 +58,7 @@ inline void Take(Result<void>&& result) {
 
 std::int64_t GetTimeout(const nanobind::handle& value);
 ParamValue ConvertTyped(const ParamValue& value, const nanobind::object& type);
+std::vector<BatchEntry> MaterializeBatchEntries(const nanobind::handle& entries);
 
 }  // namespace sitos::python::detail
 

--- a/python/bindings/module.cpp
+++ b/python/bindings/module.cpp
@@ -1,16 +1,18 @@
 // Copyright 2026 sitos contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <span>
-
 #include <nanobind/nanobind.h>
 
+#include <span>
+
+#include "client_binding.hpp"
 #include "param_value_conversion.hpp"
 #if SITOS_PYTHON_WITH_ZENOH
 #include "transport/zenoh_runtime_anchor.hpp"
 #endif
 
 void BindParamStore(nanobind::module_& python_module);
+void BindParamCache(nanobind::module_& python_module);
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -42,5 +44,7 @@ NB_MODULE(_sitos, python_module) {
   python_module.attr("__version__") = SITOS_PYTHON_VERSION;
   python_module.def("encode_value", &EncodeValue, "value"_a);
   python_module.def("decode_value", &DecodeValue, "payload"_a);
+  sitos::python::detail::RegisterClientExceptions(python_module);
   BindParamStore(python_module);
+  BindParamCache(python_module);
 }

--- a/python/bindings/param_cache.cpp
+++ b/python/bindings/param_cache.cpp
@@ -91,8 +91,11 @@ class PyParamCache {
     return false;
   }
 
-  void Attach(const std::string& sid) {
-    auto result = InvokeNative(Acquire(), [&sid](ParamCache& cache) { return cache.Attach(sid); });
+  void Attach(const nb::handle& sid_input) {
+    auto lease = Acquire();
+    const auto sid = nb::cast<std::string>(sid_input);
+    auto result =
+        InvokeNative(std::move(lease), [&sid](ParamCache& cache) { return cache.Attach(sid); });
     Take(std::move(result));
   }
 
@@ -103,8 +106,9 @@ class PyParamCache {
     lease->Native().Detach();
   }
 
-  void Put(const std::string& key, const nb::handle& value) {
+  void Put(const nb::handle& key_input, const nb::handle& value) {
     auto lease = Acquire();
+    const auto key = nb::cast<std::string>(key_input);
     const auto converted = ParamValueFromPython(value);
     auto result = InvokeNative(std::move(lease), [&key, &converted](ParamCache& cache) {
       return cache.Put(key, converted);
@@ -114,31 +118,17 @@ class PyParamCache {
 
   void PutBatch(const nb::handle& entries) {
     auto lease = Acquire();
-    std::vector<BatchEntry> materialized;
-    const auto append_pair = [&materialized](const nb::handle& item) {
-      if (!nb::isinstance<nb::tuple>(item) && !nb::isinstance<nb::list>(item)) {
-        throw nb::type_error("put_batch entries must be two-item pairs");
-      }
-      if (nb::len(item) != 2) {
-        throw nb::value_error("put_batch entries must have two items");
-      }
-      materialized.push_back({nb::cast<std::string>(item[0]), ParamValueFromPython(item[1])});
-    };
-    if (nb::hasattr(entries, "items")) {
-      nb::object items = entries.attr("items")();
-      for (nb::handle item : nb::iter(items)) append_pair(item);
-    } else {
-      for (nb::handle item : nb::iter(entries)) append_pair(item);
-    }
+    auto materialized = MaterializeBatchEntries(entries);
     auto result = InvokeNative(std::move(lease), [&materialized](ParamCache& cache) {
       return cache.PutBatch(materialized);
     });
     Take(std::move(result));
   }
 
-  nb::object Get(const std::string& key, const nb::object& default_value, const nb::object& missing,
-                 const nb::object& type) {
+  nb::object Get(const nb::handle& key_input, const nb::object& default_value,
+                 const nb::object& missing, const nb::object& type) {
     auto lease = Acquire();
+    const auto key = nb::cast<std::string>(key_input);
     auto result = lease.Native().GetShared(key);
     if (!result.IsOk()) {
       if (result.StatusCode() == Status::NotFound && default_value.ptr() != missing.ptr()) {
@@ -151,13 +141,15 @@ class PyParamCache {
     return ParamValueToPython(ConvertTyped(*shared, type));
   }
 
-  bool Contains(const std::string& key) {
+  bool Contains(const nb::handle& key_input) {
     auto lease = Acquire();
+    const auto key = nb::cast<std::string>(key_input);
     return Take(lease.Native().Contains(key));
   }
 
-  nb::object Items(const std::string& prefix) {
+  nb::object Items(const nb::handle& prefix_input) {
     auto lease = Acquire();
+    const auto prefix = nb::cast<std::string>(prefix_input);
     std::vector<std::pair<std::string, ParamValue>> values;
     auto result =
         lease.Native().List(prefix, [&values](std::string_view key, const ParamValue& value) {
@@ -267,9 +259,10 @@ void BindParamCache(nb::module_& python_module) {
       .def("put_batch", &PyParamCache::PutBatch, "entries"_a)
       .def(
           "get",
-          [missing](PyParamCache& self, const std::string& key, nb::object default_value,
+          [missing](PyParamCache& self, const nb::handle& key, nb::object default_value,
                     nb::object type) { return self.Get(key, default_value, missing, type); },
-          "key"_a, "default"_a.none() = missing, nb::kw_only(), "type"_a.none() = nb::none())
+          "key"_a, "default"_a.none() = missing, nb::kw_only(),
+          "type"_a.none() = nb::none())
       .def("contains", &PyParamCache::Contains, "key"_a)
       .def("items", &PyParamCache::Items, "prefix"_a = "");
 }

--- a/python/bindings/param_cache.cpp
+++ b/python/bindings/param_cache.cpp
@@ -1,0 +1,275 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/param_cache.hpp"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+
+#include <cassert>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "client_binding.hpp"
+#include "param_value_conversion.hpp"
+#include "sitos/batch.hpp"
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+namespace sitos::python::detail {
+
+class PyParamCache {
+ public:
+  explicit PyParamCache(const std::string& prefix, const nb::object& json,
+                        const nb::handle& timeout) {
+    ClientConfig config;
+    config.prefix = prefix;
+    config.query_timeout = std::chrono::milliseconds(GetTimeout(timeout));
+    if (!json.is_none()) config.zenoh_config_json = nb::cast<std::string>(json);
+    auto result = [&config] {
+      nb::gil_scoped_release release;
+      return ParamCache::Open(std::move(config));
+    }();
+    std::optional<ParamCache> native{Take(std::move(result))};
+    try {
+      state_->native = std::make_shared<ParamCache>(std::move(*native));
+    } catch (...) {
+      nb::gil_scoped_release release;
+      native.reset();
+      throw;
+    }
+    nb::gil_scoped_release release;
+    native.reset();
+  }
+
+  ~PyParamCache() { Close(); }
+
+  void Close() noexcept {
+    auto state = state_;
+    nb::gil_scoped_release release;
+    std::shared_ptr<ParamCache> native;
+    {
+      std::unique_lock lock(state->mutex);
+      if (state->phase == Phase::Closed) return;
+      if (state->phase == Phase::Closing) {
+        state->condition.wait(lock, [&state] { return state->phase == Phase::Closed; });
+        return;
+      }
+      state->phase = Phase::Closing;
+      state->condition.wait(lock, [&state] { return state->in_flight == 0; });
+      native = std::move(state->native);
+    }
+    if (native) {
+      native->Detach();
+      native.reset();
+    }
+    {
+      std::lock_guard lock(state->mutex);
+      state->phase = Phase::Closed;
+    }
+    state->condition.notify_all();
+  }
+
+  PyParamCache& Enter() {
+    static_cast<void>(Acquire());
+    return *this;
+  }
+
+  bool Exit(const nb::object&, const nb::object&, const nb::object&) {
+    Close();
+    return false;
+  }
+
+  void Attach(const std::string& sid) {
+    auto result = InvokeNative(Acquire(), [&sid](ParamCache& cache) { return cache.Attach(sid); });
+    Take(std::move(result));
+  }
+
+  void Detach() noexcept {
+    auto lease = AcquireForDetach();
+    if (!lease.has_value()) return;
+    nb::gil_scoped_release release;
+    lease->Native().Detach();
+  }
+
+  void Put(const std::string& key, const nb::handle& value) {
+    auto lease = Acquire();
+    const auto converted = ParamValueFromPython(value);
+    auto result = InvokeNative(std::move(lease), [&key, &converted](ParamCache& cache) {
+      return cache.Put(key, converted);
+    });
+    Take(std::move(result));
+  }
+
+  void PutBatch(const nb::handle& entries) {
+    auto lease = Acquire();
+    std::vector<BatchEntry> materialized;
+    const auto append_pair = [&materialized](const nb::handle& item) {
+      if (!nb::isinstance<nb::tuple>(item) && !nb::isinstance<nb::list>(item)) {
+        throw nb::type_error("put_batch entries must be two-item pairs");
+      }
+      if (nb::len(item) != 2) {
+        throw nb::value_error("put_batch entries must have two items");
+      }
+      materialized.push_back({nb::cast<std::string>(item[0]), ParamValueFromPython(item[1])});
+    };
+    if (nb::hasattr(entries, "items")) {
+      nb::object items = entries.attr("items")();
+      for (nb::handle item : nb::iter(items)) append_pair(item);
+    } else {
+      for (nb::handle item : nb::iter(entries)) append_pair(item);
+    }
+    auto result = InvokeNative(std::move(lease), [&materialized](ParamCache& cache) {
+      return cache.PutBatch(materialized);
+    });
+    Take(std::move(result));
+  }
+
+  nb::object Get(const std::string& key, const nb::object& default_value, const nb::object& missing,
+                 const nb::object& type) {
+    auto lease = Acquire();
+    auto result = lease.Native().GetShared(key);
+    if (!result.IsOk()) {
+      if (result.StatusCode() == Status::NotFound && default_value.ptr() != missing.ptr()) {
+        return default_value;
+      }
+      Take(std::move(result));
+    }
+    auto shared = std::move(result).Value();
+    if (type.is_none()) return ParamValueToPython(*shared);
+    return ParamValueToPython(ConvertTyped(*shared, type));
+  }
+
+  bool Contains(const std::string& key) {
+    auto lease = Acquire();
+    return Take(lease.Native().Contains(key));
+  }
+
+  nb::object Items(const std::string& prefix) {
+    auto lease = Acquire();
+    std::vector<std::pair<std::string, ParamValue>> values;
+    auto result =
+        lease.Native().List(prefix, [&values](std::string_view key, const ParamValue& value) {
+          values.emplace_back(key, value);
+          return true;
+        });
+    Take(std::move(result));
+    nb::list rows;
+    for (auto& [key, value] : values) {
+      rows.append(nb::make_tuple(key, ParamValueToPython(value)));
+    }
+    return rows.attr("__iter__")();
+  }
+
+ private:
+  enum class Phase { Open, Closing, Closed };
+
+  struct State {
+    std::mutex mutex;
+    std::condition_variable condition;
+    Phase phase = Phase::Open;
+    std::size_t in_flight = 0;
+    std::shared_ptr<ParamCache> native;
+  };
+
+  class OperationLease {
+   public:
+    OperationLease(std::shared_ptr<State> state, std::shared_ptr<ParamCache> native)
+        : state_(std::move(state)), native_(std::move(native)) {}
+    ~OperationLease() { Release(); }
+    OperationLease(const OperationLease&) = delete;
+    OperationLease& operator=(const OperationLease&) = delete;
+    OperationLease(OperationLease&& other) noexcept
+        : state_(std::move(other.state_)), native_(std::move(other.native_)) {}
+    OperationLease& operator=(OperationLease&& other) noexcept {
+      if (this != &other) {
+        Release();
+        state_ = std::move(other.state_);
+        native_ = std::move(other.native_);
+      }
+      return *this;
+    }
+
+    ParamCache& Native() const { return *native_; }
+
+   private:
+    void Release() noexcept {
+      if (!state_) return;
+      native_.reset();
+      {
+        std::lock_guard lock(state_->mutex);
+        assert(state_->in_flight > 0);
+        if (state_->in_flight > 0) --state_->in_flight;
+      }
+      state_->condition.notify_all();
+      state_.reset();
+    }
+
+    std::shared_ptr<State> state_;
+    std::shared_ptr<ParamCache> native_;
+  };
+
+  OperationLease Acquire() const {
+    auto state = state_;
+    std::lock_guard lock(state->mutex);
+    if (state->phase != Phase::Open || !state->native) {
+      throw nb::value_error("ParamCache is closed");
+    }
+    ++state->in_flight;
+    return OperationLease(state, state->native);
+  }
+
+  std::optional<OperationLease> AcquireForDetach() const noexcept {
+    auto state = state_;
+    std::lock_guard lock(state->mutex);
+    if (state->phase != Phase::Open || !state->native) return std::nullopt;
+    ++state->in_flight;
+    return std::optional<OperationLease>(std::in_place, state, state->native);
+  }
+
+  template <typename Operation>
+  static auto InvokeNative(OperationLease lease, Operation&& operation)
+      -> std::invoke_result_t<Operation, ParamCache&> {
+    nb::gil_scoped_release release;
+    return std::forward<Operation>(operation)(lease.Native());
+  }
+
+  std::shared_ptr<State> state_ = std::make_shared<State>();
+};
+
+}  // namespace sitos::python::detail
+
+void BindParamCache(nb::module_& python_module) {
+  using sitos::python::detail::PyParamCache;
+  nb::object missing = nb::dict();
+  python_module.attr("_PARAM_CACHE_MISSING") = missing;
+  nb::class_<PyParamCache>(python_module, "ParamCache")
+      .def(nb::init<const std::string&, const nb::object&, const nb::handle>(), nb::kw_only(),
+           "prefix"_a = "sitos", "zenoh_config_json"_a = nb::none(), "query_timeout_ms"_a = 5000)
+      .def("close", &PyParamCache::Close)
+      .def("__enter__", &PyParamCache::Enter, nb::rv_policy::reference_internal)
+      .def("__exit__", &PyParamCache::Exit, "exc_type"_a.none(), "exc_value"_a.none(),
+           "traceback"_a.none())
+      .def("attach", &PyParamCache::Attach, "sid"_a)
+      .def("detach", &PyParamCache::Detach)
+      .def("put", &PyParamCache::Put, "key"_a, "value"_a)
+      .def("put_batch", &PyParamCache::PutBatch, "entries"_a)
+      .def(
+          "get",
+          [missing](PyParamCache& self, const std::string& key, nb::object default_value,
+                    nb::object type) { return self.Get(key, default_value, missing, type); },
+          "key"_a, "default"_a.none() = missing, nb::kw_only(), "type"_a.none() = nb::none())
+      .def("contains", &PyParamCache::Contains, "key"_a)
+      .def("items", &PyParamCache::Items, "prefix"_a = "");
+}

--- a/python/bindings/param_cache.cpp
+++ b/python/bindings/param_cache.cpp
@@ -96,7 +96,7 @@ class PyParamCache {
     const auto sid = nb::cast<std::string>(sid_input);
     auto result =
         InvokeNative(std::move(lease), [&sid](ParamCache& cache) { return cache.Attach(sid); });
-    Take(std::move(result));
+    Take(result);
   }
 
   void Detach() noexcept {
@@ -113,7 +113,7 @@ class PyParamCache {
     auto result = InvokeNative(std::move(lease), [&key, &converted](ParamCache& cache) {
       return cache.Put(key, converted);
     });
-    Take(std::move(result));
+    Take(result);
   }
 
   void PutBatch(const nb::handle& entries) {
@@ -122,7 +122,7 @@ class PyParamCache {
     auto result = InvokeNative(std::move(lease), [&materialized](ParamCache& cache) {
       return cache.PutBatch(materialized);
     });
-    Take(std::move(result));
+    Take(result);
   }
 
   nb::object Get(const nb::handle& key_input, const nb::object& default_value,
@@ -156,7 +156,7 @@ class PyParamCache {
           values.emplace_back(key, value);
           return true;
         });
-    Take(std::move(result));
+    Take(result);
     nb::list rows;
     for (auto& [key, value] : values) {
       rows.append(nb::make_tuple(key, ParamValueToPython(value)));

--- a/python/bindings/param_store.cpp
+++ b/python/bindings/param_store.cpp
@@ -80,7 +80,7 @@ class PyParamStore {
           InvokeNative(std::move(native), [&scope, &key, &converted](sitos::ParamStore& store) {
             return store.Put(scope, key, converted);
           });
-      Take(std::move(result));
+      Take(result);
     } catch (...) {
       ReleaseNative(std::move(native));
       throw;
@@ -95,7 +95,7 @@ class PyParamStore {
           InvokeNative(std::move(native), [&scope, &materialized](sitos::ParamStore& store) {
             return store.PutBatch(scope, materialized);
           });
-      Take(std::move(result));
+      Take(result);
     } catch (...) {
       ReleaseNative(std::move(native));
       throw;
@@ -105,7 +105,7 @@ class PyParamStore {
   void Delete(const std::string& scope, const std::string& key) {
     auto result = InvokeNative(
         Acquire(), [&scope, &key](sitos::ParamStore& store) { return store.Delete(scope, key); });
-    Take(std::move(result));
+    Take(result);
   }
 
   nb::object Get(const std::string& scope, const std::string& key, const nb::object& default_value,
@@ -138,7 +138,7 @@ class PyParamStore {
                               return true;
                             });
         });
-    Take(std::move(native_result));
+    Take(native_result);
     nb::list result;
     for (auto& [key, value] : values) {
       result.append(nb::make_tuple(key, ParamValueToPython(value)));

--- a/python/bindings/param_store.cpp
+++ b/python/bindings/param_store.cpp
@@ -90,22 +90,7 @@ class PyParamStore {
   void PutBatch(const std::string& scope, const nb::handle& entries) {
     auto native = Acquire();
     try {
-      std::vector<sitos::BatchEntry> materialized;
-      const auto append_pair = [&materialized](const nb::handle& item) {
-        if (!nb::isinstance<nb::tuple>(item) && !nb::isinstance<nb::list>(item)) {
-          throw nb::type_error("put_batch entries must be two-item pairs");
-        }
-        if (nb::len(item) != 2) {
-          throw nb::value_error("put_batch entries must have two items");
-        }
-        materialized.push_back({nb::cast<std::string>(item[0]), ParamValueFromPython(item[1])});
-      };
-      if (nb::hasattr(entries, "items")) {
-        nb::object items = entries.attr("items")();
-        for (nb::handle item : nb::iter(items)) append_pair(item);
-      } else {
-        for (nb::handle item : nb::iter(entries)) append_pair(item);
-      }
+      auto materialized = MaterializeBatchEntries(entries);
       auto result =
           InvokeNative(std::move(native), [&scope, &materialized](sitos::ParamStore& store) {
             return store.PutBatch(scope, materialized);

--- a/python/bindings/param_store.cpp
+++ b/python/bindings/param_store.cpp
@@ -1,126 +1,28 @@
 // Copyright 2026 sitos contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sitos/param_store.hpp"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+
 #include <chrono>
-#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
-#include <nanobind/nanobind.h>
-#include <nanobind/stl/string.h>
-
+#include "client_binding.hpp"
 #include "param_value_conversion.hpp"
-#include "status_translation.hpp"
-#include "sitos/param_store.hpp"
 
 namespace nb = nanobind;
 using namespace nb::literals;
 
 namespace sitos::python::detail {
-
-class SitosError : public std::runtime_error {
- public:
-  using std::runtime_error::runtime_error;
-};
-class NotFoundError : public SitosError { using SitosError::SitosError; };
-class TypeMismatchError : public SitosError { using SitosError::SitosError; };
-class TimeoutError : public SitosError { using SitosError::SitosError; };
-class DisconnectedError : public SitosError { using SitosError::SitosError; };
-class ReadOnlyError : public SitosError { using SitosError::SitosError; };
-
-[[noreturn]] void ThrowStatus(sitos::Status status, std::string_view message) {
-  const std::string fallback = sitos::MakeErrorCode(status).message();
-  const std::string text = message.empty() ? fallback : std::string(message);
-  switch (StatusToPythonError(status)) {
-    case PythonErrorKind::kValueError:
-      throw nb::value_error(text.c_str());
-    case PythonErrorKind::kNotFound:
-      throw NotFoundError(text);
-    case PythonErrorKind::kTypeMismatch:
-      throw TypeMismatchError(text);
-    case PythonErrorKind::kTimeout:
-      throw TimeoutError(text);
-    case PythonErrorKind::kDisconnected:
-      throw DisconnectedError(text);
-    case PythonErrorKind::kReadOnly:
-      throw ReadOnlyError(text);
-    case PythonErrorKind::kSitosError:
-      throw SitosError(text);
-  }
-  throw SitosError(text);
-}
-
-template <typename T>
-T Take(sitos::Result<T>&& result) {
-  if (!result.IsOk()) ThrowStatus(result.StatusCode(), result.Message());
-  return std::move(result).Value();
-}
-
-void Take(sitos::Result<void>&& result) {
-  if (!result.IsOk()) ThrowStatus(result.StatusCode(), result.Message());
-}
-
-std::int64_t GetTimeout(const nb::handle& value) {
-  if (!nb::isinstance<nb::int_>(value) || nb::isinstance<nb::bool_>(value)) {
-    throw nb::type_error("query_timeout_ms must be a positive int");
-  }
-  std::int64_t converted = 0;
-  try {
-    converted = nb::cast<std::int64_t>(value);
-  } catch (const std::exception&) {
-    throw nb::value_error("query_timeout_ms is outside the C++ millisecond range");
-  }
-  if (converted <= 0) throw nb::value_error("query_timeout_ms must be positive");
-  return converted;
-}
-
-sitos::ParamValue ConvertTyped(const sitos::ParamValue& value, const nb::object& type) {
-  if (type.is_none()) return value;
-  const auto builtins = nb::module_::import_("builtins");
-  if (type.ptr() == builtins.attr("bool").ptr()) {
-    auto converted = value.As<bool>();
-    if (!converted.has_value()) {
-      ThrowStatus(sitos::Status::TypeMismatch, "parameter value type mismatch");
-    }
-    return sitos::ParamValue(*converted);
-  }
-  if (type.ptr() == builtins.attr("int").ptr()) {
-    auto converted = value.As<std::int64_t>();
-    if (!converted.has_value()) {
-      ThrowStatus(sitos::Status::TypeMismatch, "parameter value type mismatch");
-    }
-    return sitos::ParamValue(*converted);
-  }
-  if (type.ptr() == builtins.attr("float").ptr()) {
-    auto converted = value.As<double>();
-    if (!converted.has_value()) {
-      ThrowStatus(sitos::Status::TypeMismatch, "parameter value type mismatch");
-    }
-    return sitos::ParamValue(*converted);
-  }
-  if (type.ptr() == builtins.attr("str").ptr()) {
-    auto converted = value.As<std::string>();
-    if (!converted.has_value()) {
-      ThrowStatus(sitos::Status::TypeMismatch, "parameter value type mismatch");
-    }
-    return sitos::ParamValue(std::move(*converted));
-  }
-  if (type.ptr() == builtins.attr("bytes").ptr()) {
-    auto converted = value.As<std::vector<std::byte>>();
-    if (!converted.has_value()) {
-      ThrowStatus(sitos::Status::TypeMismatch, "parameter value type mismatch");
-    }
-    return sitos::ParamValue(std::move(*converted));
-  }
-  throw nb::type_error("type must be None, bool, int, float, str, or bytes");
-}
 
 class PyParamStore {
  public:
@@ -174,8 +76,8 @@ class PyParamStore {
     auto native = Acquire();
     try {
       auto converted = ParamValueFromPython(value);
-      auto result = InvokeNative(
-          std::move(native), [&scope, &key, &converted](sitos::ParamStore& store) {
+      auto result =
+          InvokeNative(std::move(native), [&scope, &key, &converted](sitos::ParamStore& store) {
             return store.Put(scope, key, converted);
           });
       Take(std::move(result));
@@ -196,8 +98,7 @@ class PyParamStore {
         if (nb::len(item) != 2) {
           throw nb::value_error("put_batch entries must have two items");
         }
-        materialized.push_back({nb::cast<std::string>(item[0]),
-                                ParamValueFromPython(item[1])});
+        materialized.push_back({nb::cast<std::string>(item[0]), ParamValueFromPython(item[1])});
       };
       if (nb::hasattr(entries, "items")) {
         nb::object items = entries.attr("items")();
@@ -205,8 +106,8 @@ class PyParamStore {
       } else {
         for (nb::handle item : nb::iter(entries)) append_pair(item);
       }
-      auto result = InvokeNative(
-          std::move(native), [&scope, &materialized](sitos::ParamStore& store) {
+      auto result =
+          InvokeNative(std::move(native), [&scope, &materialized](sitos::ParamStore& store) {
             return store.PutBatch(scope, materialized);
           });
       Take(std::move(result));
@@ -217,17 +118,15 @@ class PyParamStore {
   }
 
   void Delete(const std::string& scope, const std::string& key) {
-    auto result = InvokeNative(Acquire(), [&scope, &key](sitos::ParamStore& store) {
-      return store.Delete(scope, key);
-    });
+    auto result = InvokeNative(
+        Acquire(), [&scope, &key](sitos::ParamStore& store) { return store.Delete(scope, key); });
     Take(std::move(result));
   }
 
   nb::object Get(const std::string& scope, const std::string& key, const nb::object& default_value,
                  const nb::object& missing, const nb::object& type) {
-    auto result = InvokeNative(Acquire(), [&scope, &key](sitos::ParamStore& store) {
-      return store.Get(scope, key);
-    });
+    auto result = InvokeNative(
+        Acquire(), [&scope, &key](sitos::ParamStore& store) { return store.Get(scope, key); });
     if (!result.IsOk()) {
       if (result.StatusCode() == sitos::Status::NotFound && default_value.ptr() != missing.ptr()) {
         return default_value;
@@ -239,16 +138,15 @@ class PyParamStore {
   }
 
   bool Contains(const std::string& scope, const std::string& key) {
-    auto result = InvokeNative(Acquire(), [&scope, &key](sitos::ParamStore& store) {
-      return store.Contains(scope, key);
-    });
+    auto result = InvokeNative(
+        Acquire(), [&scope, &key](sitos::ParamStore& store) { return store.Contains(scope, key); });
     return Take(std::move(result));
   }
 
   nb::object List(const std::string& scope, const std::string& prefix) {
     std::vector<std::pair<std::string, sitos::ParamValue>> values;
-    auto native_result = InvokeNative(
-        Acquire(), [&scope, &prefix, &values](sitos::ParamStore& store) {
+    auto native_result =
+        InvokeNative(Acquire(), [&scope, &prefix, &values](sitos::ParamStore& store) {
           return store.List(scope, prefix,
                             [&values](std::string_view key, const sitos::ParamValue& value) {
                               values.emplace_back(key, value);
@@ -301,25 +199,11 @@ class PyParamStore {
 
 void BindParamStore(nb::module_& python_module) {
   using namespace sitos::python::detail;
-  static nb::exception<SitosError> base(python_module, "SitosError", PyExc_RuntimeError);
-  static nb::exception<NotFoundError> not_found(python_module, "NotFoundError", base);
-  static nb::exception<TypeMismatchError> mismatch(python_module, "TypeMismatchError", base);
-  static nb::exception<TimeoutError> timeout(python_module, "TimeoutError", base);
-  static nb::exception<DisconnectedError> disconnected(python_module, "DisconnectedError", base);
-  static nb::exception<ReadOnlyError> readonly(python_module, "ReadOnlyError", base);
-  python_module.attr("SitosError") = base;
-  python_module.attr("NotFoundError") = not_found;
-  python_module.attr("TypeMismatchError") = mismatch;
-  python_module.attr("TimeoutError") = timeout;
-  python_module.attr("DisconnectedError") = disconnected;
-  python_module.attr("ReadOnlyError") = readonly;
-
   nb::object missing = nb::dict();
   python_module.attr("_PARAM_STORE_MISSING") = missing;
   nb::class_<PyParamStore>(python_module, "ParamStore")
       .def(nb::init<const std::string&, const nb::object&, const nb::handle>(), nb::kw_only(),
-           "prefix"_a = "sitos", "zenoh_config_json"_a = nb::none(),
-           "query_timeout_ms"_a = 5000)
+           "prefix"_a = "sitos", "zenoh_config_json"_a = nb::none(), "query_timeout_ms"_a = 5000)
       .def("close", &PyParamStore::Close)
       .def("__enter__", &PyParamStore::Enter, nb::rv_policy::reference_internal)
       .def("__exit__", &PyParamStore::Exit, "exc_type"_a.none(), "exc_value"_a.none(),
@@ -327,12 +211,13 @@ void BindParamStore(nb::module_& python_module) {
       .def("put", &PyParamStore::Put, "scope"_a, "key"_a, "value"_a)
       .def("put_batch", &PyParamStore::PutBatch, "scope"_a, "entries"_a)
       .def("delete", &PyParamStore::Delete, "scope"_a, "key"_a)
-      .def("get", [missing](PyParamStore& self, const std::string& scope, const std::string& key,
-                             nb::object default_value, nb::object type) {
-        return self.Get(scope, key, default_value, missing, type);
-      },
-           "scope"_a, "key"_a, "default"_a.none() = missing, nb::kw_only(),
-           "type"_a.none() = nb::none())
+      .def(
+          "get",
+          [missing](PyParamStore& self, const std::string& scope, const std::string& key,
+                    nb::object default_value,
+                    nb::object type) { return self.Get(scope, key, default_value, missing, type); },
+          "scope"_a, "key"_a, "default"_a.none() = missing, nb::kw_only(),
+          "type"_a.none() = nb::none())
       .def("contains", &PyParamStore::Contains, "scope"_a, "key"_a)
       .def("list", &PyParamStore::List, "scope"_a, "prefix"_a);
 }

--- a/python/sitos/__init__.py
+++ b/python/sitos/__init__.py
@@ -1,6 +1,7 @@
 """Python bindings for the sitos parameter store."""
 
 from . import _sitos
+from .cache import ParamCache
 from .store import (
     DisconnectedError,
     NotFoundError,
@@ -19,6 +20,7 @@ __all__ = [
     "__version__",
     "decode_value",
     "encode_value",
+    "ParamCache",
     "ParamStore",
     "SitosError",
     "NotFoundError",

--- a/python/sitos/cache.py
+++ b/python/sitos/cache.py
@@ -1,0 +1,21 @@
+"""ParamCache is provided by the nanobind extension."""
+
+from ._sitos import (
+    DisconnectedError,
+    NotFoundError,
+    ParamCache,
+    ReadOnlyError,
+    SitosError,
+    TimeoutError,
+    TypeMismatchError,
+)
+
+__all__ = [
+    "ParamCache",
+    "SitosError",
+    "NotFoundError",
+    "TypeMismatchError",
+    "TimeoutError",
+    "DisconnectedError",
+    "ReadOnlyError",
+]

--- a/python/sitos/cache.py
+++ b/python/sitos/cache.py
@@ -6,7 +6,7 @@ from ._sitos import (
     ParamCache,
     ReadOnlyError,
     SitosError,
-    TimeoutError as TimeoutError,
+    TimeoutError,  # noqa: A004 - re-export the public sitos exception.
     TypeMismatchError,
 )
 

--- a/python/sitos/cache.py
+++ b/python/sitos/cache.py
@@ -6,16 +6,16 @@ from ._sitos import (
     ParamCache,
     ReadOnlyError,
     SitosError,
-    TimeoutError,
+    TimeoutError as TimeoutError,
     TypeMismatchError,
 )
 
 __all__ = [
-    "ParamCache",
-    "SitosError",
-    "NotFoundError",
-    "TypeMismatchError",
-    "TimeoutError",
     "DisconnectedError",
+    "NotFoundError",
+    "ParamCache",
     "ReadOnlyError",
+    "SitosError",
+    "TimeoutError",
+    "TypeMismatchError",
 ]

--- a/scripts/check_wheel.py
+++ b/scripts/check_wheel.py
@@ -26,6 +26,8 @@ FORBIDDEN_TOKENS = (
 )
 FORBIDDEN_SUFFIXES = (".a", ".lib", ".h", ".hh", ".hpp", ".cmake")
 FORBIDDEN_BASENAMES = (
+    "sitos_python_param_cache_fixture",
+    "sitos_python_param_cache_fixture.exe",
     "sitos_python_param_store_fixture",
     "sitos_python_param_store_fixture.exe",
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -273,6 +273,12 @@ if(SITOS_WITH_ZENOH)
     SOURCES integration/session_view_test.cpp)
 
   if(SITOS_BUILD_PYTHON)
+    add_executable(sitos_python_param_cache_fixture
+      python/param_cache_fixture.cpp)
+    target_link_libraries(sitos_python_param_cache_fixture PRIVATE sitos::sitos)
+    sitos_enable_warnings(sitos_python_param_cache_fixture)
+    sitos_copy_zenohc(sitos_python_param_cache_fixture)
+
     add_executable(sitos_python_param_store_fixture
       python/param_store_fixture.cpp)
     target_link_libraries(sitos_python_param_store_fixture PRIVATE sitos::sitos)

--- a/tests/python/param_cache_fixture.cpp
+++ b/tests/python/param_cache_fixture.cpp
@@ -1,0 +1,313 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <span>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "sitos/batch.hpp"
+#include "sitos/in_memory_engine.hpp"
+#include "sitos/param_cache.hpp"
+#include "sitos/param_store.hpp"
+#include "sitos/storage_node.hpp"
+#include "sitos/transport.hpp"
+
+namespace {
+
+using namespace std::chrono_literals;
+
+class Protocol {
+ public:
+  void Write(const std::string& line) {
+    std::lock_guard lock(mutex_);
+    std::cout << line << std::endl;
+  }
+
+ private:
+  std::mutex mutex_;
+};
+
+class SnapshotBarrierTransport final : public sitos::Transport {
+ public:
+  SnapshotBarrierTransport(std::shared_ptr<sitos::Transport> inner, std::string snapshot_query,
+                           std::string batch_key, Protocol& protocol)
+      : inner_(std::move(inner)),
+        snapshot_query_(std::move(snapshot_query)),
+        batch_key_(std::move(batch_key)),
+        protocol_(protocol) {}
+
+  sitos::Result<void> Put(std::string_view key, std::span<const std::byte> payload,
+                          sitos::Encoding encoding, sitos::PutOptions options) override {
+    return inner_->Put(key, payload, std::move(encoding), options);
+  }
+
+  sitos::Result<void> Delete(std::string_view key, sitos::PutOptions options) override {
+    return inner_->Delete(key, options);
+  }
+
+  sitos::Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
+                          std::chrono::milliseconds timeout) override {
+    return inner_->Get(keyexpr, sink, timeout);
+  }
+
+  sitos::Result<sitos::Subscription> DeclareSubscriber(
+      std::string_view keyexpr,
+      std::function<void(const sitos::TransportSample&)> callback) override {
+    auto wrapped = [this, callback = std::move(callback)](const sitos::TransportSample& sample) {
+      callback(sample);
+      if (sample.kind != sitos::TransportSample::Kind::Put || sample.key != batch_key_) return;
+      const auto entries = sitos::DecodeBatch(sample.payload);
+      if (!entries.has_value()) return;
+      std::vector<std::int64_t> values;
+      values.reserve(entries->size());
+      for (const auto& entry : *entries) {
+        const auto value = entry.value.As<std::int64_t>();
+        if (value.has_value()) values.push_back(*value);
+      }
+      {
+        std::lock_guard lock(mutex_);
+        ++batch_count_;
+        last_batch_size_ = entries->size();
+        last_batch_values_ = std::move(values);
+      }
+      batch_condition_.notify_all();
+    };
+    return inner_->DeclareSubscriber(keyexpr, std::move(wrapped));
+  }
+
+  sitos::Result<sitos::Queryable> DeclareQueryable(
+      std::string_view keyexpr, std::function<void(sitos::TransportQuery&)> callback) override {
+    auto wrapped = [this, callback = std::move(callback)](sitos::TransportQuery& query) {
+      bool should_block = false;
+      {
+        std::lock_guard lock(mutex_);
+        if (armed_ && query.keyexpr == snapshot_query_) {
+          armed_ = false;
+          entered_ = true;
+          should_block = true;
+        }
+      }
+      if (should_block) {
+        protocol_.Write("SNAPSHOT_ENTERED");
+        std::unique_lock lock(mutex_);
+        condition_.wait(lock, [this] { return released_; });
+      }
+      callback(query);
+    };
+    return inner_->DeclareQueryable(keyexpr, std::move(wrapped));
+  }
+
+  bool Arm() {
+    std::lock_guard lock(mutex_);
+    if (entered_ && !released_) return false;
+    armed_ = true;
+    entered_ = false;
+    released_ = false;
+    return true;
+  }
+
+  void Release() {
+    {
+      std::lock_guard lock(mutex_);
+      released_ = true;
+    }
+    condition_.notify_all();
+  }
+
+  std::string BatchStatus() const {
+    std::lock_guard lock(mutex_);
+    return BatchStatusLocked();
+  }
+
+  std::string WaitForBatchAfter(std::size_t previous) {
+    std::unique_lock lock(mutex_);
+    if (!batch_condition_.wait_for(lock, 5s,
+                                   [this, previous] { return batch_count_ > previous; })) {
+      return "ERROR batch timeout";
+    }
+    return BatchStatusLocked();
+  }
+
+ private:
+  std::string BatchStatusLocked() const {
+    std::ostringstream line;
+    line << "BATCH " << batch_count_ << " " << last_batch_size_;
+    for (const auto value : last_batch_values_) line << " " << value;
+    return line.str();
+  }
+
+  std::shared_ptr<sitos::Transport> inner_;
+  const std::string snapshot_query_;
+  const std::string batch_key_;
+  Protocol& protocol_;
+  mutable std::mutex mutex_;
+  std::condition_variable condition_;
+  std::condition_variable batch_condition_;
+  bool armed_ = false;
+  bool entered_ = false;
+  bool released_ = false;
+  std::size_t batch_count_ = 0;
+  std::size_t last_batch_size_ = 0;
+  std::vector<std::int64_t> last_batch_values_;
+};
+
+class PeerTrackingTransport final : public sitos::Transport {
+ public:
+  explicit PeerTrackingTransport(std::shared_ptr<sitos::Transport> inner)
+      : inner_(std::move(inner)) {}
+
+  sitos::Result<void> Put(std::string_view key, std::span<const std::byte> payload,
+                          sitos::Encoding encoding, sitos::PutOptions options) override {
+    return inner_->Put(key, payload, std::move(encoding), options);
+  }
+
+  sitos::Result<void> Delete(std::string_view key, sitos::PutOptions options) override {
+    return inner_->Delete(key, options);
+  }
+
+  sitos::Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
+                          std::chrono::milliseconds timeout) override {
+    return inner_->Get(keyexpr, sink, timeout);
+  }
+
+  sitos::Result<sitos::Subscription> DeclareSubscriber(
+      std::string_view keyexpr,
+      std::function<void(const sitos::TransportSample&)> callback) override {
+    auto wrapped = [this, callback = std::move(callback)](const sitos::TransportSample& sample) {
+      callback(sample);
+      {
+        std::lock_guard lock(mutex_);
+        ++callback_count_;
+      }
+      condition_.notify_all();
+    };
+    return inner_->DeclareSubscriber(keyexpr, std::move(wrapped));
+  }
+
+  sitos::Result<sitos::Queryable> DeclareQueryable(
+      std::string_view keyexpr, std::function<void(sitos::TransportQuery&)> callback) override {
+    return inner_->DeclareQueryable(keyexpr, std::move(callback));
+  }
+
+  bool WaitForValue(sitos::ParamCache& cache, std::string_view key, std::int64_t expected) {
+    std::unique_lock lock(mutex_);
+    return condition_.wait_for(lock, 5s, [&cache, key, expected] {
+      const auto value = cache.Get<std::int64_t>(key);
+      return value.IsOk() && value.Value() == expected;
+    });
+  }
+
+ private:
+  std::shared_ptr<sitos::Transport> inner_;
+  std::mutex mutex_;
+  std::condition_variable condition_;
+  std::size_t callback_count_ = 0;
+};
+
+bool IsAbsent(sitos::ParamStore& store, std::string_view scope, std::string_view key) {
+  const auto result = store.Contains(scope, key);
+  return result.IsOk() && !result.Value();
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  const std::string prefix = argc > 1 ? argv[1] : "sitos/python_cache_fixture";
+  const std::string port = argc > 2 ? argv[2] : "17448";
+  const std::string sid = argc > 3 ? argv[3] : "s1";
+  const std::string config_json =
+      "{mode: 'peer', listen: {endpoints: ['tcp/127.0.0.1:" + port + "']}}";
+  auto opened = sitos::OpenZenohTransport(config_json);
+  if (!opened.IsOk()) return 2;
+  std::shared_ptr<sitos::Transport> raw(std::move(opened).Value());
+
+  Protocol protocol;
+  const std::string snapshot_query = prefix + "/snap/" + sid + "/**";
+  const std::string batch_key = prefix + "/session/" + sid + "/:batch";
+  SnapshotBarrierTransport node_transport(raw, snapshot_query, batch_key, protocol);
+  auto peer_transport = std::make_shared<PeerTrackingTransport>(raw);
+  auto engine = std::make_shared<sitos::InMemoryEngine>();
+  sitos::StorageNode node(node_transport);
+  if (!node.Start(engine, {.prefix = prefix}).IsOk()) return 3;
+  if (!node.CreateSession(sid).IsOk() || !node.CreateSession("s2").IsOk()) {
+    node.Stop();
+    return 4;
+  }
+
+  sitos::ClientConfig config;
+  config.prefix = prefix;
+  config.query_timeout = 5s;
+  auto store_result = sitos::ParamStore::Open(raw, config);
+  if (!store_result.IsOk()) {
+    node.Stop();
+    return 5;
+  }
+  auto store = std::move(store_result).Value();
+  auto peer_result = sitos::ParamCache::Open(peer_transport, config);
+  if (!peer_result.IsOk()) {
+    node.Stop();
+    return 6;
+  }
+  auto peer = std::move(peer_result).Value();
+  if (!peer.Attach(sid).IsOk()) {
+    node.Stop();
+    return 7;
+  }
+
+  protocol.Write("READY " + prefix + " " + port + " " + sid);
+  std::string command;
+  while (std::getline(std::cin, command)) {
+    if (command == "ARM_SNAPSHOT") {
+      protocol.Write(node_transport.Arm() ? "ARMED" : "ERROR barrier active");
+    } else if (command == "PUT_DURING_ATTACH") {
+      const auto result = store.Put("session/" + sid, "during_attach", std::int64_t{7});
+      protocol.Write(result.IsOk() ? "DELTA_SUBMITTED" : "ERROR delta submission");
+    } else if (command == "RELEASE_SNAPSHOT") {
+      node_transport.Release();
+      protocol.Write("SNAPSHOT_RELEASED");
+    } else if (command == "BATCH_STATUS") {
+      protocol.Write(node_transport.BatchStatus());
+    } else if (command.starts_with("WAIT_BATCH ")) {
+      const auto previous =
+          static_cast<std::size_t>(std::stoull(command.substr(std::string("WAIT_BATCH ").size())));
+      protocol.Write(node_transport.WaitForBatchAfter(previous));
+    } else if (command.starts_with("WAIT_PEER ")) {
+      std::istringstream fields(command);
+      std::string name;
+      std::string key;
+      std::int64_t expected = 0;
+      fields >> name >> key >> expected;
+      if (fields && peer_transport->WaitForValue(peer, key, expected)) {
+        protocol.Write("PEER_OBSERVED " + key + " " + std::to_string(expected));
+      } else {
+        protocol.Write("ERROR peer timeout");
+      }
+    } else if (command.starts_with("CHECK_ISOLATION ")) {
+      const std::string key = command.substr(std::string("CHECK_ISOLATION ").size());
+      if (IsAbsent(store, "base", key) && IsAbsent(store, "session/s2", key)) {
+        protocol.Write("ISOLATED " + key);
+      } else {
+        protocol.Write("ERROR isolation");
+      }
+    } else if (command == "STOP") {
+      node_transport.Release();
+      break;
+    } else {
+      protocol.Write("ERROR unknown command");
+    }
+  }
+
+  peer.Detach();
+  node.Stop();
+  return 0;
+}

--- a/tests/python/param_cache_fixture.cpp
+++ b/tests/python/param_cache_fixture.cpp
@@ -202,9 +202,16 @@ class PeerTrackingTransport final : public sitos::Transport {
     return inner_->DeclareQueryable(keyexpr, std::move(callback));
   }
 
-  bool WaitForValue(sitos::ParamCache& cache, std::string_view key, std::int64_t expected) {
+  std::size_t CallbackCount() {
+    std::lock_guard lock(mutex_);
+    return callback_count_;
+  }
+
+  bool WaitForValue(sitos::ParamCache& cache, std::size_t previous_callback_count,
+                    std::string_view key, std::int64_t expected) {
     std::unique_lock lock(mutex_);
-    return condition_.wait_for(lock, 5s, [&cache, key, expected] {
+    return condition_.wait_for(lock, 5s, [&cache, this, previous_callback_count, key, expected] {
+      if (callback_count_ <= previous_callback_count) return false;
       const auto value = cache.Get<std::int64_t>(key);
       return value.IsOk() && value.Value() == expected;
     });
@@ -297,13 +304,16 @@ int main(int argc, char** argv) {
       const auto previous =
           static_cast<std::size_t>(std::stoull(command.substr(std::string("WAIT_BATCH ").size())));
       protocol.Write(node_transport.WaitForBatchAfter(previous));
+    } else if (command == "PEER_COUNT") {
+      protocol.Write("PEER_COUNT " + std::to_string(peer_transport->CallbackCount()));
     } else if (command.starts_with("WAIT_PEER ")) {
       std::istringstream fields(command);
       std::string name;
+      std::size_t previous_callback_count = 0;
       std::string key;
       std::int64_t expected = 0;
-      fields >> name >> key >> expected;
-      if (fields && peer_transport->WaitForValue(peer, key, expected)) {
+      fields >> name >> previous_callback_count >> key >> expected;
+      if (fields && peer_transport->WaitForValue(peer, previous_callback_count, key, expected)) {
         protocol.Write("PEER_OBSERVED " + key + " " + std::to_string(expected));
       } else {
         protocol.Write("ERROR peer timeout");

--- a/tests/python/param_cache_fixture.cpp
+++ b/tests/python/param_cache_fixture.cpp
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -39,10 +40,10 @@ class Protocol {
 
 class SnapshotBarrierTransport final : public sitos::Transport {
  public:
-  SnapshotBarrierTransport(std::shared_ptr<sitos::Transport> inner, std::string snapshot_query,
+  SnapshotBarrierTransport(std::shared_ptr<sitos::Transport> inner, std::string barrier_query,
                            std::string batch_key, Protocol& protocol)
       : inner_(std::move(inner)),
-        snapshot_query_(std::move(snapshot_query)),
+        barrier_query_(std::move(barrier_query)),
         batch_key_(std::move(batch_key)),
         protocol_(protocol) {}
 
@@ -91,18 +92,20 @@ class SnapshotBarrierTransport final : public sitos::Transport {
       bool should_block = false;
       {
         std::lock_guard lock(mutex_);
-        if (armed_ && query.keyexpr == snapshot_query_) {
+        if (armed_ && query.keyexpr == barrier_query_) {
           armed_ = false;
           entered_ = true;
           should_block = true;
         }
       }
+      callback(query);
       if (should_block) {
         protocol_.Write("SNAPSHOT_ENTERED");
         std::unique_lock lock(mutex_);
-        condition_.wait(lock, [this] { return released_; });
+        const bool released = condition_.wait_for(lock, 5s, [this] { return released_; });
+        lock.unlock();
+        if (!released) protocol_.Write("ERROR snapshot release timeout");
       }
-      callback(query);
     };
     return inner_->DeclareQueryable(keyexpr, std::move(wrapped));
   }
@@ -147,7 +150,7 @@ class SnapshotBarrierTransport final : public sitos::Transport {
   }
 
   std::shared_ptr<sitos::Transport> inner_;
-  const std::string snapshot_query_;
+  const std::string barrier_query_;
   const std::string batch_key_;
   Protocol& protocol_;
   mutable std::mutex mutex_;
@@ -219,6 +222,17 @@ bool IsAbsent(sitos::ParamStore& store, std::string_view scope, std::string_view
   return result.IsOk() && !result.Value();
 }
 
+bool WaitForStoreValue(sitos::ParamStore& store, std::string_view scope, std::string_view key,
+                       std::int64_t expected) {
+  const auto deadline = std::chrono::steady_clock::now() + 5s;
+  do {
+    const auto value = store.Get<std::int64_t>(scope, key);
+    if (value.IsOk() && value.Value() == expected) return true;
+    std::this_thread::yield();
+  } while (std::chrono::steady_clock::now() < deadline);
+  return false;
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -232,9 +246,9 @@ int main(int argc, char** argv) {
   std::shared_ptr<sitos::Transport> raw(std::move(opened).Value());
 
   Protocol protocol;
-  const std::string snapshot_query = prefix + "/snap/" + sid + "/**";
+  const std::string overlay_query = prefix + "/session/" + sid + "/**";
   const std::string batch_key = prefix + "/session/" + sid + "/:batch";
-  SnapshotBarrierTransport node_transport(raw, snapshot_query, batch_key, protocol);
+  SnapshotBarrierTransport node_transport(raw, overlay_query, batch_key, protocol);
   auto peer_transport = std::make_shared<PeerTrackingTransport>(raw);
   auto engine = std::make_shared<sitos::InMemoryEngine>();
   sitos::StorageNode node(node_transport);
@@ -270,8 +284,10 @@ int main(int argc, char** argv) {
     if (command == "ARM_SNAPSHOT") {
       protocol.Write(node_transport.Arm() ? "ARMED" : "ERROR barrier active");
     } else if (command == "PUT_DURING_ATTACH") {
-      const auto result = store.Put("session/" + sid, "during_attach", std::int64_t{7});
-      protocol.Write(result.IsOk() ? "DELTA_SUBMITTED" : "ERROR delta submission");
+      const std::string scope = "session/" + sid;
+      const auto result = store.Put(scope, "during_attach", std::int64_t{7});
+      const bool observed = result.IsOk() && WaitForStoreValue(store, scope, "during_attach", 7);
+      protocol.Write(observed ? "DELTA_SUBMITTED" : "ERROR delta submission");
     } else if (command == "RELEASE_SNAPSHOT") {
       node_transport.Release();
       protocol.Write("SNAPSHOT_RELEASED");

--- a/tests/python/test_param_cache.py
+++ b/tests/python/test_param_cache.py
@@ -1,0 +1,202 @@
+"""Acceptance tests for the Python ParamCache binding."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+import sitos
+
+
+def _load_check_wheel():
+    script = Path(__file__).resolve().parents[2] / "scripts" / "check_wheel.py"
+    spec = importlib.util.spec_from_file_location("sitos_check_wheel", script)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load the wheel validator")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    "member",
+    [
+        "sitos/sitos_python_param_cache_fixture.exe",
+        "sitos/sitos_python_param_cache_fixture",
+    ],
+)
+def test_wheel_validator_rejects_param_cache_fixture_member(member: str) -> None:
+    with pytest.raises(RuntimeError, match="forbidden wheel entry"):
+        _load_check_wheel().validate_wheel_members([member])
+
+
+def test_public_param_cache_is_exported_without_deferred_apis() -> None:
+    assert hasattr(sitos, "ParamCache")
+    assert not hasattr(sitos.ParamCache, "attach_base")
+    assert not hasattr(sitos.ParamCache, "stale")
+    assert not hasattr(sitos.ParamCache, "get_array")
+
+
+def test_constructor_is_keyword_only_and_validates_timeout() -> None:
+    with pytest.raises(TypeError):
+        sitos.ParamCache("sitos", None, 5000)
+    with pytest.raises(TypeError):
+        sitos.ParamCache(query_timeout_ms=True)
+    for timeout in (0, -1, 2**63):
+        with pytest.raises(ValueError):
+            sitos.ParamCache(query_timeout_ms=timeout)
+
+
+def test_constructor_rejects_empty_json() -> None:
+    with pytest.raises(ValueError):
+        sitos.ParamCache(zenoh_config_json="")
+
+
+def test_context_manager_performs_terminal_close() -> None:
+    with sitos.ParamCache(query_timeout_ms=5000) as cache:
+        assert isinstance(cache, sitos.ParamCache)
+    with pytest.raises(ValueError, match="ParamCache is closed"):
+        cache.contains("key")
+    cache.close()
+    cache.detach()
+
+
+def test_close_precedes_conversion_and_batch_iteration() -> None:
+    cache = sitos.ParamCache(query_timeout_ms=5000)
+    cache.close()
+
+    class ExplodingEntries:
+        def __iter__(self):
+            raise AssertionError("closed cache must not iterate entries")
+
+    with pytest.raises(ValueError, match="ParamCache is closed"):
+        cache.put("key", object())
+    with pytest.raises(ValueError, match="ParamCache is closed"):
+        cache.put_batch(ExplodingEntries())
+    with pytest.raises(ValueError, match="ParamCache is closed"):
+        cache.attach("s1")
+    with pytest.raises(ValueError, match="ParamCache is closed"):
+        cache.get("key")
+    with pytest.raises(ValueError, match="ParamCache is closed"):
+        cache.items()
+
+
+def test_detach_is_idempotent_and_cache_can_reattach() -> None:
+    cache = sitos.ParamCache(query_timeout_ms=5000)
+    try:
+        cache.detach()
+        cache.detach()
+        cache.attach("unknown_but_valid")
+        assert cache.contains("missing") is False
+        cache.detach()
+        cache.attach("unknown_but_valid")
+    finally:
+        cache.close()
+
+
+def test_malformed_sid_and_already_attached_are_rejected() -> None:
+    cache = sitos.ParamCache(query_timeout_ms=5000)
+    try:
+        with pytest.raises(ValueError):
+            cache.attach("bad/session")
+        cache.attach("s1")
+        with pytest.raises(ValueError):
+            cache.attach("s2")
+    finally:
+        cache.close()
+
+
+def test_detached_operations_preserve_invalid_argument_mapping() -> None:
+    cache = sitos.ParamCache(query_timeout_ms=5000)
+    try:
+        with pytest.raises(ValueError):
+            cache.get("key")
+        with pytest.raises(ValueError):
+            cache.contains("key")
+        with pytest.raises(ValueError):
+            cache.items()
+        with pytest.raises(ValueError):
+            cache.put("key", 1)
+        with pytest.raises(ValueError):
+            cache.put_batch([])
+    finally:
+        cache.close()
+
+
+def test_public_exception_types_are_shared_with_param_store() -> None:
+    assert issubclass(sitos.NotFoundError, sitos.SitosError)
+    assert issubclass(sitos.TypeMismatchError, sitos.SitosError)
+    assert sitos.ParamCache.__module__ == "sitos._sitos"
+
+
+def test_get_type_is_keyword_only_and_exact_builtin() -> None:
+    cache = sitos.ParamCache(query_timeout_ms=5000)
+    try:
+        cache.attach("s1")
+        cache.put("typed", 3.5)
+        assert cache.get("typed", type=int) == 3
+        with pytest.raises(TypeError):
+            cache.get("typed", None, int)
+
+        class SpoofType:
+            def __eq__(self, other: object) -> bool:
+                return other in (bool, int, float, str, bytes)
+
+        with pytest.raises(TypeError, match="type must be None"):
+            cache.get("typed", type=SpoofType())
+    finally:
+        cache.close()
+
+
+def test_get_default_only_substitutes_not_found() -> None:
+    cache = sitos.ParamCache(query_timeout_ms=5000)
+    try:
+        cache.attach("s1")
+        assert cache.get("missing", default=None) is None
+        assert cache.get("missing", default=object()) is not None
+        with pytest.raises(ValueError):
+            cache.get("bad key", default="must not mask validation")
+    finally:
+        cache.close()
+
+
+def test_local_values_batch_order_raw_prefix_and_owned_items() -> None:
+    cache = sitos.ParamCache(query_timeout_ms=5000)
+    try:
+        cache.attach("s1")
+        values = {
+            "bool": True,
+            "s64": -7,
+            "dp": 3.5,
+            "str": "text",
+            "bytes": b"bytes",
+        }
+        cache.put_batch(values)
+        cache.put_batch([("dup", 1), ("dup", 2)])
+        cache.put("foo/bar", 7)
+        cache.put("foobar", "outside")
+        assert cache.get("dup") == 2
+        assert cache.contains("foo/bar")
+        assert list(cache.items("foo")) == [("foo/bar", 7), ("foobar", "outside")]
+        rows = cache.items("foo/")
+        cache.detach()
+        assert list(rows) == [("foo/bar", 7)]
+    finally:
+        cache.close()
+
+
+def test_batch_validation_and_supported_value_boundary() -> None:
+    cache = sitos.ParamCache(query_timeout_ms=5000)
+    try:
+        cache.attach("s1")
+        with pytest.raises(ValueError, match="two items"):
+            cache.put_batch([("a",)])
+        with pytest.raises(TypeError, match="two-item pairs"):
+            cache.put_batch(["not-a-pair"])
+        with pytest.raises(OverflowError):
+            cache.put("overflow", 2**63)
+        with pytest.raises(TypeError):
+            cache.put("unsupported", bytearray(b"bytes"))
+        cache.put_batch([])
+    finally:
+        cache.close()

--- a/tests/python/test_param_cache.py
+++ b/tests/python/test_param_cache.py
@@ -1,4 +1,4 @@
-"""Acceptance tests for the Python ParamCache binding."""
+"""Fixture-free acceptance tests for the Python ParamCache binding."""
 
 import importlib.util
 from pathlib import Path
@@ -81,122 +81,7 @@ def test_close_precedes_conversion_and_batch_iteration() -> None:
         cache.items()
 
 
-def test_detach_is_idempotent_and_cache_can_reattach() -> None:
-    cache = sitos.ParamCache(query_timeout_ms=5000)
-    try:
-        cache.detach()
-        cache.detach()
-        cache.attach("unknown_but_valid")
-        assert cache.contains("missing") is False
-        cache.detach()
-        cache.attach("unknown_but_valid")
-    finally:
-        cache.close()
-
-
-def test_malformed_sid_and_already_attached_are_rejected() -> None:
-    cache = sitos.ParamCache(query_timeout_ms=5000)
-    try:
-        with pytest.raises(ValueError):
-            cache.attach("bad/session")
-        cache.attach("s1")
-        with pytest.raises(ValueError):
-            cache.attach("s2")
-    finally:
-        cache.close()
-
-
-def test_detached_operations_preserve_invalid_argument_mapping() -> None:
-    cache = sitos.ParamCache(query_timeout_ms=5000)
-    try:
-        with pytest.raises(ValueError):
-            cache.get("key")
-        with pytest.raises(ValueError):
-            cache.contains("key")
-        with pytest.raises(ValueError):
-            cache.items()
-        with pytest.raises(ValueError):
-            cache.put("key", 1)
-        with pytest.raises(ValueError):
-            cache.put_batch([])
-    finally:
-        cache.close()
-
-
 def test_public_exception_types_are_shared_with_param_store() -> None:
     assert issubclass(sitos.NotFoundError, sitos.SitosError)
     assert issubclass(sitos.TypeMismatchError, sitos.SitosError)
     assert sitos.ParamCache.__module__ == "sitos._sitos"
-
-
-def test_get_type_is_keyword_only_and_exact_builtin() -> None:
-    cache = sitos.ParamCache(query_timeout_ms=5000)
-    try:
-        cache.attach("s1")
-        cache.put("typed", 3.5)
-        assert cache.get("typed", type=int) == 3
-        with pytest.raises(TypeError):
-            cache.get("typed", None, int)
-
-        class SpoofType:
-            def __eq__(self, other: object) -> bool:
-                return other in (bool, int, float, str, bytes)
-
-        with pytest.raises(TypeError, match="type must be None"):
-            cache.get("typed", type=SpoofType())
-    finally:
-        cache.close()
-
-
-def test_get_default_only_substitutes_not_found() -> None:
-    cache = sitos.ParamCache(query_timeout_ms=5000)
-    try:
-        cache.attach("s1")
-        assert cache.get("missing", default=None) is None
-        assert cache.get("missing", default=object()) is not None
-        with pytest.raises(ValueError):
-            cache.get("bad key", default="must not mask validation")
-    finally:
-        cache.close()
-
-
-def test_local_values_batch_order_raw_prefix_and_owned_items() -> None:
-    cache = sitos.ParamCache(query_timeout_ms=5000)
-    try:
-        cache.attach("s1")
-        values = {
-            "bool": True,
-            "s64": -7,
-            "dp": 3.5,
-            "str": "text",
-            "bytes": b"bytes",
-        }
-        cache.put_batch(values)
-        cache.put_batch([("dup", 1), ("dup", 2)])
-        cache.put("foo/bar", 7)
-        cache.put("foobar", "outside")
-        assert cache.get("dup") == 2
-        assert cache.contains("foo/bar")
-        assert list(cache.items("foo")) == [("foo/bar", 7), ("foobar", "outside")]
-        rows = cache.items("foo/")
-        cache.detach()
-        assert list(rows) == [("foo/bar", 7)]
-    finally:
-        cache.close()
-
-
-def test_batch_validation_and_supported_value_boundary() -> None:
-    cache = sitos.ParamCache(query_timeout_ms=5000)
-    try:
-        cache.attach("s1")
-        with pytest.raises(ValueError, match="two items"):
-            cache.put_batch([("a",)])
-        with pytest.raises(TypeError, match="two-item pairs"):
-            cache.put_batch(["not-a-pair"])
-        with pytest.raises(OverflowError):
-            cache.put("overflow", 2**63)
-        with pytest.raises(TypeError):
-            cache.put("unsupported", bytearray(b"bytes"))
-        cache.put_batch([])
-    finally:
-        cache.close()

--- a/tests/python/test_param_cache.py
+++ b/tests/python/test_param_cache.py
@@ -69,16 +69,17 @@ def test_close_precedes_conversion_and_batch_iteration() -> None:
         def __iter__(self):
             raise AssertionError("closed cache must not iterate entries")
 
-    with pytest.raises(ValueError, match="ParamCache is closed"):
-        cache.put("key", object())
-    with pytest.raises(ValueError, match="ParamCache is closed"):
-        cache.put_batch(ExplodingEntries())
-    with pytest.raises(ValueError, match="ParamCache is closed"):
-        cache.attach("s1")
-    with pytest.raises(ValueError, match="ParamCache is closed"):
-        cache.get("key")
-    with pytest.raises(ValueError, match="ParamCache is closed"):
-        cache.items()
+    closed_operations = [
+        lambda: cache.attach(object()),
+        lambda: cache.put(object(), object()),
+        lambda: cache.put_batch(ExplodingEntries()),
+        lambda: cache.get(object()),
+        lambda: cache.contains(object()),
+        lambda: cache.items(object()),
+    ]
+    for operation in closed_operations:
+        with pytest.raises(ValueError, match="ParamCache is closed"):
+            operation()
 
 
 def test_public_exception_types_are_shared_with_param_store() -> None:

--- a/tests/python/test_param_cache_live.py
+++ b/tests/python/test_param_cache_live.py
@@ -249,9 +249,11 @@ def test_write_reaches_cpp_peer_without_base_or_other_session_mutation(
     cache = _new_cache(config)
     try:
         cache.attach("s1")
+        _send(process, "PEER_COUNT")
+        previous_callback_count = int(_readline_with_timeout(process.stdout).split()[1])
         cache.put("peer_value", 41)
         assert cache.get("peer_value") == 41
-        _send(process, "WAIT_PEER peer_value 41")
+        _send(process, f"WAIT_PEER {previous_callback_count} peer_value 41")
         assert _readline_with_timeout(process.stdout) == "PEER_OBSERVED peer_value 41"
         _send(process, "CHECK_ISOLATION peer_value")
         assert _readline_with_timeout(process.stdout) == "ISOLATED peer_value"

--- a/tests/python/test_param_cache_live.py
+++ b/tests/python/test_param_cache_live.py
@@ -166,7 +166,13 @@ def test_values_typed_get_default_batch_and_owned_items(live_cache_fixture) -> N
             "value/str": "text",
             "value/bytes": b"bytes",
         }
+        _send(process, "BATCH_STATUS")
+        initial_batch_count = int(_readline_with_timeout(process.stdout).split()[1])
         cache.put_batch(values)
+        _send(process, f"WAIT_BATCH {initial_batch_count}")
+        first_status = _readline_with_timeout(process.stdout)
+        assert int(first_status.split()[1]) == initial_batch_count + 1
+        assert first_status.split()[2] == "5"
         for key, expected in values.items():
             assert cache.get(key) == expected
         assert cache.get("value/dp", type=int) == 3
@@ -178,9 +184,11 @@ def test_values_typed_get_default_batch_and_owned_items(live_cache_fixture) -> N
         with pytest.raises(ValueError):
             cache.get("bad key", default=sentinel)
 
+        _send(process, "BATCH_STATUS")
+        before_count = int(_readline_with_timeout(process.stdout).split()[1])
         cache.put_batch([("value/dup", 1), ("value/dup", 2)])
         assert cache.get("value/dup") == 2
-        _send(process, "BATCH_STATUS")
+        _send(process, f"WAIT_BATCH {before_count}")
         status = _readline_with_timeout(process.stdout)
         assert status.endswith(" 2 1 2")
         before_count = int(status.split()[1])
@@ -242,7 +250,8 @@ def test_terminal_close_waits_for_admitted_attach_and_releases_gil(live_cache_fi
     assert process.stdout is not None
     cache = _new_cache(config)
     attach_result: list[object] = []
-    close_done = threading.Event()
+    first_close_done = threading.Event()
+    second_close_done = threading.Event()
 
     _send(process, "ARM_SNAPSHOT")
     assert _readline_with_timeout(process.stdout) == "ARMED"
@@ -250,8 +259,13 @@ def test_terminal_close_waits_for_admitted_attach_and_releases_gil(live_cache_fi
     attach.start()
     assert _readline_with_timeout(process.stdout) == "SNAPSHOT_ENTERED"
 
-    closer = threading.Thread(target=lambda: (cache.close(), close_done.set()), daemon=True)
-    closer.start()
+    first_closer = threading.Thread(
+        target=lambda: (cache.close(), first_close_done.set()), daemon=True
+    )
+    second_closer = threading.Thread(
+        target=lambda: (cache.close(), second_close_done.set()), daemon=True
+    )
+    first_closer.start()
     deadline = time.monotonic() + 5
     while time.monotonic() < deadline:
         try:
@@ -263,7 +277,9 @@ def test_terminal_close_waits_for_admitted_attach_and_releases_gil(live_cache_fi
     else:
         raise AssertionError("close did not close operation admission")
 
-    assert not close_done.is_set()
+    second_closer.start()
+    assert not first_close_done.is_set()
+    assert not second_close_done.is_set()
     progress: list[bool] = []
     worker = threading.Thread(target=lambda: progress.append(True))
     worker.start()
@@ -273,10 +289,13 @@ def test_terminal_close_waits_for_admitted_attach_and_releases_gil(live_cache_fi
     _send(process, "RELEASE_SNAPSHOT")
     assert _readline_with_timeout(process.stdout) == "SNAPSHOT_RELEASED"
     attach.join(timeout=5)
-    closer.join(timeout=5)
+    first_closer.join(timeout=5)
+    second_closer.join(timeout=5)
     assert not attach.is_alive()
-    assert not closer.is_alive()
-    assert close_done.is_set()
+    assert not first_closer.is_alive()
+    assert not second_closer.is_alive()
+    assert first_close_done.is_set()
+    assert second_close_done.is_set()
     assert len(attach_result) == 1
     with pytest.raises(ValueError, match="ParamCache is closed"):
         cache.attach("s1")

--- a/tests/python/test_param_cache_live.py
+++ b/tests/python/test_param_cache_live.py
@@ -1,0 +1,284 @@
+"""Live acceptance tests for the Python ParamCache binding."""
+
+import json
+import os
+import queue
+import socket
+import subprocess
+import threading
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+import sitos
+
+
+_FIXTURE = os.environ.get("SITOS_PYTHON_CACHE_FIXTURE")
+pytestmark = pytest.mark.skipif(
+    not _FIXTURE or not Path(_FIXTURE).is_file(),
+    reason="SITOS_PYTHON_CACHE_FIXTURE is not set",
+)
+
+
+def _readline_with_timeout(stream, timeout: float = 10.0) -> str:
+    lines: queue.Queue[str] = queue.Queue(maxsize=1)
+
+    def read() -> None:
+        lines.put(stream.readline())
+
+    reader = threading.Thread(target=read, daemon=True)
+    reader.start()
+    reader.join(timeout)
+    if reader.is_alive():
+        raise AssertionError(f"fixture did not produce a line within {timeout:g} seconds")
+    return lines.get_nowait().strip()
+
+
+def _send(process: subprocess.Popen[str], command: str) -> None:
+    assert process.stdin is not None
+    process.stdin.write(f"{command}\n")
+    process.stdin.flush()
+
+
+def _stop_fixture_process(process: subprocess.Popen[str]) -> None:
+    if process.poll() is None:
+        try:
+            _send(process, "STOP")
+        except BrokenPipeError:
+            pass
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=10)
+
+
+@pytest.fixture(scope="module")
+def live_cache_fixture() -> Iterator[tuple[subprocess.Popen[str], dict[str, object]]]:
+    assert _FIXTURE is not None
+    prefix = f"sitos/python_cache_{os.getpid()}"
+    sid = "s1"
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+    process = subprocess.Popen(
+        [_FIXTURE, prefix, str(port), sid],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    try:
+        assert process.stdout is not None
+        assert _readline_with_timeout(process.stdout) == f"READY {prefix} {port} {sid}"
+        config = {
+            "prefix": prefix,
+            "zenoh_config_json": json.dumps(
+                {"mode": "client", "connect": {"endpoints": [f"tcp/127.0.0.1:{port}"]}}
+            ),
+            "query_timeout_ms": 5000,
+        }
+        yield process, config
+    finally:
+        _stop_fixture_process(process)
+
+
+def _new_cache(config: dict[str, object]):
+    return sitos.ParamCache(**config)
+
+
+def _eventually_get(cache, key: str, timeout: float = 5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            return cache.get(key)
+        except sitos.NotFoundError:
+            threading.Event().wait(0.01)
+    raise AssertionError(f"timed out waiting for cache key {key}")
+
+
+def test_attach_validation_detach_and_reattach(live_cache_fixture) -> None:
+    _, config = live_cache_fixture
+    cache = _new_cache(config)
+    try:
+        cache.detach()
+        with pytest.raises(ValueError):
+            cache.attach("bad/session")
+        cache.attach("unknown_but_valid")
+        assert cache.contains("missing") is False
+        with pytest.raises(ValueError):
+            cache.attach("s1")
+        cache.detach()
+        cache.attach("s1")
+        cache.detach()
+        cache.attach("s1")
+    finally:
+        cache.close()
+
+
+def test_attach_buffers_controlled_concurrent_delta(live_cache_fixture) -> None:
+    process, config = live_cache_fixture
+    assert process.stdout is not None
+    cache = _new_cache(config)
+    result: list[object] = []
+    try:
+        _send(process, "ARM_SNAPSHOT")
+        assert _readline_with_timeout(process.stdout) == "ARMED"
+        attach = threading.Thread(target=lambda: result.append(cache.attach("s1")), daemon=True)
+        attach.start()
+        assert _readline_with_timeout(process.stdout) == "SNAPSHOT_ENTERED"
+
+        progress: list[bool] = []
+        worker = threading.Thread(target=lambda: progress.append(True))
+        worker.start()
+        worker.join(timeout=2)
+        assert progress == [True]
+
+        _send(process, "PUT_DURING_ATTACH")
+        assert _readline_with_timeout(process.stdout) == "DELTA_SUBMITTED"
+        _send(process, "RELEASE_SNAPSHOT")
+        assert _readline_with_timeout(process.stdout) == "SNAPSHOT_RELEASED"
+        attach.join(timeout=5)
+        assert not attach.is_alive()
+        assert result == [None]
+        assert _eventually_get(cache, "during_attach") == 7
+    finally:
+        cache.close()
+
+
+def test_values_typed_get_default_batch_and_owned_items(live_cache_fixture) -> None:
+    process, config = live_cache_fixture
+    assert process.stdout is not None
+    cache = _new_cache(config)
+    try:
+        cache.attach("s1")
+        values = {
+            "value/bool": True,
+            "value/s64": -7,
+            "value/dp": 3.5,
+            "value/str": "text",
+            "value/bytes": b"bytes",
+        }
+        cache.put_batch(values)
+        for key, expected in values.items():
+            assert cache.get(key) == expected
+        assert cache.get("value/dp", type=int) == 3
+        with pytest.raises(sitos.TypeMismatchError):
+            cache.get("value/str", type=bytes)
+
+        sentinel = object()
+        assert cache.get("value/missing", default=sentinel) is sentinel
+        with pytest.raises(ValueError):
+            cache.get("bad key", default=sentinel)
+
+        cache.put_batch([("value/dup", 1), ("value/dup", 2)])
+        assert cache.get("value/dup") == 2
+        _send(process, "BATCH_STATUS")
+        status = _readline_with_timeout(process.stdout)
+        assert status.endswith(" 2 1 2")
+        before_count = int(status.split()[1])
+        cache.put_batch([])
+        _send(process, "BATCH_STATUS")
+        assert int(_readline_with_timeout(process.stdout).split()[1]) == before_count
+
+        cache.put("foo/bar", 7)
+        cache.put("foobar", "outside")
+        assert list(cache.items("foo")) == [("foo/bar", 7), ("foobar", "outside")]
+        rows = cache.items("foo/")
+        cache.detach()
+        assert list(rows) == [("foo/bar", 7)]
+    finally:
+        cache.close()
+
+
+def test_invalid_inputs_leave_existing_local_state_unchanged(live_cache_fixture) -> None:
+    _, config = live_cache_fixture
+    cache = _new_cache(config)
+    try:
+        cache.attach("s1")
+        cache.put("stable", 11)
+        with pytest.raises(ValueError, match="two items"):
+            cache.put_batch([("stable", 12, "extra")])
+        with pytest.raises(TypeError, match="two-item pairs"):
+            cache.put_batch(["not-a-pair"])
+        with pytest.raises(TypeError):
+            cache.put("stable", bytearray(b"unsupported"))
+        with pytest.raises(OverflowError):
+            cache.put("stable", 2**63)
+        with pytest.raises(ValueError):
+            cache.items("bad prefix")
+        assert cache.get("stable") == 11
+    finally:
+        cache.close()
+
+
+def test_write_reaches_cpp_peer_without_base_or_other_session_mutation(
+    live_cache_fixture,
+) -> None:
+    process, config = live_cache_fixture
+    assert process.stdout is not None
+    cache = _new_cache(config)
+    try:
+        cache.attach("s1")
+        cache.put("peer_value", 41)
+        assert cache.get("peer_value") == 41
+        _send(process, "WAIT_PEER peer_value 41")
+        assert _readline_with_timeout(process.stdout) == "PEER_OBSERVED peer_value 41"
+        _send(process, "CHECK_ISOLATION peer_value")
+        assert _readline_with_timeout(process.stdout) == "ISOLATED peer_value"
+    finally:
+        cache.close()
+
+
+def test_terminal_close_waits_for_admitted_attach_and_releases_gil(live_cache_fixture) -> None:
+    process, config = live_cache_fixture
+    assert process.stdout is not None
+    cache = _new_cache(config)
+    attach_result: list[object] = []
+    close_done = threading.Event()
+
+    _send(process, "ARM_SNAPSHOT")
+    assert _readline_with_timeout(process.stdout) == "ARMED"
+    attach = threading.Thread(target=lambda: attach_result.append(cache.attach("s1")), daemon=True)
+    attach.start()
+    assert _readline_with_timeout(process.stdout) == "SNAPSHOT_ENTERED"
+
+    closer = threading.Thread(target=lambda: (cache.close(), close_done.set()), daemon=True)
+    closer.start()
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            cache.contains("key")
+        except ValueError as error:
+            if str(error) == "ParamCache is closed":
+                break
+        threading.Event().wait(0.01)
+    else:
+        raise AssertionError("close did not close operation admission")
+
+    assert not close_done.is_set()
+    progress: list[bool] = []
+    worker = threading.Thread(target=lambda: progress.append(True))
+    worker.start()
+    worker.join(timeout=2)
+    assert progress == [True]
+
+    _send(process, "RELEASE_SNAPSHOT")
+    assert _readline_with_timeout(process.stdout) == "SNAPSHOT_RELEASED"
+    attach.join(timeout=5)
+    closer.join(timeout=5)
+    assert not attach.is_alive()
+    assert not closer.is_alive()
+    assert close_done.is_set()
+    assert len(attach_result) == 1
+    with pytest.raises(ValueError, match="ParamCache is closed"):
+        cache.attach("s1")
+    cache.close()
+    cache.detach()

--- a/tests/python/test_param_cache_live.py
+++ b/tests/python/test_param_cache_live.py
@@ -94,25 +94,27 @@ def _new_cache(config: dict[str, object]):
     return sitos.ParamCache(**config)
 
 
-def _eventually_get(cache, key: str, timeout: float = 5.0):
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            return cache.get(key)
-        except sitos.NotFoundError:
-            threading.Event().wait(0.01)
-    raise AssertionError(f"timed out waiting for cache key {key}")
-
-
 def test_attach_validation_detach_and_reattach(live_cache_fixture) -> None:
     _, config = live_cache_fixture
     cache = _new_cache(config)
     try:
         cache.detach()
+        detached_operations = [
+            lambda: cache.get("missing"),
+            lambda: cache.contains("missing"),
+            lambda: list(cache.items()),
+            lambda: cache.put("detached", 1),
+            lambda: cache.put_batch([]),
+        ]
+        for operation in detached_operations:
+            with pytest.raises(ValueError, match="detached"):
+                operation()
+
         with pytest.raises(ValueError):
             cache.attach("bad/session")
         cache.attach("unknown_but_valid")
         assert cache.contains("missing") is False
+        assert cache.get("missing", default=None) is None
         with pytest.raises(ValueError):
             cache.attach("s1")
         cache.detach()
@@ -123,11 +125,12 @@ def test_attach_validation_detach_and_reattach(live_cache_fixture) -> None:
         cache.close()
 
 
-def test_attach_buffers_controlled_concurrent_delta(live_cache_fixture) -> None:
+def test_attach_observes_controlled_concurrent_delta(live_cache_fixture) -> None:
     process, config = live_cache_fixture
     assert process.stdout is not None
     cache = _new_cache(config)
     result: list[object] = []
+    released = False
     try:
         _send(process, "ARM_SNAPSHOT")
         assert _readline_with_timeout(process.stdout) == "ARMED"
@@ -144,12 +147,16 @@ def test_attach_buffers_controlled_concurrent_delta(live_cache_fixture) -> None:
         _send(process, "PUT_DURING_ATTACH")
         assert _readline_with_timeout(process.stdout) == "DELTA_SUBMITTED"
         _send(process, "RELEASE_SNAPSHOT")
+        released = True
         assert _readline_with_timeout(process.stdout) == "SNAPSHOT_RELEASED"
         attach.join(timeout=5)
         assert not attach.is_alive()
         assert result == [None]
-        assert _eventually_get(cache, "during_attach") == 7
+        assert cache.get("during_attach") == 7
     finally:
+        if not released:
+            _send(process, "RELEASE_SNAPSHOT")
+            _readline_with_timeout(process.stdout)
         cache.close()
 
 
@@ -179,8 +186,15 @@ def test_values_typed_get_default_batch_and_owned_items(live_cache_fixture) -> N
         with pytest.raises(sitos.TypeMismatchError):
             cache.get("value/str", type=bytes)
 
+        class IntSubclass(int):
+            pass
+
+        with pytest.raises(TypeError, match="type must be"):
+            cache.get("value/s64", type=IntSubclass)
+
         sentinel = object()
         assert cache.get("value/missing", default=sentinel) is sentinel
+        assert cache.get("value/missing", default=None) is None
         with pytest.raises(ValueError):
             cache.get("bad key", default=sentinel)
 
@@ -242,6 +256,50 @@ def test_write_reaches_cpp_peer_without_base_or_other_session_mutation(
         _send(process, "CHECK_ISOLATION peer_value")
         assert _readline_with_timeout(process.stdout) == "ISOLATED peer_value"
     finally:
+        cache.close()
+
+
+def test_detach_waits_for_admitted_attach_and_releases_gil(live_cache_fixture) -> None:
+    process, config = live_cache_fixture
+    assert process.stdout is not None
+    cache = _new_cache(config)
+    attach_result: list[object] = []
+    detach_done = threading.Event()
+    released = False
+
+    try:
+        _send(process, "ARM_SNAPSHOT")
+        assert _readline_with_timeout(process.stdout) == "ARMED"
+        attach = threading.Thread(
+            target=lambda: attach_result.append(cache.attach("s1")), daemon=True
+        )
+        attach.start()
+        assert _readline_with_timeout(process.stdout) == "SNAPSHOT_ENTERED"
+
+        detacher = threading.Thread(target=lambda: (cache.detach(), detach_done.set()), daemon=True)
+        detacher.start()
+        progress: list[bool] = []
+        worker = threading.Thread(target=lambda: progress.append(True))
+        worker.start()
+        worker.join(timeout=2)
+        assert progress == [True]
+        assert not detach_done.is_set()
+
+        _send(process, "RELEASE_SNAPSHOT")
+        released = True
+        assert _readline_with_timeout(process.stdout) == "SNAPSHOT_RELEASED"
+        attach.join(timeout=5)
+        detacher.join(timeout=5)
+        assert not attach.is_alive()
+        assert not detacher.is_alive()
+        assert attach_result == [None]
+        assert detach_done.is_set()
+        with pytest.raises(ValueError, match="detached"):
+            cache.get("during_attach")
+    finally:
+        if not released:
+            _send(process, "RELEASE_SNAPSHOT")
+            _readline_with_timeout(process.stdout)
         cache.close()
 
 


### PR DESCRIPTION
## Summary

Closes #24

- Add the session-only Python `ParamCache` API with Attach/Detach, owned local reads, session writes, typed Get, eager lexical Items, and terminal quiescent Close.
- Reuse the exact Issue #23 Status/exception/timeout/typed-conversion boundary through one shared binding utility.
- Add a source-only single-session C++ fixture with deterministic snapshot, peer, batch, and shutdown handshakes while keeping repaired-wheel tests fixture-free.

## Requirements

- P01 — provide Python APIs with the same ParamCache concepts and semantics as C++.
- ADR-0022 — keep ParamCache session-only; do not restore AttachBase.
- ADR-0023 — preserve submission-first writes, per-cache sequencing, ownership, and native quiescence.
- ADR-0026 — keep fixture binaries out of repaired wheels and leave Zenoh runtime bundling to repair tools.

## Scope Checklist

- [x] `python/bindings/param_cache.cpp` and `python/sitos/cache.py`
- [x] `attach(sid)`, reusable `detach()`, and terminal quiescent `close()`
- [x] `get(key, default=..., *, type=...)`, `contains`, and lexical owned `items(prefix)`
- [x] session-only `put` and duplicate-preserving single-message `put_batch`
- [x] shared Issue #23 exception, Status, timeout, and typed-conversion helpers
- [x] deterministic operation admission, GIL release, concurrent Close, and native ownership release
- [x] fixture-free repaired-wheel API checks
- [x] source-only attach/concurrent-delta, peer, batch, isolation, GIL, and Close tests
- [x] no `attach_base`, `stale`, `get_array`, callbacks, Transport injection, or delivery-barrier API
- [x] Python API and roadmap documentation updated

## Acceptance Criteria Verification

### Python acceptance

```text
python -m pytest \
  tests/python/test_param_value.py \
  tests/python/test_param_store.py \
  tests/python/test_param_cache.py \
  tests/python/test_param_cache_live.py -q

71 passed, 1 skipped in 4.41s
```

The live ParamCache suite was additionally run ten times against
`build-on/tests/sitos_python_param_cache_fixture.exe`:

```text
10 runs × 6 passed; no failures
```

### C++ and transport regression

```text
Zenoh ON, MSVC Debug: 323/323 passed
Zenoh OFF, MSVC Debug: 276/276 passed
```

### Installed Python component

```text
cmake --install build-on --component python --prefix .pi/install-24
python -c "import sitos; ... ParamCache ..."
0.1.0
```

The installed component contains `_sitos`, `__init__.py`, `cache.py`, and `store.py`. The smoke test confirms `ParamCache` export, construction, terminal Close, and deferred-API absence.

### Additional checks

```text
git diff origin/main...HEAD --check
python -m py_compile ...
secret scan: no issues
```

## RED-phase Confirmation

Genuine RED was recorded before production implementation in commits `039a6a2` and `81698dd` using the pre-existing Issue #23 extension from the canonical `build-on` tree:

```text
python -m pytest \
  tests/python/test_param_cache.py \
  tests/python/test_param_cache_live.py -q

FFFFFFFFssssss
8 failed, 6 skipped in 0.24s
```

Representative failures:

```text
AssertionError: assert False
 + where False = hasattr(sitos, 'ParamCache')

AttributeError: module 'sitos' has no attribute 'ParamCache'

Failed: DID NOT RAISE <class 'RuntimeError'>
# cache fixture basename was not yet rejected by check_wheel.py
```

The live module was intentionally skipped because the source-only cache fixture did not yet exist. Production binding code first appears in the later commit `dc86800`.

## Design Notes

- Python `get` is built on `ParamCache::GetShared()`; runtime typed conversion does not attempt to call the C++ template `Get<T>` dynamically.
- `PyParamCache` privately owns `Open → Closing → Closed`, an in-flight operation count, a condition variable, stable shared native ownership, and RAII operation leases.
- Close rejects new admission, waits without the GIL, destroys native ownership only after admitted leases release it, and makes concurrent Close callers wait for physical completion.
- ParamStore intentionally retains its existing logical-Close contract; no generic lifecycle framework was introduced.
- No new ADR is required because the implementation applies accepted ADR-0022, ADR-0023, and ADR-0026 without changing wire, Transport, or consistency contracts.

## ADR Needed?

- [x] No
- [ ] Yes — ADR PR: #
