### PR TITLE
docs(process): add contract registry and milestone design-review gate (#115)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,8 +20,8 @@ Paste the failure output from the initial RED tests:
 
 ## ADR Needed?
 
-An ADR is required if docs/10_adr_process.md §6 applies **or** contract-registry Rule 2 does
-(a second surface overlapping an existing registry row).
+An ADR is required when docs/10_adr_process.md §6 applies. §6 includes introducing a second
+surface that overlaps an existing contract-registry row (registry Rule 2).
 
 - [ ] No
 - [ ] Yes — ADR PR: #

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,8 @@ Reference requirement IDs from docs/01_requirements.md (F/N/C/P/X):
 
 ## Contract Registry
 
-Affected contract-registry row(s) (docs/08_contract_registry.md) advanced, or `N/A`:
+Affected contract-registry row(s) (docs/08_contract_registry.md) with their status transition
+(`Contract` / `Implementation` / `none`), or `N/A` if no contract is touched:
 
 ## Acceptance Criteria Verification
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,10 @@ Closes #
 
 Reference requirement IDs from docs/01_requirements.md (F/N/C/P/X):
 
+## Contract Registry
+
+Affected contract-registry row(s) (docs/08_contract_registry.md) advanced, or `N/A`:
+
 ## Acceptance Criteria Verification
 
 Paste test execution logs:
@@ -15,6 +19,9 @@ Paste test execution logs:
 Paste the failure output from the initial RED tests:
 
 ## ADR Needed?
+
+An ADR is required if docs/10_adr_process.md §6 applies **or** contract-registry Rule 2 does
+(a second surface overlapping an existing registry row).
 
 - [ ] No
 - [ ] Yes — ADR PR: #

--- a/docs/00_overview.md
+++ b/docs/00_overview.md
@@ -82,7 +82,7 @@ repository as a general-purpose library not limited to CT reconstruction.
 | [10_adr_process.md](10_adr_process.md) | Public | ADR writing and operation rules (to be moved to docs/adr/README.md) |
 | [development_workflow.md](development_workflow.md) | Public | Branching strategy, TiDD, and TDD operation rules (to be moved to CONTRIBUTING) |
 
-Public documents (00–08) are maintained under `docs/` in the sitos repository.
+All documents listed above are public and maintained under `docs/` in the sitos repository.
 Public documents must not contain references to non-public documents.
 
 ## 6. Record of Major Decisions (ADR Summary)

--- a/docs/00_overview.md
+++ b/docs/00_overview.md
@@ -77,11 +77,12 @@ repository as a general-purpose library not limited to CT reconstruction.
 | [05_api_python.md](05_api_python.md) | Public | Python API specification |
 | [06_build_test_packaging.md](06_build_test_packaging.md) | Public | Build, testing, and packaging |
 | [07_issue_breakdown.md](07_issue_breakdown.md) | Public | Milestones and proposed issue breakdown |
+| [08_contract_registry.md](08_contract_registry.md) | Public | Public contract registry: index of wire surfaces and stable identifiers |
 | [09_dependency_policy.md](09_dependency_policy.md) | Public | Dependency and zenoh compatibility policy |
 | [10_adr_process.md](10_adr_process.md) | Public | ADR writing and operation rules (to be moved to docs/adr/README.md) |
 | [development_workflow.md](development_workflow.md) | Public | Branching strategy, TiDD, and TDD operation rules (to be moved to CONTRIBUTING) |
 
-Public documents (00–07) are maintained under `docs/` in the sitos repository.
+Public documents (00–08) are maintained under `docs/` in the sitos repository.
 Public documents must not contain references to non-public documents.
 
 ## 6. Record of Major Decisions (ADR Summary)

--- a/docs/08_contract_registry.md
+++ b/docs/08_contract_registry.md
@@ -67,7 +67,7 @@ Values that must remain stable across releases because callers persist, compare,
 | Python exception hierarchy (`sitos.SitosError` and current subclasses, Status mapping) | Normative | Implemented | [05](05_api_python.md) §2.1 | — | One registered class per name; mapping extends only when `Status` extends |
 | Planned Python exception: `OutcomeUnknownError` | Planned | Planned | — | #114 → ADR | |
 | Session-id grammar (`<sid>`) | Normative | Implemented | [03](03_wire_protocol.md) §1 | — | `src/key.cpp` `IsValidSessionId`; grammar is never narrowed |
-| `meta/ack/<uuid>` route id grammar (lenient parser, `IsValidAckUuid`) | Planned | Implemented | not yet documented in [03](03_wire_protocol.md) §1 | #14/#114 → ADR | parser-accepted de-facto grammar; to be documented normatively |
+| `meta/ack/<uuid>` route id grammar (lenient parser, `IsValidAckUuid`) | Planned | Implemented | not yet documented in [03](03_wire_protocol.md) §1 | #114 → ADR | parser-accepted de-facto grammar; to be documented normatively; current owner #14 |
 | Generated correlation-id format (canonical UUIDv4) | Planned | Planned | — | #114 → ADR | |
 | Fence result identifiers (`FenceDurability`, `FenceReceipt` fields) | Planned | Planned | — | #107 → ADR | reuses the #106/#114 result protocol |
 | Session state-lost read result (overlay/snapshot lost after restart) | Planned | Planned | — | #108 → ADR | |

--- a/docs/08_contract_registry.md
+++ b/docs/08_contract_registry.md
@@ -52,9 +52,9 @@ open decision (`—` when settled); implementers and consumers are listed separa
 | zenoh Encoding identifiers and normalization (`kSitosV1`, `kSitosV1Batch`, legacy spelling, absent/unknown fallback) | Normative | Implemented | [03](03_wire_protocol.md) §2.2 | — | `include/sitos/transport.hpp` |
 | Batch v1 (`:batch` multi-entry payload) | Normative | Implemented | [03](03_wire_protocol.md) §5 | — | batch codec |
 | `meta/session/<sid>` reply (session metadata JSON) | Normative | Implemented | [03](03_wire_protocol.md) §7.1 | — | StorageNode meta route |
-| `meta/ack/<uuid>` **route behavior** (token recording, AckResult payload, query semantics) | Planned | Planned | [03](03_wire_protocol.md) §6 (outline) | #114 → ADR | implementers #14 (transport ack), #17 (ParamStore policy) |
+| `meta/ack/<uuid>` **route behavior** (token recording, AckResult payload, query semantics) | Planned | Planned | [03](03_wire_protocol.md) §6 (outline) | #14 → ADR | #17 (ParamStore policy); #114 pending consolidation |
 | Same-publisher in-band fence marker | Planned | Planned | — (added on ADR acceptance) | #106 → ADR | consumers #99, #107 |
-| `buffers/<sid>/**` value scope (opaque binary values) | Normative | Planned | [ADR-0014](adr/0014-session-scoped-buffers.md) | ADR-0014 | #56; fences via #107 |
+| `buffers/<sid>/**` value scope (opaque binary values) | Normative | Planned | [ADR-0014](adr/0014-session-scoped-buffers.md) | — | #56; fences via #107 |
 
 ## 3. Stable identifiers
 
@@ -67,7 +67,7 @@ Values that must remain stable across releases because callers persist, compare,
 | Python exception hierarchy (`sitos.SitosError` and current subclasses, Status mapping) | Normative | Implemented | [05](05_api_python.md) §2.1 | — | One registered class per name; mapping extends only when `Status` extends |
 | Planned Python exception: `OutcomeUnknownError` | Planned | Planned | — | #114 → ADR | |
 | Session-id grammar (`<sid>`) | Normative | Implemented | [03](03_wire_protocol.md) §1 | — | `src/key.cpp` `IsValidSessionId`; grammar is never narrowed |
-| `meta/ack/<uuid>` route id grammar (lenient parser, `IsValidAckUuid`) | Planned | Implemented | not yet documented in [03](03_wire_protocol.md) §1 | #114 → ADR | parser-accepted de-facto grammar; to be documented normatively; current owner #14 |
+| `meta/ack/<uuid>` route id grammar (lenient parser, `IsValidAckUuid`) | Planned | Implemented | not yet documented in [03](03_wire_protocol.md) §1 | #14 → ADR | parser-accepted de-facto grammar; to be documented normatively; #114 pending consolidation |
 | Generated correlation-id format (canonical UUIDv4) | Planned | Planned | — | #114 → ADR | |
 | Fence result identifiers (`FenceDurability`, `FenceReceipt` fields) | Planned | Planned | — | #107 → ADR | reuses the #106/#114 result protocol |
 | Session state-lost read result (overlay/snapshot lost after restart) | Planned | Planned | — | #108 → ADR | |

--- a/docs/08_contract_registry.md
+++ b/docs/08_contract_registry.md
@@ -11,7 +11,9 @@ Each contract is tracked along three independent axes, because they move separat
 * **Implementation status** — `Implemented` once merged code realizes it, otherwise `Planned`.
   A contract can be `Normative` while its implementation is still `Planned` (an Accepted ADR whose
   code has not landed), and vice versa (a merged de-facto behavior not yet documented normatively).
-* **Design authority** — the single Issue or ADR that owns the decision.
+* **Design authority** — the single Issue or ADR that owns the decision, or `—` once the contract is
+  settled and normative. Implementers and downstream consumers are recorded separately; they are not
+  the design authority.
 
 Row cells are **non-normative summaries**; the linked specifications are authoritative. The registry
 owns inventory, contract maturity, implementation status, and design authority — not contract text —
@@ -22,13 +24,13 @@ so it cannot diverge from the specifications it points to.
 1. A new wire surface or stable identifier is added here as a **Planned row during issue or proposal
    review, or at milestone assembly — before implementation begins.** An issue that adds or changes
    a contract references its row (existing, or the Planned row added at review time). The
-   implementing PR **advances** the row's Implementation status (and, once the owning ADR is
-   Accepted, its Contract status); it does not perform first registration.
+   implementing PR **advances** the row's Implementation status; the PR that lands the owning ADR
+   advances its Contract status. Neither performs first registration.
 2. Introducing a **second surface whose purpose overlaps an existing row** requires an ADR that
-   records why the existing surface cannot be reused (see [10_adr_process.md](10_adr_process.md)).
-3. A Planned row names exactly one design authority and always carries an open owning Issue or ADR,
-   so it cannot remain tentative without a tracked owner. A proposal Issue must hand off to an ADR:
-   the row's **Contract status becomes `Normative` only when that owning ADR is Accepted** — a
+   records why the existing surface cannot be reused (see [10_adr_process.md](10_adr_process.md) §6).
+3. A Planned row names **exactly one** design authority and always carries an open owning Issue or
+   ADR, so it cannot remain tentative without a tracked owner. A proposal Issue must hand off to an
+   ADR: the row's **Contract status becomes `Normative` only when that owning ADR is Accepted** — a
    proposal Issue alone never makes a row normative. Forward-written specification sections carry the
    banner described in [development_workflow.md](development_workflow.md) §7.4 until that event.
 4. When a milestone is assembled, the new and changed surfaces of its issues are checked against
@@ -38,35 +40,37 @@ so it cannot diverge from the specifications it points to.
 
 ## 2. Wire surfaces
 
-Everything observable by another process over zenoh.
+Everything observable by another process over zenoh. "Design authority" is the single owner of an
+open decision (`—` when settled); implementers and consumers are listed separately.
 
-| Surface | Contract | Implementation | Normative spec | Design authority |
-|---|---|---|---|---|
-| Key space and keyexpr structure (`base/`, `session/<sid>/`, `snap/<sid>/`, `:batch` segment, `meta/**`) | Normative | Implemented | [03](03_wire_protocol.md) §1 | `src/key.cpp` |
-| Operation-to-key mapping (Put/Get/List/Delete → key expressions) | Normative | Implemented | [03](03_wire_protocol.md) §3 | `src/key.cpp`, ParamStore |
-| Query semantics (single-key get, List enumeration, zero-reply, wildcard, read-only snap/session, unknown session) | Normative | Implemented | [03](03_wire_protocol.md) §4 | StorageNode routing |
-| Payload v1 (single value: type tag + LE body, canonical NaN; golden fixtures `tests/fixtures/payload_v1/`) | Normative | Implemented | [03](03_wire_protocol.md) §2.1 | `ParamValue` codec |
-| zenoh Encoding identifiers and normalization (`kSitosV1`, `kSitosV1Batch`, legacy spelling, absent/unknown fallback) | Normative | Implemented | [03](03_wire_protocol.md) §2.2 | `include/sitos/transport.hpp` |
-| Batch v1 (`:batch` multi-entry payload) | Normative | Implemented | [03](03_wire_protocol.md) §5 | batch codec |
-| `meta/session/<sid>` reply (session metadata JSON) | Normative | Implemented | [03](03_wire_protocol.md) §7.1 | StorageNode meta route |
-| `meta/ack/<uuid>` route, ack token attachment, and AckResult payload | Planned | Planned | [03](03_wire_protocol.md) §6 (outline) | current: #14 (transport ack), #17 (ParamStore policy); #114 proposes consolidation (pending) |
-| Same-publisher in-band fence marker | Planned | Planned | — (added on ADR acceptance) | #106 ADR; consumers #99/#107 |
-| `buffers/<sid>/**` value scope (opaque binary values) | Normative | Planned | [ADR-0014](adr/0014-session-scoped-buffers.md) | #56; fences via #107 |
+| Surface | Contract | Implementation | Normative spec | Design authority | Implementer / consumers |
+|---|---|---|---|---|---|
+| Key space and keyexpr **path grammar** (`base/`, `session/<sid>/`, `snap/<sid>/`, `:batch` segment, `meta/**` route shapes) | Normative | Implemented | [03](03_wire_protocol.md) §1 | — | `src/key.cpp` |
+| Operation-to-key mapping (Put/Get/List/Delete → key expressions) | Normative | Implemented | [03](03_wire_protocol.md) §3 | — | `src/key.cpp`, ParamStore |
+| Query semantics (single-key get, List enumeration, zero-reply, wildcard, read-only snap/session, unknown session) | Normative | Implemented | [03](03_wire_protocol.md) §4 | — | StorageNode routing |
+| Payload v1 (single value: type tag + LE body, canonical NaN; golden fixtures `tests/fixtures/payload_v1/`) | Normative | Implemented | [03](03_wire_protocol.md) §2.1 | — | `ParamValue` codec |
+| zenoh Encoding identifiers and normalization (`kSitosV1`, `kSitosV1Batch`, legacy spelling, absent/unknown fallback) | Normative | Implemented | [03](03_wire_protocol.md) §2.2 | — | `include/sitos/transport.hpp` |
+| Batch v1 (`:batch` multi-entry payload) | Normative | Implemented | [03](03_wire_protocol.md) §5 | — | batch codec |
+| `meta/session/<sid>` reply (session metadata JSON) | Normative | Implemented | [03](03_wire_protocol.md) §7.1 | — | StorageNode meta route |
+| `meta/ack/<uuid>` **route behavior** (token recording, AckResult payload, query semantics) | Planned | Planned | [03](03_wire_protocol.md) §6 (outline) | #114 → ADR | implementers #14 (transport ack), #17 (ParamStore policy) |
+| Same-publisher in-band fence marker | Planned | Planned | — (added on ADR acceptance) | #106 → ADR | consumers #99, #107 |
+| `buffers/<sid>/**` value scope (opaque binary values) | Normative | Planned | [ADR-0014](adr/0014-session-scoped-buffers.md) | ADR-0014 | #56; fences via #107 |
 
 ## 3. Stable identifiers
 
 Values that must remain stable across releases because callers persist, compare, or match on them.
 
-| Identifier set | Contract | Implementation | Normative spec | Stability rule / authority |
-|---|---|---|---|---|
-| `Status` enum numeric values (`Ok`..`Error`) | Normative | Implemented | [04](04_api_cpp.md) §1.1 | Append-only; existing values are never renumbered |
-| Planned `Status` append: `OutcomeUnknown` | Planned | Planned | — | #114 → ADR |
-| Python exception hierarchy (`sitos.SitosError` and current subclasses, Status mapping) | Normative | Implemented | [05](05_api_python.md) §2.1 | One registered class per name; mapping extends only when `Status` extends |
-| Planned Python exception: `OutcomeUnknownError` | Planned | Planned | — | #114 → ADR |
-| Session-id grammar (`<sid>`) | Normative | Implemented | [03](03_wire_protocol.md) §1 | `src/key.cpp` `IsValidSessionId`; grammar is never narrowed |
-| Accepted `meta/ack/<uuid>` route id grammar (lenient, `IsValidAckUuid`) | Planned | Implemented | not yet documented in [03](03_wire_protocol.md) §1 | de-facto parser grammar; to be documented normatively by #14/#114 |
-| Generated correlation-id format (canonical UUIDv4) | Planned | Planned | — | #114 → ADR |
-| Fence result identifiers (`FenceDurability`, `FenceReceipt` fields) | Planned | Planned | — | #107 (reusing the #106/#114 result protocol) |
-| Session unavailable / state-lost read result | Planned | Planned | — | #108 → ADR |
+| Identifier set | Contract | Implementation | Normative spec | Design authority | Stability rule / notes |
+|---|---|---|---|---|---|
+| `Status` enum numeric values (`Ok`..`Error`) | Normative | Implemented | [04](04_api_cpp.md) §1.1 | — | Append-only; existing values are never renumbered |
+| Planned `Status` append: `OutcomeUnknown` | Planned | Planned | — | #114 → ADR | |
+| Python exception hierarchy (`sitos.SitosError` and current subclasses, Status mapping) | Normative | Implemented | [05](05_api_python.md) §2.1 | — | One registered class per name; mapping extends only when `Status` extends |
+| Planned Python exception: `OutcomeUnknownError` | Planned | Planned | — | #114 → ADR | |
+| Session-id grammar (`<sid>`) | Normative | Implemented | [03](03_wire_protocol.md) §1 | — | `src/key.cpp` `IsValidSessionId`; grammar is never narrowed |
+| `meta/ack/<uuid>` route id grammar (lenient parser, `IsValidAckUuid`) | Planned | Implemented | not yet documented in [03](03_wire_protocol.md) §1 | #14/#114 → ADR | parser-accepted de-facto grammar; to be documented normatively |
+| Generated correlation-id format (canonical UUIDv4) | Planned | Planned | — | #114 → ADR | |
+| Fence result identifiers (`FenceDurability`, `FenceReceipt` fields) | Planned | Planned | — | #107 → ADR | reuses the #106/#114 result protocol |
+| Session state-lost read result (overlay/snapshot lost after restart) | Planned | Planned | — | #108 → ADR | |
+| Typed catalog-unavailable result (catalog corruption fail-closed) | Planned | Planned | — | #108 → ADR | |
 
 (END OF DOCUMENT)

--- a/docs/08_contract_registry.md
+++ b/docs/08_contract_registry.md
@@ -2,49 +2,71 @@
 
 An index of every wire surface and stable cross-component identifier in sitos. The registry exists
 so that a second surface with an overlapping purpose cannot be introduced silently: any issue that
-adds or changes a contract must reference its row here, and overlap forces an explicit decision.
+adds or changes a contract references its row here, and overlap forces an explicit decision.
 
-**The registry is an index, not a specification.** Contract text lives only in the linked normative
-documents; rows never restate byte layouts, grammars, or values, so the registry cannot diverge
-from the specifications it points to.
+Each contract is tracked along three independent axes, because they move separately:
+
+* **Contract status** — `Normative` once a specification or an Accepted ADR fixes it, otherwise
+  `Planned`.
+* **Implementation status** — `Implemented` once merged code realizes it, otherwise `Planned`.
+  A contract can be `Normative` while its implementation is still `Planned` (an Accepted ADR whose
+  code has not landed), and vice versa (a merged de-facto behavior not yet documented normatively).
+* **Design authority** — the single Issue or ADR that owns the decision.
+
+Row cells are **non-normative summaries**; the linked specifications are authoritative. The registry
+owns inventory, contract maturity, implementation status, and design authority — not contract text —
+so it cannot diverge from the specifications it points to.
 
 ## 1. Rules
 
-1. An issue that **adds or changes** a wire surface or stable identifier must reference the
-   affected registry row in its body, and the implementing PR must update that row in the same PR.
+1. A new wire surface or stable identifier is added here as a **Planned row during issue or proposal
+   review, or at milestone assembly — before implementation begins.** An issue that adds or changes
+   a contract references its row (existing, or the Planned row added at review time). The
+   implementing PR **advances** the row's Implementation status (and, once the owning ADR is
+   Accepted, its Contract status); it does not perform first registration.
 2. Introducing a **second surface whose purpose overlaps an existing row** requires an ADR that
    records why the existing surface cannot be reused (see [10_adr_process.md](10_adr_process.md)).
-3. **Planned** rows name their design authority (a proposal issue or ADR). Mechanism details in
-   planned rows and their referenced sections are tentative until that authority's ADR is
-   Accepted. Forward-written specification sections carry the banner described in
-   [development_workflow.md](development_workflow.md) §7.4.
+3. A Planned row names exactly one design authority and always carries an open owning Issue or ADR,
+   so it cannot remain tentative without a tracked owner. A proposal Issue must hand off to an ADR:
+   the row's **Contract status becomes `Normative` only when that owning ADR is Accepted** — a
+   proposal Issue alone never makes a row normative. Forward-written specification sections carry the
+   banner described in [development_workflow.md](development_workflow.md) §7.4 until that event.
 4. When a milestone is assembled, the new and changed surfaces of its issues are checked against
    this registry as part of the milestone design review
-   ([development_workflow.md](development_workflow.md) §7).
+   ([development_workflow.md](development_workflow.md) §7); any unregistered surface is added as a
+   Planned row during that gate.
 
 ## 2. Wire surfaces
 
 Everything observable by another process over zenoh.
 
-| Surface | Status | Normative spec | Design authority / implementer |
-|---|---|---|---|
-| Key space and keyexpr grammar (`base/`, `session/<sid>/`, `snap/<sid>/`, `:batch` segment, `meta/**`; id grammar for `<sid>`/`<uuid>`) | Normative, implemented | [03_wire_protocol.md](03_wire_protocol.md) §1 | `src/key.cpp` |
-| Payload v1 (single value: type tag + LE body, canonical NaN; golden fixtures `tests/fixtures/payload_v1/`) | Normative, implemented | [03_wire_protocol.md](03_wire_protocol.md) §2 | `ParamValue` codec |
-| Batch v1 (`:batch` multi-entry payload) | Normative, implemented | [03_wire_protocol.md](03_wire_protocol.md) §5 | batch codec |
-| Encoding identifiers (`Encoding::kSitosV1`, `Encoding::kSitosV1Batch`) | Normative, implemented | [03_wire_protocol.md](03_wire_protocol.md) | `include/sitos/transport.hpp` |
-| `meta/session/<sid>` reply (session metadata JSON) | Normative, implemented | [03_wire_protocol.md](03_wire_protocol.md) §7 | StorageNode meta route |
-| `meta/ack/<uuid>` route, ack token attachment, and AckResult payload | **Planned, not normative** | [03_wire_protocol.md](03_wire_protocol.md) §6 | Proposal #114 (pending) → ADR; implementers #14/#17 |
-| Same-publisher in-band fence marker | **Planned, not normative** | — (to be added on ADR acceptance) | #106 ADR, shared result protocol per #114; consumers #99/#107 |
-| `buffers/<sid>/**` value scope (opaque binary values) | **Planned, not normative** | [ADR-0014](adr/0014-session-scoped-buffers.md) | #56; fences via #107 |
+| Surface | Contract | Implementation | Normative spec | Design authority |
+|---|---|---|---|---|
+| Key space and keyexpr structure (`base/`, `session/<sid>/`, `snap/<sid>/`, `:batch` segment, `meta/**`) | Normative | Implemented | [03](03_wire_protocol.md) §1 | `src/key.cpp` |
+| Operation-to-key mapping (Put/Get/List/Delete → key expressions) | Normative | Implemented | [03](03_wire_protocol.md) §3 | `src/key.cpp`, ParamStore |
+| Query semantics (single-key get, List enumeration, zero-reply, wildcard, read-only snap/session, unknown session) | Normative | Implemented | [03](03_wire_protocol.md) §4 | StorageNode routing |
+| Payload v1 (single value: type tag + LE body, canonical NaN; golden fixtures `tests/fixtures/payload_v1/`) | Normative | Implemented | [03](03_wire_protocol.md) §2.1 | `ParamValue` codec |
+| zenoh Encoding identifiers and normalization (`kSitosV1`, `kSitosV1Batch`, legacy spelling, absent/unknown fallback) | Normative | Implemented | [03](03_wire_protocol.md) §2.2 | `include/sitos/transport.hpp` |
+| Batch v1 (`:batch` multi-entry payload) | Normative | Implemented | [03](03_wire_protocol.md) §5 | batch codec |
+| `meta/session/<sid>` reply (session metadata JSON) | Normative | Implemented | [03](03_wire_protocol.md) §7.1 | StorageNode meta route |
+| `meta/ack/<uuid>` route, ack token attachment, and AckResult payload | Planned | Planned | [03](03_wire_protocol.md) §6 (outline) | current: #14 (transport ack), #17 (ParamStore policy); #114 proposes consolidation (pending) |
+| Same-publisher in-band fence marker | Planned | Planned | — (added on ADR acceptance) | #106 ADR; consumers #99/#107 |
+| `buffers/<sid>/**` value scope (opaque binary values) | Normative | Planned | [ADR-0014](adr/0014-session-scoped-buffers.md) | #56; fences via #107 |
 
 ## 3. Stable identifiers
 
 Values that must remain stable across releases because callers persist, compare, or match on them.
 
-| Identifier set | Status | Normative spec | Stability rule |
-|---|---|---|---|
-| `Status` enum numeric values | Normative, implemented | [04_api_cpp.md](04_api_cpp.md) §1.1 | Append-only; existing values are never renumbered. Planned append: `OutcomeUnknown` (#114) |
-| Python exception hierarchy (`sitos.SitosError` and subclasses, Status mapping) | Normative, implemented | [05_api_python.md](05_api_python.md) §2.1 | One registered class per name; mapping extends only when `Status` extends. Planned append: `OutcomeUnknownError` (#114) |
-| Session id / ack-uuid grammar | Normative, implemented | [03_wire_protocol.md](03_wire_protocol.md) §1 | Canonical UUID forms are subsets; grammar is never narrowed |
+| Identifier set | Contract | Implementation | Normative spec | Stability rule / authority |
+|---|---|---|---|---|
+| `Status` enum numeric values (`Ok`..`Error`) | Normative | Implemented | [04](04_api_cpp.md) §1.1 | Append-only; existing values are never renumbered |
+| Planned `Status` append: `OutcomeUnknown` | Planned | Planned | — | #114 → ADR |
+| Python exception hierarchy (`sitos.SitosError` and current subclasses, Status mapping) | Normative | Implemented | [05](05_api_python.md) §2.1 | One registered class per name; mapping extends only when `Status` extends |
+| Planned Python exception: `OutcomeUnknownError` | Planned | Planned | — | #114 → ADR |
+| Session-id grammar (`<sid>`) | Normative | Implemented | [03](03_wire_protocol.md) §1 | `src/key.cpp` `IsValidSessionId`; grammar is never narrowed |
+| Accepted `meta/ack/<uuid>` route id grammar (lenient, `IsValidAckUuid`) | Planned | Implemented | not yet documented in [03](03_wire_protocol.md) §1 | de-facto parser grammar; to be documented normatively by #14/#114 |
+| Generated correlation-id format (canonical UUIDv4) | Planned | Planned | — | #114 → ADR |
+| Fence result identifiers (`FenceDurability`, `FenceReceipt` fields) | Planned | Planned | — | #107 (reusing the #106/#114 result protocol) |
+| Session unavailable / state-lost read result | Planned | Planned | — | #108 → ADR |
 
 (END OF DOCUMENT)

--- a/docs/08_contract_registry.md
+++ b/docs/08_contract_registry.md
@@ -1,0 +1,50 @@
+# sitos — Public Contract Registry
+
+An index of every wire surface and stable cross-component identifier in sitos. The registry exists
+so that a second surface with an overlapping purpose cannot be introduced silently: any issue that
+adds or changes a contract must reference its row here, and overlap forces an explicit decision.
+
+**The registry is an index, not a specification.** Contract text lives only in the linked normative
+documents; rows never restate byte layouts, grammars, or values, so the registry cannot diverge
+from the specifications it points to.
+
+## 1. Rules
+
+1. An issue that **adds or changes** a wire surface or stable identifier must reference the
+   affected registry row in its body, and the implementing PR must update that row in the same PR.
+2. Introducing a **second surface whose purpose overlaps an existing row** requires an ADR that
+   records why the existing surface cannot be reused (see [10_adr_process.md](10_adr_process.md)).
+3. **Planned** rows name their design authority (a proposal issue or ADR). Mechanism details in
+   planned rows and their referenced sections are tentative until that authority's ADR is
+   Accepted. Forward-written specification sections carry the banner described in
+   [development_workflow.md](development_workflow.md) §7.4.
+4. When a milestone is assembled, the new and changed surfaces of its issues are checked against
+   this registry as part of the milestone design review
+   ([development_workflow.md](development_workflow.md) §7).
+
+## 2. Wire surfaces
+
+Everything observable by another process over zenoh.
+
+| Surface | Status | Normative spec | Design authority / implementer |
+|---|---|---|---|
+| Key space and keyexpr grammar (`base/`, `session/<sid>/`, `snap/<sid>/`, `:batch` segment, `meta/**`; id grammar for `<sid>`/`<uuid>`) | Normative, implemented | [03_wire_protocol.md](03_wire_protocol.md) §1 | `src/key.cpp` |
+| Payload v1 (single value: type tag + LE body, canonical NaN; golden fixtures `tests/fixtures/payload_v1/`) | Normative, implemented | [03_wire_protocol.md](03_wire_protocol.md) §2 | `ParamValue` codec |
+| Batch v1 (`:batch` multi-entry payload) | Normative, implemented | [03_wire_protocol.md](03_wire_protocol.md) §5 | batch codec |
+| Encoding identifiers (`Encoding::kSitosV1`, `Encoding::kSitosV1Batch`) | Normative, implemented | [03_wire_protocol.md](03_wire_protocol.md) | `include/sitos/transport.hpp` |
+| `meta/session/<sid>` reply (session metadata JSON) | Normative, implemented | [03_wire_protocol.md](03_wire_protocol.md) §7 | StorageNode meta route |
+| `meta/ack/<uuid>` route, ack token attachment, and AckResult payload | **Planned, not normative** | [03_wire_protocol.md](03_wire_protocol.md) §6 | Proposal #114 (pending) → ADR; implementers #14/#17 |
+| Same-publisher in-band fence marker | **Planned, not normative** | — (to be added on ADR acceptance) | #106 ADR, shared result protocol per #114; consumers #99/#107 |
+| `buffers/<sid>/**` value scope (opaque binary values) | **Planned, not normative** | [ADR-0014](adr/0014-session-scoped-buffers.md) | #56; fences via #107 |
+
+## 3. Stable identifiers
+
+Values that must remain stable across releases because callers persist, compare, or match on them.
+
+| Identifier set | Status | Normative spec | Stability rule |
+|---|---|---|---|
+| `Status` enum numeric values | Normative, implemented | [04_api_cpp.md](04_api_cpp.md) §1.1 | Append-only; existing values are never renumbered. Planned append: `OutcomeUnknown` (#114) |
+| Python exception hierarchy (`sitos.SitosError` and subclasses, Status mapping) | Normative, implemented | [05_api_python.md](05_api_python.md) §2.1 | One registered class per name; mapping extends only when `Status` extends. Planned append: `OutcomeUnknownError` (#114) |
+| Session id / ack-uuid grammar | Normative, implemented | [03_wire_protocol.md](03_wire_protocol.md) §1 | Canonical UUID forms are subsets; grammar is never narrowed |
+
+(END OF DOCUMENT)

--- a/docs/10_adr_process.md
+++ b/docs/10_adr_process.md
@@ -104,6 +104,8 @@ An ADR is required for changes that fall under any of the following:
 * Changes touching the invariants in [09_dependency_policy.md](09_dependency_policy.md) §6
 * Changes to the thread model, consistency model, or snapshot semantics
 * Changes to the build system or supported platforms
+* Introducing a second surface that overlaps an existing contract-registry row
+  (registry Rule 2, [08_contract_registry.md](08_contract_registry.md) §1)
 
 ADRs are not needed for implementation details that do not fall under these
 categories (internal refactoring, bug fixes, performance improvements).

--- a/docs/development_workflow.md
+++ b/docs/development_workflow.md
@@ -95,7 +95,9 @@ Each issue must include at minimum the following (following the format in [07]):
 * Target implementation files
 * Acceptance criteria (AC) — in a verifiable form
 * Dependent issues
-* Affected contract-registry row(s) ([08_contract_registry.md](08_contract_registry.md)), or `N/A`
+* Affected contract-registry row(s) with their status transition (`Contract` /
+  `Implementation` / `none`), or `N/A` if no contract is touched
+  ([08_contract_registry.md](08_contract_registry.md))
 
 ## 3. Test-Driven Development (TDD): Red-Green-Refactor
 
@@ -134,7 +136,8 @@ Rules:
   - RED-phase failure confirmation (§3)
   - Judgment on whether an ADR is needed (whether [10] §6 applies; §6 now includes
     the contract-registry Rule 2 overlap trigger)
-  - Affected contract-registry row(s) advanced ([08]), or `N/A`
+  - Affected contract-registry row(s) with their status transition (`Contract` /
+    `Implementation` / `none`), or `N/A` if no contract is touched ([08])
 * CI (build + all tests + clang-format + clang-tidy) must be green
 * Merge to main by squash merge (keep history grouped by issue)
 

--- a/docs/development_workflow.md
+++ b/docs/development_workflow.md
@@ -93,6 +93,7 @@ Each issue must include at minimum the following (following the format in [07]):
 * Target implementation files
 * Acceptance criteria (AC) — in a verifiable form
 * Dependent issues
+* Affected contract-registry row(s) ([08_contract_registry.md](08_contract_registry.md)), or `N/A`
 
 ## 3. Test-Driven Development (TDD): Red-Green-Refactor
 
@@ -130,6 +131,7 @@ Rules:
   - AC verification results (test execution logs)
   - RED-phase failure confirmation (§3)
   - Judgment on whether an ADR is needed (whether [10] §6 applies)
+  - Affected contract-registry row(s) advanced ([08]), or `N/A`
 * CI (build + all tests + clang-format + clang-tidy) must be green
 * Merge to main by squash merge (keep history grouped by issue)
 
@@ -167,21 +169,31 @@ pass (motivated by the Issue #114 retrospective: the ack and fence lanes were ea
 individually, and their shared substrate was found only after the milestone was assembled).
 
 **Gate**: when a milestone is assembled or materially re-scoped, post one milestone design review
-(a timeline comment on the milestone-defining issue, or a dedicated issue) covering §7.1–§7.3
+(a timeline comment on the milestone-defining issue, or a dedicated issue) covering §7.1–§7.4
 before implementation of the milestone's issues begins. Guideline effort: half a day.
+
+The gate **completes** only when its findings are recorded, each finding has a named follow-up
+owner, and the milestone owner accepts the outcome — not merely when the artifact is posted. For a
+**material re-scope**, rerun the gate before the added or changed scope begins and pause only the
+affected work, not the whole milestone.
 
 ### 7.1 Shared-Mechanism Inventory
 
 List the mechanisms each issue in the milestone needs (examples: tokens, correlation identifiers,
-result reporting, polling/retry, ring buffers, ordering fences, catalogs). Any mechanism appearing
-in **two or more issues** gets a unifying design issue created at assembly time — a shared
-substrate is a planned artifact, not a later discovery.
+result reporting, polling/retry, ring buffers, ordering fences, catalogs). A **new, unresolved, or
+materially changed** cross-component mechanism used by **two or more issues** and **lacking an
+existing contract owner** gets a unifying design issue created at assembly time — a shared substrate
+is a planned artifact, not a later discovery. If an existing owner or Accepted ADR already governs
+the mechanism (for example the shared Result/Status model or logging), reference it instead of
+creating a redundant issue.
 
 ### 7.2 Contract-Surface Check
 
 List every wire surface or stable identifier the milestone adds or changes, and check each against
-the [contract registry](08_contract_registry.md). An addition whose purpose overlaps an existing
-row requires an ADR recording why the existing surface cannot be reused.
+the [contract registry](08_contract_registry.md). Any surface that has no row yet is added as a
+Planned row during this gate (registry Rule 1), so first registration happens here rather than in a
+later implementation PR. An addition whose purpose overlaps an existing row requires an ADR
+recording why the existing surface cannot be reused.
 
 ### 7.3 Dependency and Intake Annotations
 

--- a/docs/development_workflow.md
+++ b/docs/development_workflow.md
@@ -132,8 +132,8 @@ Rules:
   - Corresponding requirement IDs ([01] F/N/C/P/X)
   - AC verification results (test execution logs)
   - RED-phase failure confirmation (§3)
-  - Judgment on whether an ADR is needed (whether [10] §6 **or** contract-registry
-    Rule 2 applies)
+  - Judgment on whether an ADR is needed (whether [10] §6 applies; §6 now includes
+    the contract-registry Rule 2 overlap trigger)
   - Affected contract-registry row(s) advanced ([08]), or `N/A`
 * CI (build + all tests + clang-format + clang-tidy) must be green
 * Merge to main by squash merge (keep history grouped by issue)

--- a/docs/development_workflow.md
+++ b/docs/development_workflow.md
@@ -132,7 +132,8 @@ Rules:
   - Corresponding requirement IDs ([01] F/N/C/P/X)
   - AC verification results (test execution logs)
   - RED-phase failure confirmation (§3)
-  - Judgment on whether an ADR is needed (whether [10] §6 applies)
+  - Judgment on whether an ADR is needed (whether [10] §6 **or** contract-registry
+    Rule 2 applies)
   - Affected contract-registry row(s) advanced ([08]), or `N/A`
 * CI (build + all tests + clang-format + clang-tidy) must be green
 * Merge to main by squash merge (keep history grouped by issue)

--- a/docs/development_workflow.md
+++ b/docs/development_workflow.md
@@ -21,7 +21,9 @@ main ─────●───────●───────●───
 * Working branches are **short-lived** (guideline: 1 issue = 1 branch = 1 PR,
   within a few days)
 * Branch name: `feat/<number>-<short-kebab-description>`
-  (example: `feat/3-param-value-codec`)
+  (example: `feat/3-param-value-codec`). The prefix is always `feat/` regardless
+  of change type; the change type lives on the issue label and the commit
+  message (§2.1), so the branch does not repeat it
 * Releases are tags on main (`v0.1.0`, etc.). Do not create release branches
   until a hotfix is needed
 * Do not create long-lived develop / feature branches

--- a/docs/development_workflow.md
+++ b/docs/development_workflow.md
@@ -160,4 +160,47 @@ merged (checkboxes on the issue side may remain unchecked when closed).
 2. release-please generates the CHANGELOG and version PR from Conventional Commits
 3. Merge the version PR → tag → `wheels.yml` publishes to PyPI
 
+## 7. Milestone Design Review (horizontal pass)
+
+Per-issue reviews are depth-first; assembling a milestone additionally requires one breadth-first
+pass (motivated by the Issue #114 retrospective: the ack and fence lanes were each reviewed
+individually, and their shared substrate was found only after the milestone was assembled).
+
+**Gate**: when a milestone is assembled or materially re-scoped, post one milestone design review
+(a timeline comment on the milestone-defining issue, or a dedicated issue) covering §7.1–§7.3
+before implementation of the milestone's issues begins. Guideline effort: half a day.
+
+### 7.1 Shared-Mechanism Inventory
+
+List the mechanisms each issue in the milestone needs (examples: tokens, correlation identifiers,
+result reporting, polling/retry, ring buffers, ordering fences, catalogs). Any mechanism appearing
+in **two or more issues** gets a unifying design issue created at assembly time — a shared
+substrate is a planned artifact, not a later discovery.
+
+### 7.2 Contract-Surface Check
+
+List every wire surface or stable identifier the milestone adds or changes, and check each against
+the [contract registry](08_contract_registry.md). An addition whose purpose overlaps an existing
+row requires an ADR recording why the existing surface cannot be reused.
+
+### 7.3 Dependency and Intake Annotations
+
+* For each cross-issue dependency inside the milestone, record in one line **which shared
+  substrate the dependency encodes** (before asking whether it can be cut).
+* When a new downstream consumer motivates the milestone, pair the new issues with a re-read of
+  existing backlog issues touching the same layers, and record the updates each needs.
+
+### 7.4 “Planned, Not Normative” Banner
+
+A specification section written before its mechanism is decided must open with a banner naming the
+deciding authority, in the form:
+
+> **Planned, not yet normative:** Issue/ADR #NN owns this mechanism. Implementers must not treat
+> this outline as a finalized contract.
+
+Load-bearing contracts (wire payload layouts, key grammar, stable enum values) are decided early
+and written normatively; mechanism details (retry counts, cache policies, marker representations)
+default to this banner and are finalized in the owning pre-implementation ADR. Existing documents
+are converted opportunistically when next edited.
+
 (END OF DOCUMENT)


### PR DESCRIPTION
## Summary

- add `docs/08_contract_registry.md`: an index of every wire surface and stable identifier, tracked
  along three axes (Contract status / Implementation status / single Design authority), with rules
  making registration happen at issue review and an overlapping-purpose second surface require an ADR
- add `docs/development_workflow.md` §7: a milestone design-review gate (shared-mechanism inventory
  with a scoped trigger, registry check, dependency-substrate annotation, new-consumer intake,
  planned-not-normative banner) with explicit completion/re-scope criteria
- wire registry Rule 2 into the ADR trigger (`docs/10` §6) and the PR template
- register the new document in the `docs/00_overview.md` document map

Closes #115

## Issue #115 checklist (finalized — see the reviewed-rules addendum on #115)

- [x] `docs/08_contract_registry.md`: wire-surface and stable-identifier tables, each row carrying
      Contract status, Implementation status, Normative spec, a single Design authority, and
      implementers/consumers separately
- [x] Registry rules: new surfaces registered as Planned rows at issue/proposal review or milestone
      assembly; overlapping-purpose second surface requires an ADR (wired into `docs/10` §6 and the
      PR template); a Planned row has exactly one authority and becomes Normative only when its
      owning ADR is Accepted; the registry is an index, not a spec
- [x] `docs/development_workflow.md` §7 (scoped shared-mechanism trigger, registry check with in-gate
      registration, dependency substrate annotation, new-consumer intake, planned-not-normative
      banner, gate completion + re-scope criteria)
- [x] `docs/00_overview.md` §5: registry added to the document map

## Notes for review

- Requirement IDs: none apply (process documentation; no F/N/C/P/X behavior changes).
- ADR judgment: **not required** — this adds process rules and an index document; it makes no
  architecture decision and changes no contract. Registry Rule 2 is now itself an ADR trigger, but
  this PR introduces no overlapping surface.
- RED-phase / AC-test logs: **N/A** — documentation-only, exempt from production-code TDD under §3.
- Branch prefix is `docs/` here; the convention (now clarified in §1) fixes it to `feat/` going
  forward. Left as-is per owner decision; not renamed.
- Workflow §7 is appended after §6 so existing section references (§2.1, §3) keep their numbers.

## Inventory verification (registry rows → source of truth)

| Row group | Verified against |
|---|---|
| Key-space path grammar / op-to-key / query semantics | `src/key.cpp`, `03` §1/§3/§4 |
| Payload v1 / Encoding normalization / Batch v1 | `ParamValue` codec, `03` §2.1/§2.2/§5 |
| `meta/session` reply | StorageNode meta route, `03` §7.1 |
| `buffers/<sid>` (Normative, impl Planned) | ADR-0014 Accepted (2026-07-09), #56 pending |
| Session-id / `meta/ack` parser grammar | `src/key.cpp` `IsValidSessionId` / `IsValidAckUuid` |
| `Status` / Python exceptions (implemented rows only) | `04` §1.1, `05` §2.1 |
| Planned (ack / fence / UUIDv4 / OutcomeUnknown / #107 / #108×2) | single authorities #114 / #106 / #107 / #108 |

## Verification

- All relative links and referenced section numbers verified against the tree
  (`03` §1/§2.1/§2.2/§3/§4/§5/§6/§7.1, `04` §1.1, `05` §2.1, ADR-0014, `10` §6).
- `git diff --check` passes; SonarCloud quality gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
