### PR TITLE
feat(store): add ParamStore subscriptions (#16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
           UBSAN_OPTIONS: halt_on_error=1
         run: >-
           ctest --test-dir build/sanitizer-${{ matrix.name }}
-          --output-on-failure -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|TransportGetCompletionTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
+          --output-on-failure -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|TransportGetCompletionTest|ParamStoreSubscribeTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
 
   build-windows:
     runs-on: windows-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ endfunction()
 add_library(sitos STATIC
   src/client_config.cpp
   src/param_store.cpp
+  src/param_subscription.cpp
   src/param_cache.cpp
   src/status.cpp
   src/param_value.cpp

--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -367,8 +367,8 @@ interleaving, and duplicate/self-echo samples are not suppressed. `Close()` clos
 undeclares the native handle, waits for native callbacks, queued work, user callbacks, and diagnostics,
 and guarantees no callback or LogSink invocation after return. Callback exceptions are contained and
 logged. Callbacks may submit nonblocking writes but must not perform blocking reads or subscription
-lifecycle operations from within the callback. This boundary is specified by Proposed ADR-0030;
-Python callback dispatch remains Issue #26.
+lifecycle operations from within the callback. This boundary is specified by ADR-0030; Python
+callback dispatch remains Issue #26.
 
 ## 8. Session Lifecycle (Overall Sequence)
 

--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -353,6 +353,23 @@ ParamStore write success means only that Transport accepted/submitted the operat
 not confirm StorageNode application, durability, or cache visibility. Acknowledged writes and
 retry policy belong to Issues #14 and #17; this API does not add a `put_ack` configuration field.
 
+### 7.3 ParamStore Subscription
+
+`ParamStore::Subscribe` is a delta-only observer over base or session Transport samples. It performs
+no initial read. Declaration-time samples are copied and staged; a successful declaration drains
+staged work before returning, while declaration failure invokes no user callback. A move-only
+`ParamSubscription` owns the native handle, callback state, shared Transport, and client LogSink
+independently of ParamStore.
+
+Each subscription has a threadless single-flight drainer. User callbacks are serialized per
+subscription, canonical batches are prevalidated and expanded in encoded order without
+interleaving, and duplicate/self-echo samples are not suppressed. `Close()` closes admission,
+undeclares the native handle, waits for native callbacks, queued work, user callbacks, and diagnostics,
+and guarantees no callback or LogSink invocation after return. Callback exceptions are contained and
+logged. Callbacks may submit nonblocking writes but must not perform blocking reads or subscription
+lifecycle operations from within the callback. This boundary is specified by Proposed ADR-0030;
+Python callback dispatch remains Issue #26.
+
 ## 8. Session Lifecycle (Overall Sequence)
 
 ```
@@ -385,6 +402,7 @@ External client        Controller(StorageNode)          Calc(ParamCache)
 | ParamCache delta application | zenoh subscriber thread. The writer lock is held only briefly for replacement |
 | ParamCache local reads | Any application thread (atomic State snapshot + shared map lock) [N07] |
 | ParamCache writes | Caller thread; submission occurs without lifecycle or map locks, then local sequencing |
+| ParamSubscription callbacks | Whichever Transport callback/caller thread owns the per-subscription drainer; serialized per subscription, no thread affinity |
 | Python callbacks | Dedicated dispatch thread + queue (the GIL is not acquired on zenoh threads) [P04] |
 
 ## 10. Error Handling Policy

--- a/docs/04_api_cpp.md
+++ b/docs/04_api_cpp.md
@@ -83,6 +83,7 @@ struct ClientConfig {
     std::string prefix = "sitos";
     std::optional<std::string> zenoh_config_json;
     std::chrono::milliseconds query_timeout{5000};
+    std::shared_ptr<LogSink> log_sink = DefaultLogSink();
 };
 Result<void> ValidateClientConfig(const ClientConfig& config);
 
@@ -137,8 +138,12 @@ class ParamStore {
 
   ParamStore(const ParamStore&) = delete;
   ParamStore& operator=(const ParamStore&) = delete;
-  ParamStore(ParamStore&&) noexcept = default;
-  ParamStore& operator=(ParamStore&&) noexcept = default;
+  ParamStore(ParamStore&&) noexcept;
+  ParamStore& operator=(ParamStore&&) noexcept;
+
+  Result<ParamSubscription> Subscribe(std::string_view scope,
+                                      std::string_view prefix,
+                                      ParamCallback callback);
 
   Result<void> Put(std::string_view scope, std::string_view key,
                    const ParamValue& value);
@@ -168,6 +173,21 @@ sends no message.
 sorts relative keys lexicographically, then invokes the sink on the caller thread. A false
 sink result is normal early termination; sink exceptions propagate unchanged. Raw prefixes
 are used: `foo` matches `foo`, `foo/bar`, and `foobar`, while `foo/` matches descendants only.
+
+### 2.1 ParamStore subscriptions
+
+`Subscribe` accepts only `base` and syntactically valid `session/<sid>` scopes. It is delta-only:
+it performs no initial Get/List. Matching PUT and DELETE samples produce owned relative-key
+`ParamChange` events. Canonical `:batch` PUTs are fully validated before delivery and expand into
+ordered individual PUT events, preserving duplicates. Unknown ordinary encodings are delivered as
+BYTES; malformed known payloads, invalid batches, and unsupported paths are dropped with diagnostics.
+
+`ParamSubscription` is move-only. Declaration-time samples are staged and drained only after
+successful declaration. `Close()` is synchronous, idempotent, and callback-quiescent. It waits for
+native callbacks, queued work, user callbacks, and diagnostics; no callback or LogSink call starts
+after it returns. Callbacks are serialized per subscription but have no thread affinity. They may
+submit nonblocking Put/PutBatch/Delete, but must not call blocking reads or close/destroy the
+subscription from inside its callback. Python callback dispatch is Issue #26.
 
 ## 3. StorageEngine / StorageNode — Storage Node Side
 
@@ -306,6 +326,6 @@ Large binary values belong to the disk-backed `buffers/<sid>/**` scope described
 | `ParamCache` | Attach/Detach and local write sequencing are synchronized internally. Local reads are cache-only; stale/reconnect behavior is future #20 behavior |
 | `StorageNode` | All methods may be called concurrently |
 | `SessionView` | All methods may be called concurrently. List callbacks run on the caller thread outside internal locks; re-entry and Stop from inside a sink are safe |
-| callback | Called from zenoh threads. Blocking is prohibited. From inside a callback, only Get-style APIs on the same object may be called |
+| ParamSubscription callback | Serialized per subscription with no thread affinity. It may submit nonblocking Put/PutBatch/Delete, but blocking reads, Subscribe, subscription lifecycle, and Transport/session lifecycle operations are forbidden |
 
 (END OF DOCUMENT)

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -181,13 +181,13 @@ cmake -S . -B build/tsan -G Ninja -DCMAKE_BUILD_TYPE=Debug \
   -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF -DSITOS_ENABLE_TSAN=ON
 cmake --build build/tsan
 ctest --test-dir build/tsan --output-on-failure \
-  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|ParamStoreSubscribeTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
+  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|TransportGetCompletionTest|ParamStoreSubscribeTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
 
 cmake -S . -B build/asan -G Ninja -DCMAKE_BUILD_TYPE=Debug \
   -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF -DSITOS_ENABLE_ASAN_UBSAN=ON
 cmake --build build/asan
 ctest --test-dir build/asan --output-on-failure \
-  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|ParamStoreSubscribeTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
+  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|TransportGetCompletionTest|ParamStoreSubscribeTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
 ```
 
 For a platform where the zenoh-c standalone runtime supports sanitizer instrumentation,

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -171,8 +171,9 @@ major behaviors.
 
 ## 5.2 Lifecycle sanitizer runs
 
-Issue #11 lifecycle tests, Issue #13 batch sequencing tests, Issue #18 ParamCache, and Issue #21
-SessionView lifecycle/concurrency tests have reproducible sanitizer configurations. TSan runs the
+Issue #11 lifecycle tests, Issue #13 batch sequencing tests, Issue #16 ParamStore subscription,
+Issue #18 ParamCache, and Issue #21 SessionView lifecycle/concurrency tests have reproducible
+sanitizer configurations. TSan runs the
 zenoh-independent fake-Transport paths; ASan/UBSan runs the same paths separately:
 
 ```sh
@@ -180,13 +181,13 @@ cmake -S . -B build/tsan -G Ninja -DCMAKE_BUILD_TYPE=Debug \
   -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF -DSITOS_ENABLE_TSAN=ON
 cmake --build build/tsan
 ctest --test-dir build/tsan --output-on-failure \
-  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
+  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|ParamStoreSubscribeTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
 
 cmake -S . -B build/asan -G Ninja -DCMAKE_BUILD_TYPE=Debug \
   -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF -DSITOS_ENABLE_ASAN_UBSAN=ON
 cmake --build build/asan
 ctest --test-dir build/asan --output-on-failure \
-  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
+  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|ParamStoreSubscribeTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
 ```
 
 For a platform where the zenoh-c standalone runtime supports sanitizer instrumentation,

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -220,7 +220,7 @@ so it is not a v0.2 blocker. Include it by v0.5.
 
 ### #16 ParamStore: Subscribe
 * Milestone: v0.3
-* References: [04] §2.1, [01] F13, Proposed ADR-0030
+* References: [04] §2.1, [01] F13, ADR-0030
 * Implementation targets: `include/sitos/param_subscription.hpp`, `include/sitos/param_store.hpp`,
   `src/param_subscription.cpp`, `tests/unit/param_store_subscribe_test.cpp`,
   `tests/integration/param_store_subscribe_test.cpp`

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -220,12 +220,15 @@ so it is not a v0.2 blocker. Include it by v0.5.
 
 ### #16 ParamStore: Subscribe
 * Milestone: v0.3
-* References: [04] §2, [01] F13
-* Implementation targets: `include/sitos/param_store.hpp`, `src/param_store.cpp`,
+* References: [04] §2.1, [01] F13, Proposed ADR-0030
+* Implementation targets: `include/sitos/param_subscription.hpp`, `include/sitos/param_store.hpp`,
+  `src/param_subscription.cpp`, `tests/unit/param_store_subscribe_test.cpp`,
   `tests/integration/param_store_subscribe_test.cpp`
-* Scope: Subscribe/Subscription RAII, callback error handling, unsubscribe
-* Acceptance criteria: integration tests — put notification, expanded batch notifications, no notifications after unsubscribe
-* Depends on: #15
+* Scope: delta-only PUT/DELETE subscription, staging, ordered `:batch` expansion, callback exception
+  containment, injected client logging, synchronous callback-quiescent RAII close
+* Acceptance criteria: deterministic fake-Transport tests for validation/staging/ordering/re-entry/
+  Close and one same-session Zenoh integration test for PUT/DELETE/batch/control-subscriber delivery
+* Depends on: #13, #15, #76, #85, #88, #90; ADR-0030 must be Accepted immediately before merge
 
 ### #17 ParamStore: ack/error mapping
 * Milestone: v0.5

--- a/docs/adr/0030-param-store-subscription-lifetime-and-delivery.md
+++ b/docs/adr/0030-param-store-subscription-lifetime-and-delivery.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed — Issue #16
+Accepted — 2026-07-26
 
 ## Context
 
@@ -42,7 +42,7 @@ application, persistence, visibility, or peer delivery. Python callback dispatch
 - This ADR does not add a wire surface or stable identifier and reuses existing key, Encoding,
   payload-v1, and batch-v1 contracts.
 
-## Alternatives considered
+## Options Considered
 
 - Fire-and-forget callbacks were rejected because Close could return while callbacks or diagnostics
   still accessed subscription-owned state.

--- a/docs/adr/0030-param-store-subscription-lifetime-and-delivery.md
+++ b/docs/adr/0030-param-store-subscription-lifetime-and-delivery.md
@@ -1,0 +1,52 @@
+# ADR-0030: Define ParamStore subscription lifetime and delivery semantics
+
+## Status
+
+Proposed — Issue #16
+
+## Context
+
+`ParamStore::Subscribe` needs an application-facing callback API over Transport subscriber samples.
+A callback can overlap declaration, other subscriber callbacks, and synchronous write self-echoes.
+Low-level Transport handle destruction alone does not define the lifetime of queued work, user
+callbacks, diagnostics, or callback-owned state.
+
+## Decision
+
+Issue #16 adds a move-only `ParamSubscription` that owns its Transport subscription, callback state,
+and client LogSink lifetime independently of `ParamStore`. `Subscribe` stages owned samples during
+subscriber declaration and drains them only after declaration succeeds. Declaration failure invokes
+no user callback.
+
+Each subscription uses a threadless single-flight drainer. Callbacks are serialized per subscription,
+full batches are one non-interleaved work item, duplicates and encoded order are preserved, and
+non-drainer native callbacks wait for their work. A synchronous callback on the drainer thread queues
+reentrant writes without waiting. There is no global order, self-echo suppression, or duplicate
+suppression.
+
+`Close()` is synchronous, idempotent, and `noexcept`: it closes admission, undeclares the native
+subscriber, waits for admitted native callbacks and queued/draining work, and guarantees that no user
+callback or LogSink call remains or starts after return. Self-close, self-destruction, and self-move
+from a callback or subscription-owned LogSink are unsupported.
+
+Callbacks observe valid Transport delivery and decoding only. They do not acknowledge StorageNode
+application, persistence, visibility, or peer delivery. Python callback dispatch remains Issue #26.
+
+## Consequences
+
+- Applications receive owned relative keys and values through an explicit PUT/DELETE event type.
+- Callback exceptions are contained and logged through the injected backend-neutral LogSink.
+- The API has no worker thread, timeout cancellation, queue capacity, or overflow policy.
+- Native subscriber closure lifetime must be proven by the Issue #16 prerequisite regression; an
+  unresolved native lifetime failure blocks implementation and requires a separate Transport fix.
+- This ADR does not add a wire surface or stable identifier and reuses existing key, Encoding,
+  payload-v1, and batch-v1 contracts.
+
+## Alternatives considered
+
+- Fire-and-forget callbacks were rejected because Close could return while callbacks or diagnostics
+  still accessed subscription-owned state.
+- A dedicated worker thread was rejected to keep the client API KISS and preserve callback-thread
+  flexibility; it is not required for serialized delivery.
+- Initial Get/List replay was rejected because this API is delta-only; ParamCache owns snapshot
+  attachment semantics.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,3 +33,4 @@ See [docs/10_adr_process.md](../10_adr_process.md) for the process.
 | [0026](0026-python-wheel-build-and-native-runtime.md) | Define the Python wheel build and bundled native-runtime boundary |
 | [0027](0027-keep-http-control-planes-in-host-applications.md) | Keep HTTP control planes in host applications |
 | [0028](0028-unify-acknowledged-operation-results.md) | Unify acknowledged operation results |
+| [0030](0030-param-store-subscription-lifetime-and-delivery.md) | Define ParamStore subscription lifetime and delivery semantics |

--- a/include/sitos/client_config.hpp
+++ b/include/sitos/client_config.hpp
@@ -5,9 +5,11 @@
 #define SITOS_CLIENT_CONFIG_HPP
 
 #include <chrono>
+#include <memory>
 #include <optional>
 #include <string>
 
+#include "sitos/logging.hpp"
 #include "sitos/result.hpp"
 
 namespace sitos {
@@ -16,6 +18,7 @@ struct ClientConfig {
   std::string prefix = "sitos";
   std::optional<std::string> zenoh_config_json;
   std::chrono::milliseconds query_timeout{5000};
+  std::shared_ptr<LogSink> log_sink = DefaultLogSink();
 };
 
 Result<void> ValidateClientConfig(const ClientConfig& config);

--- a/include/sitos/param_store.hpp
+++ b/include/sitos/param_store.hpp
@@ -8,6 +8,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <span>
 #include <string>
@@ -27,6 +28,10 @@
 #include "sitos/transport.hpp"
 
 namespace sitos {
+
+namespace param_store_test_access {
+class ParamStoreTestAccess;
+}
 
 /// Move-only, thread-safe synchronous client for base/session parameter data.
 class ParamStore {
@@ -73,9 +78,12 @@ class ParamStore {
   Result<void> List(std::string_view scope, std::string_view prefix, const ListSink& sink);
 
  private:
+  friend class param_store_test_access::ParamStoreTestAccess;
+
   ParamStore(std::shared_ptr<Transport> transport, ClientConfig config);
 
   std::shared_ptr<DeclarationControl> declaration_control_;
+  std::function<void()> subscription_native_entry_hook_;
 
   static Result<Scope> ParseAndValidateScope(std::string_view scope);
   static Result<void> ValidateUserKey(std::string_view key);

--- a/include/sitos/param_store.hpp
+++ b/include/sitos/param_store.hpp
@@ -8,7 +8,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <functional>
 #include <memory>
 #include <span>
 #include <string>
@@ -43,8 +42,8 @@ class ParamStore {
 
   ParamStore(const ParamStore&) = delete;
   ParamStore& operator=(const ParamStore&) = delete;
-  ParamStore(ParamStore&& other) noexcept;
-  ParamStore& operator=(ParamStore&& other) noexcept;
+  ParamStore(ParamStore&& other) noexcept = default;
+  ParamStore& operator=(ParamStore&& other) noexcept = default;
 
   Result<ParamSubscription> Subscribe(std::string_view scope, std::string_view prefix,
                                       ParamCallback callback);
@@ -83,11 +82,6 @@ class ParamStore {
   ParamStore(std::shared_ptr<Transport> transport, ClientConfig config);
 
   std::shared_ptr<DeclarationControl> declaration_control_;
-  std::function<void()> subscription_native_entry_hook_;
-  std::function<void()> subscription_decode_hook_;
-  std::function<void()> subscription_fail_staging_hook_;
-  std::function<void()> subscription_close_admission_hook_;
-  std::function<void()> subscription_close_reset_hook_;
 
   static Result<Scope> ParseAndValidateScope(std::string_view scope);
   static Result<void> ValidateUserKey(std::string_view key);

--- a/include/sitos/param_store.hpp
+++ b/include/sitos/param_store.hpp
@@ -22,6 +22,7 @@
 #include "sitos/param_concepts.hpp"
 #include "sitos/key.hpp"
 #include "sitos/param_value.hpp"
+#include "sitos/param_subscription.hpp"
 #include "sitos/result.hpp"
 #include "sitos/transport.hpp"
 
@@ -30,13 +31,18 @@ namespace sitos {
 /// Move-only, thread-safe synchronous client for base/session parameter data.
 class ParamStore {
  public:
+  struct DeclarationControl;
+
   static Result<ParamStore> Open(ClientConfig config = {});
   static Result<ParamStore> Open(std::shared_ptr<Transport> transport, ClientConfig config = {});
 
   ParamStore(const ParamStore&) = delete;
   ParamStore& operator=(const ParamStore&) = delete;
-  ParamStore(ParamStore&&) noexcept = default;
-  ParamStore& operator=(ParamStore&&) noexcept = default;
+  ParamStore(ParamStore&& other) noexcept;
+  ParamStore& operator=(ParamStore&& other) noexcept;
+
+  Result<ParamSubscription> Subscribe(std::string_view scope, std::string_view prefix,
+                                      ParamCallback callback);
 
   Result<void> Put(std::string_view scope, std::string_view key, const ParamValue& value);
 
@@ -67,8 +73,9 @@ class ParamStore {
   Result<void> List(std::string_view scope, std::string_view prefix, const ListSink& sink);
 
  private:
-  ParamStore(std::shared_ptr<Transport> transport, ClientConfig config)
-      : transport_(std::move(transport)), config_(std::move(config)) {}
+  ParamStore(std::shared_ptr<Transport> transport, ClientConfig config);
+
+  std::shared_ptr<DeclarationControl> declaration_control_;
 
   static Result<Scope> ParseAndValidateScope(std::string_view scope);
   static Result<void> ValidateUserKey(std::string_view key);

--- a/include/sitos/param_store.hpp
+++ b/include/sitos/param_store.hpp
@@ -86,6 +86,7 @@ class ParamStore {
   std::function<void()> subscription_native_entry_hook_;
   std::function<void()> subscription_fail_staging_hook_;
   std::function<void()> subscription_close_admission_hook_;
+  std::function<void()> subscription_close_reset_hook_;
 
   static Result<Scope> ParseAndValidateScope(std::string_view scope);
   static Result<void> ValidateUserKey(std::string_view key);

--- a/include/sitos/param_store.hpp
+++ b/include/sitos/param_store.hpp
@@ -84,6 +84,7 @@ class ParamStore {
 
   std::shared_ptr<DeclarationControl> declaration_control_;
   std::function<void()> subscription_native_entry_hook_;
+  std::function<void()> subscription_decode_hook_;
   std::function<void()> subscription_fail_staging_hook_;
   std::function<void()> subscription_close_admission_hook_;
   std::function<void()> subscription_close_reset_hook_;

--- a/include/sitos/param_store.hpp
+++ b/include/sitos/param_store.hpp
@@ -84,6 +84,8 @@ class ParamStore {
 
   std::shared_ptr<DeclarationControl> declaration_control_;
   std::function<void()> subscription_native_entry_hook_;
+  std::function<void()> subscription_fail_staging_hook_;
+  std::function<void()> subscription_close_admission_hook_;
 
   static Result<Scope> ParseAndValidateScope(std::string_view scope);
   static Result<void> ValidateUserKey(std::string_view key);

--- a/include/sitos/param_subscription.hpp
+++ b/include/sitos/param_subscription.hpp
@@ -39,8 +39,8 @@ class ParamSubscription {
 
   /// Stops delivery and waits for all admitted work to finish.
   ///
-  /// Calling Close, destroying this handle, or move-assigning this handle from its own callback
-  /// is forbidden.
+  /// Calling Close, destroying this handle, or move-assigning it from either this subscription's
+  /// ParamCallback or its subscription-owned LogSink::Write context is forbidden.
   void Close() noexcept;
 
  private:

--- a/include/sitos/param_subscription.hpp
+++ b/include/sitos/param_subscription.hpp
@@ -38,6 +38,9 @@ class ParamSubscription {
   ~ParamSubscription();
 
   /// Stops delivery and waits for all admitted work to finish.
+  ///
+  /// Calling Close, destroying this handle, or move-assigning this handle from its own callback
+  /// is forbidden.
   void Close() noexcept;
 
  private:

--- a/include/sitos/param_subscription.hpp
+++ b/include/sitos/param_subscription.hpp
@@ -1,0 +1,52 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Delta subscription API for ParamStore.
+
+#ifndef SITOS_PARAM_SUBSCRIPTION_HPP
+#define SITOS_PARAM_SUBSCRIPTION_HPP
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "sitos/param_value.hpp"
+
+namespace sitos {
+
+/// Kind of change delivered by a ParamStore subscription.
+enum class ParamChangeKind { kPut, kDelete };
+
+/// Owned relative-key change delivered to a subscription callback.
+struct ParamChange {
+  ParamChangeKind kind;
+  std::string key;
+  std::optional<ParamValue> value;
+};
+
+/// Callback invoked for each matching change.
+using ParamCallback = std::function<void(const ParamChange&)>;
+
+/// Move-only, callback-quiescent subscription handle.
+class ParamSubscription {
+ public:
+  ParamSubscription(const ParamSubscription&) = delete;
+  ParamSubscription& operator=(const ParamSubscription&) = delete;
+  ParamSubscription(ParamSubscription&& other) noexcept;
+  ParamSubscription& operator=(ParamSubscription&& other) noexcept;
+  ~ParamSubscription();
+
+  /// Stops delivery and waits for all admitted work to finish.
+  void Close() noexcept;
+
+ private:
+  friend class ParamStore;
+  struct Impl;
+  explicit ParamSubscription(std::unique_ptr<Impl> impl);
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace sitos
+
+#endif  // SITOS_PARAM_SUBSCRIPTION_HPP

--- a/include/sitos/sitos.hpp
+++ b/include/sitos/sitos.hpp
@@ -13,6 +13,7 @@
 #include "sitos/param_cache.hpp"
 #include "sitos/param_concepts.hpp"
 #include "sitos/param_store.hpp"
+#include "sitos/param_subscription.hpp"
 #include "sitos/param_value.hpp"
 #include "sitos/result.hpp"
 #include "sitos/session.hpp"

--- a/src/param_store_test_access.hpp
+++ b/src/param_store_test_access.hpp
@@ -13,6 +13,8 @@ namespace sitos::param_store_test_access {
 class ParamStoreTestAccess {
  public:
   static void SetNativeEntryHook(ParamStore& store, std::function<void()> hook);
+  static void SetLifecycleHooks(ParamStore& store, std::function<void()> fail_staging_hook,
+                                std::function<void()> close_admission_hook);
 };
 
 }  // namespace sitos::param_store_test_access

--- a/src/param_store_test_access.hpp
+++ b/src/param_store_test_access.hpp
@@ -1,0 +1,20 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SITOS_PARAM_STORE_TEST_ACCESS_HPP
+#define SITOS_PARAM_STORE_TEST_ACCESS_HPP
+
+#include <functional>
+
+#include "sitos/param_store.hpp"
+
+namespace sitos::param_store_test_access {
+
+class ParamStoreTestAccess {
+ public:
+  static void SetNativeEntryHook(ParamStore& store, std::function<void()> hook);
+};
+
+}  // namespace sitos::param_store_test_access
+
+#endif  // SITOS_PARAM_STORE_TEST_ACCESS_HPP

--- a/src/param_store_test_access.hpp
+++ b/src/param_store_test_access.hpp
@@ -13,6 +13,7 @@ namespace sitos::param_store_test_access {
 class ParamStoreTestAccess {
  public:
   static void SetNativeEntryHook(ParamStore& store, std::function<void()> hook);
+  static void SetDecodeHook(ParamStore& store, std::function<void()> hook);
   static void SetLifecycleHooks(ParamStore& store, std::function<void()> fail_staging_hook,
                                 std::function<void()> close_admission_hook,
                                 std::function<void()> close_reset_hook);

--- a/src/param_store_test_access.hpp
+++ b/src/param_store_test_access.hpp
@@ -14,7 +14,8 @@ class ParamStoreTestAccess {
  public:
   static void SetNativeEntryHook(ParamStore& store, std::function<void()> hook);
   static void SetLifecycleHooks(ParamStore& store, std::function<void()> fail_staging_hook,
-                                std::function<void()> close_admission_hook);
+                                std::function<void()> close_admission_hook,
+                                std::function<void()> close_reset_hook);
 };
 
 }  // namespace sitos::param_store_test_access

--- a/src/param_subscription.cpp
+++ b/src/param_subscription.cpp
@@ -46,6 +46,7 @@ struct SubscriptionState : std::enable_shared_from_this<SubscriptionState> {
                     std::string prefix_value, Scope scope_value, std::string list_prefix_value,
                     ParamCallback callback_value, std::shared_ptr<LogSink> log_sink_value,
                     std::function<void()> native_entry_hook_value,
+                    std::function<void()> decode_hook_value,
                     std::function<void()> fail_staging_hook_value,
                     std::function<void()> close_admission_hook_value,
                     std::function<void()> close_reset_hook_value)
@@ -57,6 +58,7 @@ struct SubscriptionState : std::enable_shared_from_this<SubscriptionState> {
         callback(std::move(callback_value)),
         log_sink(std::move(log_sink_value)),
         native_entry_hook(std::move(native_entry_hook_value)),
+        decode_hook(std::move(decode_hook_value)),
         fail_staging_hook(std::move(fail_staging_hook_value)),
         close_admission_hook(std::move(close_admission_hook_value)),
         close_reset_hook(std::move(close_reset_hook_value)) {}
@@ -69,6 +71,7 @@ struct SubscriptionState : std::enable_shared_from_this<SubscriptionState> {
   ParamCallback callback;
   std::shared_ptr<LogSink> log_sink;
   std::function<void()> native_entry_hook;
+  std::function<void()> decode_hook;
   std::function<void()> fail_staging_hook;
   std::function<void()> close_admission_hook;
   std::function<void()> close_reset_hook;
@@ -108,7 +111,11 @@ void Error(const std::shared_ptr<SubscriptionState>& state, std::string_view mes
 std::optional<std::vector<ParamChange>> Decode(
     const std::shared_ptr<SubscriptionState>& state, const OwnedSample& sample) {
   auto parsed = ParseKey(state->prefix, sample.key);
-  if (!parsed || !MatchesScope(*parsed, state->scope)) return std::nullopt;
+  if (!parsed) {
+    Warn(state, "malformed or reserved transport key");
+    return std::vector<ParamChange>{};
+  }
+  if (!MatchesScope(*parsed, state->scope)) return std::nullopt;
 
   if (sample.kind == TransportSample::Kind::Delete) {
     if (parsed->is_batch) {
@@ -173,23 +180,39 @@ std::optional<std::vector<ParamChange>> Decode(
 
 void Deliver(const std::shared_ptr<SubscriptionState>& state,
              const std::shared_ptr<WorkItem>& item) {
-  auto changes = Decode(state, item->sample);
-  if (changes.has_value()) {
-    for (const auto& change : *changes) {
-      try {
-        state->callback(change);
-      } catch (const std::exception& exception) {
-        Error(state, exception.what());
-      } catch (...) {
-        Error(state, "ParamSubscription callback threw a non-standard exception");
+  struct CompletionGuard {
+    explicit CompletionGuard(const std::shared_ptr<WorkItem>& item_value) : item(item_value) {}
+    ~CompletionGuard() {
+      {
+        std::lock_guard<std::mutex> lock(item->mutex);
+        item->complete = true;
       }
+      item->condition.notify_all();
+    }
+    std::shared_ptr<WorkItem> item;
+  } completion(item);
+
+  std::optional<std::vector<ParamChange>> changes;
+  try {
+    if (state->decode_hook) state->decode_hook();
+    changes = Decode(state, item->sample);
+  } catch (const std::exception& exception) {
+    Error(state, exception.what());
+    return;
+  } catch (...) {
+    Error(state, "ParamSubscription internal decode failed");
+    return;
+  }
+  if (!changes.has_value()) return;
+  for (const auto& change : *changes) {
+    try {
+      state->callback(change);
+    } catch (const std::exception& exception) {
+      Error(state, exception.what());
+    } catch (...) {
+      Error(state, "ParamSubscription callback threw a non-standard exception");
     }
   }
-  {
-    std::lock_guard<std::mutex> lock(item->mutex);
-    item->complete = true;
-  }
-  item->condition.notify_all();
 }
 
 void Drain(const std::shared_ptr<SubscriptionState>& state) {
@@ -206,7 +229,13 @@ void Drain(const std::shared_ptr<SubscriptionState>& state) {
       item = std::move(state->queue.front());
       state->queue.pop_front();
     }
-    Deliver(state, item);
+    try {
+      Deliver(state, item);
+    } catch (const std::exception& exception) {
+      Error(state, exception.what());
+    } catch (...) {
+      Error(state, "ParamSubscription internal delivery failed");
+    }
   }
 }
 
@@ -313,6 +342,7 @@ void CloseState(const std::shared_ptr<SubscriptionState>& state) noexcept {
   state->callback = {};
   state->log_sink.reset();
   state->native_entry_hook = {};
+  state->decode_hook = {};
   state->fail_staging_hook = {};
   state->close_admission_hook = {};
   state->close_reset_hook = {};
@@ -332,6 +362,10 @@ namespace param_store_test_access {
 
 void ParamStoreTestAccess::SetNativeEntryHook(ParamStore& store, std::function<void()> hook) {
   store.subscription_native_entry_hook_ = std::move(hook);
+}
+
+void ParamStoreTestAccess::SetDecodeHook(ParamStore& store, std::function<void()> hook) {
+  store.subscription_decode_hook_ = std::move(hook);
 }
 
 void ParamStoreTestAccess::SetLifecycleHooks(ParamStore& store,
@@ -370,6 +404,7 @@ ParamStore::ParamStore(std::shared_ptr<Transport> transport, ClientConfig config
 ParamStore::ParamStore(ParamStore&& other) noexcept
     : declaration_control_(std::move(other.declaration_control_)),
       subscription_native_entry_hook_(std::move(other.subscription_native_entry_hook_)),
+      subscription_decode_hook_(std::move(other.subscription_decode_hook_)),
       subscription_fail_staging_hook_(std::move(other.subscription_fail_staging_hook_)),
       subscription_close_admission_hook_(std::move(other.subscription_close_admission_hook_)),
       subscription_close_reset_hook_(std::move(other.subscription_close_reset_hook_)),
@@ -380,6 +415,7 @@ ParamStore& ParamStore::operator=(ParamStore&& other) noexcept {
   if (this == &other) return *this;
   declaration_control_ = std::move(other.declaration_control_);
   subscription_native_entry_hook_ = std::move(other.subscription_native_entry_hook_);
+  subscription_decode_hook_ = std::move(other.subscription_decode_hook_);
   subscription_fail_staging_hook_ = std::move(other.subscription_fail_staging_hook_);
   subscription_close_admission_hook_ = std::move(other.subscription_close_admission_hook_);
   subscription_close_reset_hook_ = std::move(other.subscription_close_reset_hook_);
@@ -406,7 +442,8 @@ Result<ParamSubscription> ParamStore::Subscribe(std::string_view scope, std::str
   auto state = std::make_shared<SubscriptionState>(
       transport_, declaration_control_, config_.prefix, parsed_scope.Value(), std::string(prefix),
       std::move(callback), config_.log_sink, subscription_native_entry_hook_,
-      subscription_fail_staging_hook_, subscription_close_admission_hook_,
+      subscription_decode_hook_, subscription_fail_staging_hook_,
+      subscription_close_admission_hook_,
       subscription_close_reset_hook_);
 
   std::optional<Result<Subscription>> declared;

--- a/src/param_subscription.cpp
+++ b/src/param_subscription.cpp
@@ -47,7 +47,8 @@ struct SubscriptionState : std::enable_shared_from_this<SubscriptionState> {
                     ParamCallback callback_value, std::shared_ptr<LogSink> log_sink_value,
                     std::function<void()> native_entry_hook_value,
                     std::function<void()> fail_staging_hook_value,
-                    std::function<void()> close_admission_hook_value)
+                    std::function<void()> close_admission_hook_value,
+                    std::function<void()> close_reset_hook_value)
       : transport(std::move(transport_value)),
         control(std::move(control_value)),
         prefix(std::move(prefix_value)),
@@ -57,7 +58,8 @@ struct SubscriptionState : std::enable_shared_from_this<SubscriptionState> {
         log_sink(std::move(log_sink_value)),
         native_entry_hook(std::move(native_entry_hook_value)),
         fail_staging_hook(std::move(fail_staging_hook_value)),
-        close_admission_hook(std::move(close_admission_hook_value)) {}
+        close_admission_hook(std::move(close_admission_hook_value)),
+        close_reset_hook(std::move(close_reset_hook_value)) {}
 
   std::shared_ptr<Transport> transport;
   std::shared_ptr<ParamStore::DeclarationControl> control;
@@ -69,6 +71,7 @@ struct SubscriptionState : std::enable_shared_from_this<SubscriptionState> {
   std::function<void()> native_entry_hook;
   std::function<void()> fail_staging_hook;
   std::function<void()> close_admission_hook;
+  std::function<void()> close_reset_hook;
   Subscription native;
 
   std::mutex mutex;
@@ -295,6 +298,7 @@ void CloseState(const std::shared_ptr<SubscriptionState>& state) noexcept {
 
   {
     std::lock_guard<std::mutex> declaration_lock(state->control->mutex);
+    if (state->close_reset_hook) state->close_reset_hook();
     state->native = Subscription{};
   }
 
@@ -311,6 +315,7 @@ void CloseState(const std::shared_ptr<SubscriptionState>& state) noexcept {
   state->native_entry_hook = {};
   state->fail_staging_hook = {};
   state->close_admission_hook = {};
+  state->close_reset_hook = {};
   state->close_finished = true;
   lock.unlock();
   state->condition.notify_all();
@@ -331,9 +336,11 @@ void ParamStoreTestAccess::SetNativeEntryHook(ParamStore& store, std::function<v
 
 void ParamStoreTestAccess::SetLifecycleHooks(ParamStore& store,
                                              std::function<void()> fail_staging_hook,
-                                             std::function<void()> close_admission_hook) {
+                                             std::function<void()> close_admission_hook,
+                                             std::function<void()> close_reset_hook) {
   store.subscription_fail_staging_hook_ = std::move(fail_staging_hook);
   store.subscription_close_admission_hook_ = std::move(close_admission_hook);
+  store.subscription_close_reset_hook_ = std::move(close_reset_hook);
 }
 
 }  // namespace param_store_test_access
@@ -365,6 +372,7 @@ ParamStore::ParamStore(ParamStore&& other) noexcept
       subscription_native_entry_hook_(std::move(other.subscription_native_entry_hook_)),
       subscription_fail_staging_hook_(std::move(other.subscription_fail_staging_hook_)),
       subscription_close_admission_hook_(std::move(other.subscription_close_admission_hook_)),
+      subscription_close_reset_hook_(std::move(other.subscription_close_reset_hook_)),
       transport_(std::move(other.transport_)),
       config_(std::move(other.config_)) {}
 
@@ -374,6 +382,7 @@ ParamStore& ParamStore::operator=(ParamStore&& other) noexcept {
   subscription_native_entry_hook_ = std::move(other.subscription_native_entry_hook_);
   subscription_fail_staging_hook_ = std::move(other.subscription_fail_staging_hook_);
   subscription_close_admission_hook_ = std::move(other.subscription_close_admission_hook_);
+  subscription_close_reset_hook_ = std::move(other.subscription_close_reset_hook_);
   transport_ = std::move(other.transport_);
   config_ = std::move(other.config_);
   return *this;
@@ -397,7 +406,8 @@ Result<ParamSubscription> ParamStore::Subscribe(std::string_view scope, std::str
   auto state = std::make_shared<SubscriptionState>(
       transport_, declaration_control_, config_.prefix, parsed_scope.Value(), std::string(prefix),
       std::move(callback), config_.log_sink, subscription_native_entry_hook_,
-      subscription_fail_staging_hook_, subscription_close_admission_hook_);
+      subscription_fail_staging_hook_, subscription_close_admission_hook_,
+      subscription_close_reset_hook_);
 
   std::optional<Result<Subscription>> declared;
   {

--- a/src/param_subscription.cpp
+++ b/src/param_subscription.cpp
@@ -108,6 +108,69 @@ void Error(const std::shared_ptr<SubscriptionState>& state, std::string_view mes
   EmitLog(state->log_sink, LogLevel::kError, "ParamSubscription", message);
 }
 
+std::vector<ParamChange> DecodeDelete(const std::shared_ptr<SubscriptionState>& state,
+                                      ParsedKey parsed) {
+  if (parsed.is_batch) {
+    Warn(state, "batch DELETE is unsupported");
+    return {};
+  }
+  if (!state->list_prefix.empty() && !parsed.relative_key.starts_with(state->list_prefix)) {
+    return {};
+  }
+  return {ParamChange{ParamChangeKind::kDelete, std::move(parsed.relative_key), std::nullopt}};
+}
+
+std::vector<ParamChange> DecodeBatchSample(const std::shared_ptr<SubscriptionState>& state,
+                                           const OwnedSample& sample) {
+  if (sample.encoding.id != Encoding::kSitosV1Batch) {
+    Warn(state, "batch sample has an unsupported encoding");
+    return {};
+  }
+  auto entries = DecodeBatch(sample.payload);
+  if (!entries.has_value()) {
+    Warn(state, "malformed batch sample");
+    return {};
+  }
+  std::vector<ParamChange> changes;
+  changes.reserve(entries->size());
+  for (auto& entry : *entries) {
+    if (!IsValidKey(entry.key)) {
+      Warn(state, "batch sample contains an invalid key");
+      return {};
+    }
+    if (state->list_prefix.empty() || entry.key.starts_with(state->list_prefix)) {
+      changes.push_back(ParamChange{ParamChangeKind::kPut, std::move(entry.key),
+                                    std::move(entry.value)});
+    }
+  }
+  return changes;
+}
+
+std::vector<ParamChange> DecodeOrdinary(const std::shared_ptr<SubscriptionState>& state,
+                                        const OwnedSample& sample, ParsedKey parsed) {
+  if (!state->list_prefix.empty() && !parsed.relative_key.starts_with(state->list_prefix)) {
+    return {};
+  }
+  if (sample.encoding.id == Encoding::kSitosV1Batch) {
+    Warn(state, "ordinary sample has batch encoding");
+    return {};
+  }
+
+  if (sample.encoding.id == Encoding::kSitosV1) {
+    auto decoded = ParamValue::Decode(sample.payload);
+    if (!decoded.has_value()) {
+      Warn(state, "malformed sitos.v1 sample");
+      return {};
+    }
+    return {ParamChange{ParamChangeKind::kPut, std::move(parsed.relative_key),
+                        std::move(*decoded)}};
+  }
+  std::vector<std::byte> raw(sample.payload.begin(), sample.payload.end());
+  auto value = ParamValue(std::move(raw));
+  Warn(state, "unknown sample encoding; wrapped as bytes");
+  return {ParamChange{ParamChangeKind::kPut, std::move(parsed.relative_key), std::move(value)}};
+}
+
 std::optional<std::vector<ParamChange>> Decode(
     const std::shared_ptr<SubscriptionState>& state, const OwnedSample& sample) {
   auto parsed = ParseKey(state->prefix, sample.key);
@@ -116,81 +179,32 @@ std::optional<std::vector<ParamChange>> Decode(
     return std::vector<ParamChange>{};
   }
   if (!MatchesScope(*parsed, state->scope)) return std::nullopt;
-
   if (sample.kind == TransportSample::Kind::Delete) {
-    if (parsed->is_batch) {
-      Warn(state, "batch DELETE is unsupported");
-      return std::vector<ParamChange>{};
-    }
-    if (!state->list_prefix.empty() && !parsed->relative_key.starts_with(state->list_prefix)) {
-      return std::vector<ParamChange>{};
-    }
-    return std::vector<ParamChange>{
-        ParamChange{ParamChangeKind::kDelete, std::move(parsed->relative_key), std::nullopt}};
+    return DecodeDelete(state, std::move(*parsed));
   }
-
-  if (parsed->is_batch) {
-    if (sample.encoding.id != Encoding::kSitosV1Batch) {
-      Warn(state, "batch sample has an unsupported encoding");
-      return std::vector<ParamChange>{};
-    }
-    auto entries = DecodeBatch(sample.payload);
-    if (!entries.has_value()) {
-      Warn(state, "malformed batch sample");
-      return std::vector<ParamChange>{};
-    }
-    std::vector<ParamChange> changes;
-    changes.reserve(entries->size());
-    for (auto& entry : *entries) {
-      if (!IsValidKey(entry.key)) {
-        Warn(state, "batch sample contains an invalid key");
-        return std::vector<ParamChange>{};
-      }
-      if (state->list_prefix.empty() || entry.key.starts_with(state->list_prefix)) {
-        changes.push_back(ParamChange{ParamChangeKind::kPut, std::move(entry.key),
-                                      std::move(entry.value)});
-      }
-    }
-    return changes;
-  }
-
-  if (!state->list_prefix.empty() && !parsed->relative_key.starts_with(state->list_prefix)) {
-    return std::vector<ParamChange>{};
-  }
-  if (sample.encoding.id == Encoding::kSitosV1Batch) {
-    Warn(state, "ordinary sample has batch encoding");
-    return std::vector<ParamChange>{};
-  }
-
-  std::vector<std::byte> raw(sample.payload.begin(), sample.payload.end());
-  ParamValue value = ParamValue(std::move(raw));
-  if (sample.encoding.id == Encoding::kSitosV1) {
-    auto decoded = ParamValue::Decode(sample.payload);
-    if (!decoded.has_value()) {
-      Warn(state, "malformed sitos.v1 sample");
-      return std::vector<ParamChange>{};
-    }
-    value = std::move(*decoded);
-  } else {
-    Warn(state, "unknown sample encoding; wrapped as bytes");
-  }
-  return std::vector<ParamChange>{
-      ParamChange{ParamChangeKind::kPut, std::move(parsed->relative_key), std::move(value)}};
+  if (parsed->is_batch) return DecodeBatchSample(state, sample);
+  return DecodeOrdinary(state, sample, std::move(*parsed));
 }
+
+struct CompletionGuard {
+  explicit CompletionGuard(const std::shared_ptr<WorkItem>& item_value) : item(item_value) {}
+  CompletionGuard(const CompletionGuard&) = delete;
+  CompletionGuard& operator=(const CompletionGuard&) = delete;
+  CompletionGuard(CompletionGuard&&) = delete;
+  CompletionGuard& operator=(CompletionGuard&&) = delete;
+  ~CompletionGuard() {
+    {
+      std::lock_guard<std::mutex> lock(item->mutex);
+      item->complete = true;
+    }
+    item->condition.notify_all();
+  }
+  std::shared_ptr<WorkItem> item;
+};
 
 void Deliver(const std::shared_ptr<SubscriptionState>& state,
              const std::shared_ptr<WorkItem>& item) {
-  struct CompletionGuard {
-    explicit CompletionGuard(const std::shared_ptr<WorkItem>& item_value) : item(item_value) {}
-    ~CompletionGuard() {
-      {
-        std::lock_guard<std::mutex> lock(item->mutex);
-        item->complete = true;
-      }
-      item->condition.notify_all();
-    }
-    std::shared_ptr<WorkItem> item;
-  } completion(item);
+  CompletionGuard completion(item);
 
   std::optional<std::vector<ParamChange>> changes;
   try {
@@ -252,9 +266,15 @@ void OnSample(const std::shared_ptr<SubscriptionState>& state, const TransportSa
     ++state->native_in_flight;
   }
   struct NativeGuard {
-    std::shared_ptr<SubscriptionState> state;
+    NativeGuard(const std::shared_ptr<SubscriptionState>& state_value) : state(state_value) {}
+    NativeGuard(const NativeGuard&) = delete;
+    NativeGuard& operator=(const NativeGuard&) = delete;
+    NativeGuard(NativeGuard&&) = delete;
+    NativeGuard& operator=(NativeGuard&&) = delete;
     ~NativeGuard() { CompleteNative(state); }
-  } guard{state};
+    std::shared_ptr<SubscriptionState> state;
+  };
+  NativeGuard guard(state);
   if (state->native_entry_hook) state->native_entry_hook();
 
   std::vector<std::byte> payload(sample.payload.begin(), sample.payload.end());
@@ -278,7 +298,7 @@ void OnSample(const std::shared_ptr<SubscriptionState>& state, const TransportSa
     return;
   }
   std::unique_lock<std::mutex> item_lock(item->mutex);
-  item->condition.wait(item_lock, [&] { return item->complete; });
+  item->condition.wait(item_lock, [&item] { return item->complete; });
 }
 
 void ActivateAndDrain(const std::shared_ptr<SubscriptionState>& state) {
@@ -305,7 +325,7 @@ void FailStaging(const std::shared_ptr<SubscriptionState>& state) {
     hook();
     lock.lock();
   }
-  state->condition.wait(lock, [&] { return state->native_in_flight == 0; });
+  state->condition.wait(lock, [&state] { return state->native_in_flight == 0; });
   state->queue.clear();
   state->staging = false;
   state->condition.notify_all();
@@ -316,7 +336,7 @@ void CloseState(const std::shared_ptr<SubscriptionState>& state) noexcept {
     std::unique_lock<std::mutex> lock(state->mutex);
     if (state->close_finished) return;
     if (state->close_started) {
-      state->condition.wait(lock, [&] { return state->close_finished; });
+      state->condition.wait(lock, [&state] { return state->close_finished; });
       return;
     }
     state->close_started = true;
@@ -332,7 +352,7 @@ void CloseState(const std::shared_ptr<SubscriptionState>& state) noexcept {
   }
 
   std::unique_lock<std::mutex> lock(state->mutex);
-  state->condition.wait(lock, [&] {
+  state->condition.wait(lock, [&state] {
     return state->native_in_flight == 0 && state->queue.empty() && !state->drainer;
   });
   state->transport.reset();
@@ -435,8 +455,9 @@ Result<ParamSubscription> ParamStore::Subscribe(std::string_view scope, std::str
   if (parsed_scope.Value().kind == ScopeKind::Snap) {
     return Result<ParamSubscription>::Err(Status::InvalidArgument, "snapshot scope is read-only");
   }
-  auto prefix_result = ValidateListPrefix(prefix);
-  if (!prefix_result.IsOk()) return Result<ParamSubscription>::ErrFrom(prefix_result);
+  if (auto prefix_result = ValidateListPrefix(prefix); !prefix_result.IsOk()) {
+    return Result<ParamSubscription>::ErrFrom(prefix_result);
+  }
 
   const std::string selector = config_.prefix + "/" + ScopePath(parsed_scope.Value()) + "/**";
   auto state = std::make_shared<SubscriptionState>(

--- a/src/param_subscription.cpp
+++ b/src/param_subscription.cpp
@@ -7,6 +7,7 @@
 
 #include <condition_variable>
 #include <deque>
+#include <exception>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -141,7 +142,8 @@ std::optional<std::vector<ParamChange>> Decode(
     return std::vector<ParamChange>{};
   }
 
-  ParamValue value = ParamValue(std::vector<std::byte>(sample.payload.begin(), sample.payload.end()));
+  std::vector<std::byte> raw(sample.payload.begin(), sample.payload.end());
+  ParamValue value = ParamValue(std::move(raw));
   if (sample.encoding.id == Encoding::kSitosV1) {
     auto decoded = ParamValue::Decode(sample.payload);
     if (!decoded.has_value()) {
@@ -212,8 +214,8 @@ void OnSample(const std::shared_ptr<SubscriptionState>& state, const TransportSa
     ~NativeGuard() { CompleteNative(state); }
   } guard{state};
 
-  OwnedSample owned{sample.key, std::vector<std::byte>(sample.payload.begin(), sample.payload.end()),
-                    sample.encoding, sample.kind};
+  std::vector<std::byte> payload(sample.payload.begin(), sample.payload.end());
+  OwnedSample owned{sample.key, std::move(payload), sample.encoding, sample.kind};
   auto item = std::make_shared<WorkItem>(std::move(owned));
   bool become_drainer = false;
   {

--- a/src/param_subscription.cpp
+++ b/src/param_subscription.cpp
@@ -1,0 +1,371 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/param_store.hpp"
+
+#include "list_prefix_validation.hpp"
+
+#include <condition_variable>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace sitos {
+
+struct ParamStore::DeclarationControl {
+  std::mutex mutex;
+};
+
+namespace {
+
+struct OwnedSample {
+  std::string key;
+  std::vector<std::byte> payload;
+  Encoding encoding;
+  TransportSample::Kind kind;
+};
+
+struct WorkItem {
+  explicit WorkItem(OwnedSample value) : sample(std::move(value)) {}
+
+  OwnedSample sample;
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool complete = false;
+};
+
+struct SubscriptionState : std::enable_shared_from_this<SubscriptionState> {
+  SubscriptionState(std::shared_ptr<Transport> transport_value,
+                    std::shared_ptr<ParamStore::DeclarationControl> control_value,
+                    std::string prefix_value, Scope scope_value, std::string list_prefix_value,
+                    ParamCallback callback_value, std::shared_ptr<LogSink> log_sink_value)
+      : transport(std::move(transport_value)),
+        control(std::move(control_value)),
+        prefix(std::move(prefix_value)),
+        scope(std::move(scope_value)),
+        list_prefix(std::move(list_prefix_value)),
+        callback(std::move(callback_value)),
+        log_sink(std::move(log_sink_value)) {}
+
+  std::shared_ptr<Transport> transport;
+  std::shared_ptr<ParamStore::DeclarationControl> control;
+  std::string prefix;
+  Scope scope;
+  std::string list_prefix;
+  ParamCallback callback;
+  std::shared_ptr<LogSink> log_sink;
+  Subscription native;
+
+  std::mutex mutex;
+  std::condition_variable condition;
+  std::deque<std::shared_ptr<WorkItem>> queue;
+  bool accepting = true;
+  bool staging = true;
+  bool close_started = false;
+  bool close_finished = false;
+  bool drainer = false;
+  std::thread::id drainer_id;
+  std::size_t native_in_flight = 0;
+};
+
+std::string ScopePath(const Scope& scope) {
+  if (scope.kind == ScopeKind::Base) return "base";
+  if (scope.kind == ScopeKind::Session) return "session/" + scope.sid;
+  return "snap/" + scope.sid;
+}
+
+bool MatchesScope(const ParsedKey& parsed, const Scope& scope) {
+  if (scope.kind == ScopeKind::Base) return parsed.kind == KeyKind::Base;
+  return parsed.kind == KeyKind::Session && parsed.sid == scope.sid;
+}
+
+void Warn(const std::shared_ptr<SubscriptionState>& state, std::string_view message) {
+  EmitLog(state->log_sink, LogLevel::kWarning, "ParamSubscription", message);
+}
+
+void Error(const std::shared_ptr<SubscriptionState>& state, std::string_view message) {
+  EmitLog(state->log_sink, LogLevel::kError, "ParamSubscription", message);
+}
+
+std::optional<std::vector<ParamChange>> Decode(
+    const std::shared_ptr<SubscriptionState>& state, const OwnedSample& sample) {
+  auto parsed = ParseKey(state->prefix, sample.key);
+  if (!parsed || !MatchesScope(*parsed, state->scope)) return std::nullopt;
+
+  if (sample.kind == TransportSample::Kind::Delete) {
+    if (parsed->is_batch) {
+      Warn(state, "batch DELETE is unsupported");
+      return std::vector<ParamChange>{};
+    }
+    if (!state->list_prefix.empty() && !parsed->relative_key.starts_with(state->list_prefix)) {
+      return std::vector<ParamChange>{};
+    }
+    return std::vector<ParamChange>{
+        ParamChange{ParamChangeKind::kDelete, std::move(parsed->relative_key), std::nullopt}};
+  }
+
+  if (parsed->is_batch) {
+    if (sample.encoding.id != Encoding::kSitosV1Batch) {
+      Warn(state, "batch sample has an unsupported encoding");
+      return std::vector<ParamChange>{};
+    }
+    auto entries = DecodeBatch(sample.payload);
+    if (!entries.has_value()) {
+      Warn(state, "malformed batch sample");
+      return std::vector<ParamChange>{};
+    }
+    std::vector<ParamChange> changes;
+    changes.reserve(entries->size());
+    for (auto& entry : *entries) {
+      if (!IsValidKey(entry.key)) {
+        Warn(state, "batch sample contains an invalid key");
+        return std::vector<ParamChange>{};
+      }
+      if (state->list_prefix.empty() || entry.key.starts_with(state->list_prefix)) {
+        changes.push_back(ParamChange{ParamChangeKind::kPut, std::move(entry.key),
+                                      std::move(entry.value)});
+      }
+    }
+    return changes;
+  }
+
+  if (!state->list_prefix.empty() && !parsed->relative_key.starts_with(state->list_prefix)) {
+    return std::vector<ParamChange>{};
+  }
+  if (sample.encoding.id == Encoding::kSitosV1Batch) {
+    Warn(state, "ordinary sample has batch encoding");
+    return std::vector<ParamChange>{};
+  }
+
+  ParamValue value = ParamValue(std::vector<std::byte>(sample.payload.begin(), sample.payload.end()));
+  if (sample.encoding.id == Encoding::kSitosV1) {
+    auto decoded = ParamValue::Decode(sample.payload);
+    if (!decoded.has_value()) {
+      Warn(state, "malformed sitos.v1 sample");
+      return std::vector<ParamChange>{};
+    }
+    value = std::move(*decoded);
+  } else {
+    Warn(state, "unknown sample encoding; wrapped as bytes");
+  }
+  return std::vector<ParamChange>{
+      ParamChange{ParamChangeKind::kPut, std::move(parsed->relative_key), std::move(value)}};
+}
+
+void Deliver(const std::shared_ptr<SubscriptionState>& state,
+             const std::shared_ptr<WorkItem>& item) {
+  auto changes = Decode(state, item->sample);
+  if (changes.has_value()) {
+    for (const auto& change : *changes) {
+      try {
+        state->callback(change);
+      } catch (const std::exception& exception) {
+        Error(state, exception.what());
+      } catch (...) {
+        Error(state, "ParamSubscription callback threw a non-standard exception");
+      }
+    }
+  }
+  {
+    std::lock_guard<std::mutex> lock(item->mutex);
+    item->complete = true;
+  }
+  item->condition.notify_all();
+}
+
+void Drain(const std::shared_ptr<SubscriptionState>& state) {
+  for (;;) {
+    std::shared_ptr<WorkItem> item;
+    {
+      std::lock_guard<std::mutex> lock(state->mutex);
+      if (state->queue.empty()) {
+        state->drainer = false;
+        state->drainer_id = {};
+        state->condition.notify_all();
+        return;
+      }
+      item = std::move(state->queue.front());
+      state->queue.pop_front();
+    }
+    Deliver(state, item);
+  }
+}
+
+void CompleteNative(const std::shared_ptr<SubscriptionState>& state) {
+  std::lock_guard<std::mutex> lock(state->mutex);
+  --state->native_in_flight;
+  state->condition.notify_all();
+}
+
+void OnSample(const std::shared_ptr<SubscriptionState>& state, const TransportSample& sample) {
+  {
+    std::lock_guard<std::mutex> lock(state->mutex);
+    if (!state->accepting) return;
+    ++state->native_in_flight;
+  }
+  struct NativeGuard {
+    std::shared_ptr<SubscriptionState> state;
+    ~NativeGuard() { CompleteNative(state); }
+  } guard{state};
+
+  OwnedSample owned{sample.key, std::vector<std::byte>(sample.payload.begin(), sample.payload.end()),
+                    sample.encoding, sample.kind};
+  auto item = std::make_shared<WorkItem>(std::move(owned));
+  bool become_drainer = false;
+  {
+    std::lock_guard<std::mutex> lock(state->mutex);
+    if (!state->accepting) return;
+    state->queue.push_back(item);
+    if (state->staging) return;
+    if (!state->drainer) {
+      state->drainer = true;
+      state->drainer_id = std::this_thread::get_id();
+      become_drainer = true;
+    } else if (state->drainer_id == std::this_thread::get_id()) {
+      return;
+    }
+  }
+  if (become_drainer) {
+    Drain(state);
+    return;
+  }
+  std::unique_lock<std::mutex> item_lock(item->mutex);
+  item->condition.wait(item_lock, [&] { return item->complete; });
+}
+
+void ActivateAndDrain(const std::shared_ptr<SubscriptionState>& state) {
+  bool become_drainer = false;
+  {
+    std::lock_guard<std::mutex> lock(state->mutex);
+    state->staging = false;
+    if (!state->queue.empty()) {
+      state->drainer = true;
+      state->drainer_id = std::this_thread::get_id();
+      become_drainer = true;
+    }
+    state->condition.notify_all();
+  }
+  if (become_drainer) Drain(state);
+}
+
+void FailStaging(const std::shared_ptr<SubscriptionState>& state) {
+  std::lock_guard<std::mutex> lock(state->mutex);
+  state->accepting = false;
+  state->staging = false;
+  state->queue.clear();
+  state->condition.notify_all();
+}
+
+void CloseState(const std::shared_ptr<SubscriptionState>& state) noexcept {
+  {
+    std::unique_lock<std::mutex> lock(state->mutex);
+    if (state->close_finished) return;
+    if (state->close_started) {
+      state->condition.wait(lock, [&] { return state->close_finished; });
+      return;
+    }
+    state->close_started = true;
+    state->accepting = false;
+    state->staging = false;
+  }
+
+  {
+    std::lock_guard<std::mutex> declaration_lock(state->control->mutex);
+    state->native = Subscription{};
+  }
+
+  std::unique_lock<std::mutex> lock(state->mutex);
+  state->condition.wait(lock, [&] {
+    return state->native_in_flight == 0 && state->queue.empty() && !state->drainer;
+  });
+  state->close_finished = true;
+  lock.unlock();
+  state->condition.notify_all();
+}
+
+}  // namespace
+
+struct ParamSubscription::Impl {
+  explicit Impl(std::shared_ptr<SubscriptionState> state_value) : state(std::move(state_value)) {}
+  std::shared_ptr<SubscriptionState> state;
+};
+
+ParamSubscription::ParamSubscription(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {}
+
+ParamSubscription::ParamSubscription(ParamSubscription&& other) noexcept = default;
+
+ParamSubscription& ParamSubscription::operator=(ParamSubscription&& other) noexcept {
+  if (this == &other) return *this;
+  Close();
+  impl_ = std::move(other.impl_);
+  return *this;
+}
+
+ParamSubscription::~ParamSubscription() { Close(); }
+
+void ParamSubscription::Close() noexcept {
+  if (impl_) CloseState(impl_->state);
+}
+
+ParamStore::ParamStore(std::shared_ptr<Transport> transport, ClientConfig config)
+    : declaration_control_(std::make_shared<DeclarationControl>()),
+      transport_(std::move(transport)),
+      config_(std::move(config)) {}
+
+ParamStore::ParamStore(ParamStore&& other) noexcept
+    : declaration_control_(std::move(other.declaration_control_)),
+      transport_(std::move(other.transport_)),
+      config_(std::move(other.config_)) {}
+
+ParamStore& ParamStore::operator=(ParamStore&& other) noexcept {
+  if (this == &other) return *this;
+  declaration_control_ = std::move(other.declaration_control_);
+  transport_ = std::move(other.transport_);
+  config_ = std::move(other.config_);
+  return *this;
+}
+
+Result<ParamSubscription> ParamStore::Subscribe(std::string_view scope, std::string_view prefix,
+                                                ParamCallback callback) {
+  if (!transport_) return Result<ParamSubscription>::Err(Status::InvalidArgument,
+                                                         "moved-from ParamStore");
+  if (!callback) return Result<ParamSubscription>::Err(Status::InvalidArgument,
+                                                       "empty subscription callback");
+  auto parsed_scope = ParseAndValidateScope(scope);
+  if (!parsed_scope.IsOk()) return Result<ParamSubscription>::ErrFrom(parsed_scope);
+  if (parsed_scope.Value().kind == ScopeKind::Snap) {
+    return Result<ParamSubscription>::Err(Status::InvalidArgument, "snapshot scope is read-only");
+  }
+  auto prefix_result = ValidateListPrefix(prefix);
+  if (!prefix_result.IsOk()) return Result<ParamSubscription>::ErrFrom(prefix_result);
+
+  const std::string selector = config_.prefix + "/" + ScopePath(parsed_scope.Value()) + "/**";
+  auto state = std::make_shared<SubscriptionState>(
+      transport_, declaration_control_, config_.prefix, parsed_scope.Value(), std::string(prefix),
+      std::move(callback), config_.log_sink);
+
+  std::optional<Result<Subscription>> declared;
+  {
+    std::lock_guard<std::mutex> declaration_lock(declaration_control_->mutex);
+    std::weak_ptr<SubscriptionState> weak_state = state;
+    declared.emplace(transport_->DeclareSubscriber(
+        selector, [weak_state](const TransportSample& sample) {
+          if (auto locked = weak_state.lock()) OnSample(locked, sample);
+        }));
+    if (declared->IsOk()) state->native = std::move(*declared).Value();
+  }
+  if (!declared->IsOk()) {
+    FailStaging(state);
+    return Result<ParamSubscription>::ErrFrom(*declared);
+  }
+
+  ActivateAndDrain(state);
+  auto impl = std::make_unique<ParamSubscription::Impl>(std::move(state));
+  return Result<ParamSubscription>::Ok(ParamSubscription(std::move(impl)));
+}
+
+}  // namespace sitos

--- a/src/param_subscription.cpp
+++ b/src/param_subscription.cpp
@@ -45,7 +45,9 @@ struct SubscriptionState : std::enable_shared_from_this<SubscriptionState> {
                     std::shared_ptr<ParamStore::DeclarationControl> control_value,
                     std::string prefix_value, Scope scope_value, std::string list_prefix_value,
                     ParamCallback callback_value, std::shared_ptr<LogSink> log_sink_value,
-                    std::function<void()> native_entry_hook_value)
+                    std::function<void()> native_entry_hook_value,
+                    std::function<void()> fail_staging_hook_value,
+                    std::function<void()> close_admission_hook_value)
       : transport(std::move(transport_value)),
         control(std::move(control_value)),
         prefix(std::move(prefix_value)),
@@ -53,7 +55,9 @@ struct SubscriptionState : std::enable_shared_from_this<SubscriptionState> {
         list_prefix(std::move(list_prefix_value)),
         callback(std::move(callback_value)),
         log_sink(std::move(log_sink_value)),
-        native_entry_hook(std::move(native_entry_hook_value)) {}
+        native_entry_hook(std::move(native_entry_hook_value)),
+        fail_staging_hook(std::move(fail_staging_hook_value)),
+        close_admission_hook(std::move(close_admission_hook_value)) {}
 
   std::shared_ptr<Transport> transport;
   std::shared_ptr<ParamStore::DeclarationControl> control;
@@ -63,6 +67,8 @@ struct SubscriptionState : std::enable_shared_from_this<SubscriptionState> {
   ParamCallback callback;
   std::shared_ptr<LogSink> log_sink;
   std::function<void()> native_entry_hook;
+  std::function<void()> fail_staging_hook;
+  std::function<void()> close_admission_hook;
   Subscription native;
 
   std::mutex mutex;
@@ -225,7 +231,6 @@ void OnSample(const std::shared_ptr<SubscriptionState>& state, const TransportSa
   bool become_drainer = false;
   {
     std::lock_guard<std::mutex> lock(state->mutex);
-    if (!state->accepting) return;
     state->queue.push_back(item);
     if (state->staging) return;
     if (!state->drainer) {
@@ -262,9 +267,15 @@ void ActivateAndDrain(const std::shared_ptr<SubscriptionState>& state) {
 void FailStaging(const std::shared_ptr<SubscriptionState>& state) {
   std::unique_lock<std::mutex> lock(state->mutex);
   state->accepting = false;
-  state->staging = false;
+  if (state->fail_staging_hook) {
+    auto hook = state->fail_staging_hook;
+    lock.unlock();
+    hook();
+    lock.lock();
+  }
   state->condition.wait(lock, [&] { return state->native_in_flight == 0; });
   state->queue.clear();
+  state->staging = false;
   state->condition.notify_all();
 }
 
@@ -280,6 +291,7 @@ void CloseState(const std::shared_ptr<SubscriptionState>& state) noexcept {
     state->accepting = false;
     state->staging = false;
   }
+  if (state->close_admission_hook) state->close_admission_hook();
 
   {
     std::lock_guard<std::mutex> declaration_lock(state->control->mutex);
@@ -290,6 +302,15 @@ void CloseState(const std::shared_ptr<SubscriptionState>& state) noexcept {
   state->condition.wait(lock, [&] {
     return state->native_in_flight == 0 && state->queue.empty() && !state->drainer;
   });
+  state->transport.reset();
+  state->control.reset();
+  state->prefix.clear();
+  state->list_prefix.clear();
+  state->callback = {};
+  state->log_sink.reset();
+  state->native_entry_hook = {};
+  state->fail_staging_hook = {};
+  state->close_admission_hook = {};
   state->close_finished = true;
   lock.unlock();
   state->condition.notify_all();
@@ -306,6 +327,13 @@ namespace param_store_test_access {
 
 void ParamStoreTestAccess::SetNativeEntryHook(ParamStore& store, std::function<void()> hook) {
   store.subscription_native_entry_hook_ = std::move(hook);
+}
+
+void ParamStoreTestAccess::SetLifecycleHooks(ParamStore& store,
+                                             std::function<void()> fail_staging_hook,
+                                             std::function<void()> close_admission_hook) {
+  store.subscription_fail_staging_hook_ = std::move(fail_staging_hook);
+  store.subscription_close_admission_hook_ = std::move(close_admission_hook);
 }
 
 }  // namespace param_store_test_access
@@ -335,6 +363,8 @@ ParamStore::ParamStore(std::shared_ptr<Transport> transport, ClientConfig config
 ParamStore::ParamStore(ParamStore&& other) noexcept
     : declaration_control_(std::move(other.declaration_control_)),
       subscription_native_entry_hook_(std::move(other.subscription_native_entry_hook_)),
+      subscription_fail_staging_hook_(std::move(other.subscription_fail_staging_hook_)),
+      subscription_close_admission_hook_(std::move(other.subscription_close_admission_hook_)),
       transport_(std::move(other.transport_)),
       config_(std::move(other.config_)) {}
 
@@ -342,6 +372,8 @@ ParamStore& ParamStore::operator=(ParamStore&& other) noexcept {
   if (this == &other) return *this;
   declaration_control_ = std::move(other.declaration_control_);
   subscription_native_entry_hook_ = std::move(other.subscription_native_entry_hook_);
+  subscription_fail_staging_hook_ = std::move(other.subscription_fail_staging_hook_);
+  subscription_close_admission_hook_ = std::move(other.subscription_close_admission_hook_);
   transport_ = std::move(other.transport_);
   config_ = std::move(other.config_);
   return *this;
@@ -364,7 +396,8 @@ Result<ParamSubscription> ParamStore::Subscribe(std::string_view scope, std::str
   const std::string selector = config_.prefix + "/" + ScopePath(parsed_scope.Value()) + "/**";
   auto state = std::make_shared<SubscriptionState>(
       transport_, declaration_control_, config_.prefix, parsed_scope.Value(), std::string(prefix),
-      std::move(callback), config_.log_sink, subscription_native_entry_hook_);
+      std::move(callback), config_.log_sink, subscription_native_entry_hook_,
+      subscription_fail_staging_hook_, subscription_close_admission_hook_);
 
   std::optional<Result<Subscription>> declared;
   {

--- a/src/param_subscription.cpp
+++ b/src/param_subscription.cpp
@@ -9,6 +9,7 @@
 #include <condition_variable>
 #include <deque>
 #include <exception>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -18,8 +19,21 @@
 
 namespace sitos {
 
+namespace {
+
+struct SubscriptionTestHooks {
+  std::function<void()> native_entry;
+  std::function<void()> decode;
+  std::function<void()> fail_staging;
+  std::function<void()> close_admission;
+  std::function<void()> close_reset;
+};
+
+}  // namespace
+
 struct ParamStore::DeclarationControl {
   std::mutex mutex;
+  std::shared_ptr<const SubscriptionTestHooks> hooks;
 };
 
 namespace {
@@ -45,11 +59,7 @@ struct SubscriptionState : std::enable_shared_from_this<SubscriptionState> {
                     std::shared_ptr<ParamStore::DeclarationControl> control_value,
                     std::string prefix_value, Scope scope_value, std::string list_prefix_value,
                     ParamCallback callback_value, std::shared_ptr<LogSink> log_sink_value,
-                    std::function<void()> native_entry_hook_value,
-                    std::function<void()> decode_hook_value,
-                    std::function<void()> fail_staging_hook_value,
-                    std::function<void()> close_admission_hook_value,
-                    std::function<void()> close_reset_hook_value)
+                    std::shared_ptr<const SubscriptionTestHooks> hooks_value)
       : transport(std::move(transport_value)),
         control(std::move(control_value)),
         prefix(std::move(prefix_value)),
@@ -57,11 +67,7 @@ struct SubscriptionState : std::enable_shared_from_this<SubscriptionState> {
         list_prefix(std::move(list_prefix_value)),
         callback(std::move(callback_value)),
         log_sink(std::move(log_sink_value)),
-        native_entry_hook(std::move(native_entry_hook_value)),
-        decode_hook(std::move(decode_hook_value)),
-        fail_staging_hook(std::move(fail_staging_hook_value)),
-        close_admission_hook(std::move(close_admission_hook_value)),
-        close_reset_hook(std::move(close_reset_hook_value)) {}
+        hooks(std::move(hooks_value)) {}
 
   std::shared_ptr<Transport> transport;
   std::shared_ptr<ParamStore::DeclarationControl> control;
@@ -70,11 +76,7 @@ struct SubscriptionState : std::enable_shared_from_this<SubscriptionState> {
   std::string list_prefix;
   ParamCallback callback;
   std::shared_ptr<LogSink> log_sink;
-  std::function<void()> native_entry_hook;
-  std::function<void()> decode_hook;
-  std::function<void()> fail_staging_hook;
-  std::function<void()> close_admission_hook;
-  std::function<void()> close_reset_hook;
+  std::shared_ptr<const SubscriptionTestHooks> hooks;
   Subscription native;
 
   std::mutex mutex;
@@ -106,6 +108,33 @@ void Warn(const std::shared_ptr<SubscriptionState>& state, std::string_view mess
 
 void Error(const std::shared_ptr<SubscriptionState>& state, std::string_view message) {
   EmitLog(state->log_sink, LogLevel::kError, "ParamSubscription", message);
+}
+
+template <typename ErrorHandler>
+bool InvokeTestHook(const std::shared_ptr<const SubscriptionTestHooks>& hooks,
+                    std::function<void()> SubscriptionTestHooks::*member,
+                    ErrorHandler&& on_error) noexcept {
+  if (!hooks || !(hooks.get()->*member)) return true;
+  try {
+    (hooks.get()->*member)();
+    return true;
+  } catch (const std::exception& exception) {
+    try {
+      on_error(exception.what());
+    } catch (...) {
+    }
+  } catch (...) {
+    try {
+      on_error("ParamSubscription internal test hook failed");
+    } catch (...) {
+    }
+  }
+  return false;
+}
+
+bool InvokeTestHook(const std::shared_ptr<const SubscriptionTestHooks>& hooks,
+                    std::function<void()> SubscriptionTestHooks::*member) noexcept {
+  return InvokeTestHook(hooks, member, [](std::string_view) {});
 }
 
 std::vector<ParamChange> DecodeDelete(const std::shared_ptr<SubscriptionState>& state,
@@ -208,7 +237,10 @@ void Deliver(const std::shared_ptr<SubscriptionState>& state,
 
   std::optional<std::vector<ParamChange>> changes;
   try {
-    if (state->decode_hook) state->decode_hook();
+    if (!InvokeTestHook(state->hooks, &SubscriptionTestHooks::decode,
+                        [&state](std::string_view message) { Error(state, message); })) {
+      return;
+    }
     changes = Decode(state, item->sample);
   } catch (const std::exception& exception) {
     Error(state, exception.what());
@@ -275,7 +307,7 @@ void OnSample(const std::shared_ptr<SubscriptionState>& state, const TransportSa
     std::shared_ptr<SubscriptionState> state;
   };
   NativeGuard guard(state);
-  if (state->native_entry_hook) state->native_entry_hook();
+  InvokeTestHook(state->hooks, &SubscriptionTestHooks::native_entry);
 
   std::vector<std::byte> payload(sample.payload.begin(), sample.payload.end());
   OwnedSample owned{sample.key, std::move(payload), sample.encoding, sample.kind};
@@ -319,12 +351,9 @@ void ActivateAndDrain(const std::shared_ptr<SubscriptionState>& state) {
 void FailStaging(const std::shared_ptr<SubscriptionState>& state) {
   std::unique_lock<std::mutex> lock(state->mutex);
   state->accepting = false;
-  if (state->fail_staging_hook) {
-    auto hook = state->fail_staging_hook;
-    lock.unlock();
-    hook();
-    lock.lock();
-  }
+  lock.unlock();
+  InvokeTestHook(state->hooks, &SubscriptionTestHooks::fail_staging);
+  lock.lock();
   state->condition.wait(lock, [&state] { return state->native_in_flight == 0; });
   state->queue.clear();
   state->staging = false;
@@ -343,11 +372,11 @@ void CloseState(const std::shared_ptr<SubscriptionState>& state) noexcept {
     state->accepting = false;
     state->staging = false;
   }
-  if (state->close_admission_hook) state->close_admission_hook();
+  InvokeTestHook(state->hooks, &SubscriptionTestHooks::close_admission);
 
   {
     std::lock_guard<std::mutex> declaration_lock(state->control->mutex);
-    if (state->close_reset_hook) state->close_reset_hook();
+    InvokeTestHook(state->hooks, &SubscriptionTestHooks::close_reset);
     state->native = Subscription{};
   }
 
@@ -361,11 +390,7 @@ void CloseState(const std::shared_ptr<SubscriptionState>& state) noexcept {
   state->list_prefix.clear();
   state->callback = {};
   state->log_sink.reset();
-  state->native_entry_hook = {};
-  state->decode_hook = {};
-  state->fail_staging_hook = {};
-  state->close_admission_hook = {};
-  state->close_reset_hook = {};
+  state->hooks.reset();
   state->close_finished = true;
   lock.unlock();
   state->condition.notify_all();
@@ -380,21 +405,44 @@ struct ParamSubscription::Impl {
 
 namespace param_store_test_access {
 
+template <typename Update>
+void UpdateSubscriptionTestHooks(std::shared_ptr<ParamStore::DeclarationControl> control,
+                                Update&& update) {
+  std::lock_guard<std::mutex> lock(control->mutex);
+  auto hooks = control->hooks;
+  auto updated = hooks ? std::make_shared<SubscriptionTestHooks>(*hooks)
+                       : std::make_shared<SubscriptionTestHooks>();
+  update(*updated);
+  control->hooks = std::move(updated);
+}
+
 void ParamStoreTestAccess::SetNativeEntryHook(ParamStore& store, std::function<void()> hook) {
-  store.subscription_native_entry_hook_ = std::move(hook);
+  UpdateSubscriptionTestHooks(
+      store.declaration_control_, [hook = std::move(hook)](SubscriptionTestHooks& hooks) mutable {
+        hooks.native_entry = std::move(hook);
+      });
 }
 
 void ParamStoreTestAccess::SetDecodeHook(ParamStore& store, std::function<void()> hook) {
-  store.subscription_decode_hook_ = std::move(hook);
+  UpdateSubscriptionTestHooks(
+      store.declaration_control_, [hook = std::move(hook)](SubscriptionTestHooks& hooks) mutable {
+        hooks.decode = std::move(hook);
+      });
 }
 
 void ParamStoreTestAccess::SetLifecycleHooks(ParamStore& store,
                                              std::function<void()> fail_staging_hook,
                                              std::function<void()> close_admission_hook,
                                              std::function<void()> close_reset_hook) {
-  store.subscription_fail_staging_hook_ = std::move(fail_staging_hook);
-  store.subscription_close_admission_hook_ = std::move(close_admission_hook);
-  store.subscription_close_reset_hook_ = std::move(close_reset_hook);
+  UpdateSubscriptionTestHooks(
+      store.declaration_control_, [fail_staging_hook = std::move(fail_staging_hook),
+              close_admission_hook = std::move(close_admission_hook),
+              close_reset_hook = std::move(close_reset_hook)](
+                 SubscriptionTestHooks& hooks) mutable {
+        hooks.fail_staging = std::move(fail_staging_hook);
+        hooks.close_admission = std::move(close_admission_hook);
+        hooks.close_reset = std::move(close_reset_hook);
+      });
 }
 
 }  // namespace param_store_test_access
@@ -421,29 +469,6 @@ ParamStore::ParamStore(std::shared_ptr<Transport> transport, ClientConfig config
       transport_(std::move(transport)),
       config_(std::move(config)) {}
 
-ParamStore::ParamStore(ParamStore&& other) noexcept
-    : declaration_control_(std::move(other.declaration_control_)),
-      subscription_native_entry_hook_(std::move(other.subscription_native_entry_hook_)),
-      subscription_decode_hook_(std::move(other.subscription_decode_hook_)),
-      subscription_fail_staging_hook_(std::move(other.subscription_fail_staging_hook_)),
-      subscription_close_admission_hook_(std::move(other.subscription_close_admission_hook_)),
-      subscription_close_reset_hook_(std::move(other.subscription_close_reset_hook_)),
-      transport_(std::move(other.transport_)),
-      config_(std::move(other.config_)) {}
-
-ParamStore& ParamStore::operator=(ParamStore&& other) noexcept {
-  if (this == &other) return *this;
-  declaration_control_ = std::move(other.declaration_control_);
-  subscription_native_entry_hook_ = std::move(other.subscription_native_entry_hook_);
-  subscription_decode_hook_ = std::move(other.subscription_decode_hook_);
-  subscription_fail_staging_hook_ = std::move(other.subscription_fail_staging_hook_);
-  subscription_close_admission_hook_ = std::move(other.subscription_close_admission_hook_);
-  subscription_close_reset_hook_ = std::move(other.subscription_close_reset_hook_);
-  transport_ = std::move(other.transport_);
-  config_ = std::move(other.config_);
-  return *this;
-}
-
 Result<ParamSubscription> ParamStore::Subscribe(std::string_view scope, std::string_view prefix,
                                                 ParamCallback callback) {
   if (!transport_) return Result<ParamSubscription>::Err(Status::InvalidArgument,
@@ -460,16 +485,14 @@ Result<ParamSubscription> ParamStore::Subscribe(std::string_view scope, std::str
   }
 
   const std::string selector = config_.prefix + "/" + ScopePath(parsed_scope.Value()) + "/**";
-  auto state = std::make_shared<SubscriptionState>(
-      transport_, declaration_control_, config_.prefix, parsed_scope.Value(), std::string(prefix),
-      std::move(callback), config_.log_sink, subscription_native_entry_hook_,
-      subscription_decode_hook_, subscription_fail_staging_hook_,
-      subscription_close_admission_hook_,
-      subscription_close_reset_hook_);
-
+  std::shared_ptr<SubscriptionState> state;
   std::optional<Result<Subscription>> declared;
   {
     std::lock_guard<std::mutex> declaration_lock(declaration_control_->mutex);
+    state = std::make_shared<SubscriptionState>(
+        transport_, declaration_control_, config_.prefix, parsed_scope.Value(),
+        std::string(prefix), std::move(callback), config_.log_sink,
+        declaration_control_->hooks);
     std::weak_ptr<SubscriptionState> weak_state = state;
     declared.emplace(transport_->DeclareSubscriber(
         selector, [weak_state](const TransportSample& sample) {

--- a/src/param_subscription.cpp
+++ b/src/param_subscription.cpp
@@ -4,6 +4,7 @@
 #include "sitos/param_store.hpp"
 
 #include "list_prefix_validation.hpp"
+#include "param_store_test_access.hpp"
 
 #include <condition_variable>
 #include <deque>
@@ -43,14 +44,16 @@ struct SubscriptionState : std::enable_shared_from_this<SubscriptionState> {
   SubscriptionState(std::shared_ptr<Transport> transport_value,
                     std::shared_ptr<ParamStore::DeclarationControl> control_value,
                     std::string prefix_value, Scope scope_value, std::string list_prefix_value,
-                    ParamCallback callback_value, std::shared_ptr<LogSink> log_sink_value)
+                    ParamCallback callback_value, std::shared_ptr<LogSink> log_sink_value,
+                    std::function<void()> native_entry_hook_value)
       : transport(std::move(transport_value)),
         control(std::move(control_value)),
         prefix(std::move(prefix_value)),
         scope(std::move(scope_value)),
         list_prefix(std::move(list_prefix_value)),
         callback(std::move(callback_value)),
-        log_sink(std::move(log_sink_value)) {}
+        log_sink(std::move(log_sink_value)),
+        native_entry_hook(std::move(native_entry_hook_value)) {}
 
   std::shared_ptr<Transport> transport;
   std::shared_ptr<ParamStore::DeclarationControl> control;
@@ -59,6 +62,7 @@ struct SubscriptionState : std::enable_shared_from_this<SubscriptionState> {
   std::string list_prefix;
   ParamCallback callback;
   std::shared_ptr<LogSink> log_sink;
+  std::function<void()> native_entry_hook;
   Subscription native;
 
   std::mutex mutex;
@@ -213,6 +217,7 @@ void OnSample(const std::shared_ptr<SubscriptionState>& state, const TransportSa
     std::shared_ptr<SubscriptionState> state;
     ~NativeGuard() { CompleteNative(state); }
   } guard{state};
+  if (state->native_entry_hook) state->native_entry_hook();
 
   std::vector<std::byte> payload(sample.payload.begin(), sample.payload.end());
   OwnedSample owned{sample.key, std::move(payload), sample.encoding, sample.kind};
@@ -255,9 +260,10 @@ void ActivateAndDrain(const std::shared_ptr<SubscriptionState>& state) {
 }
 
 void FailStaging(const std::shared_ptr<SubscriptionState>& state) {
-  std::lock_guard<std::mutex> lock(state->mutex);
+  std::unique_lock<std::mutex> lock(state->mutex);
   state->accepting = false;
   state->staging = false;
+  state->condition.wait(lock, [&] { return state->native_in_flight == 0; });
   state->queue.clear();
   state->condition.notify_all();
 }
@@ -296,6 +302,14 @@ struct ParamSubscription::Impl {
   std::shared_ptr<SubscriptionState> state;
 };
 
+namespace param_store_test_access {
+
+void ParamStoreTestAccess::SetNativeEntryHook(ParamStore& store, std::function<void()> hook) {
+  store.subscription_native_entry_hook_ = std::move(hook);
+}
+
+}  // namespace param_store_test_access
+
 ParamSubscription::ParamSubscription(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {}
 
 ParamSubscription::ParamSubscription(ParamSubscription&& other) noexcept = default;
@@ -320,12 +334,14 @@ ParamStore::ParamStore(std::shared_ptr<Transport> transport, ClientConfig config
 
 ParamStore::ParamStore(ParamStore&& other) noexcept
     : declaration_control_(std::move(other.declaration_control_)),
+      subscription_native_entry_hook_(std::move(other.subscription_native_entry_hook_)),
       transport_(std::move(other.transport_)),
       config_(std::move(other.config_)) {}
 
 ParamStore& ParamStore::operator=(ParamStore&& other) noexcept {
   if (this == &other) return *this;
   declaration_control_ = std::move(other.declaration_control_);
+  subscription_native_entry_hook_ = std::move(other.subscription_native_entry_hook_);
   transport_ = std::move(other.transport_);
   config_ = std::move(other.config_);
   return *this;
@@ -348,7 +364,7 @@ Result<ParamSubscription> ParamStore::Subscribe(std::string_view scope, std::str
   const std::string selector = config_.prefix + "/" + ScopePath(parsed_scope.Value()) + "/**";
   auto state = std::make_shared<SubscriptionState>(
       transport_, declaration_control_, config_.prefix, parsed_scope.Value(), std::string(prefix),
-      std::move(callback), config_.log_sink);
+      std::move(callback), config_.log_sink, subscription_native_entry_hook_);
 
   std::optional<Result<Subscription>> declared;
   {

--- a/src/param_subscription.cpp
+++ b/src/param_subscription.cpp
@@ -106,35 +106,33 @@ void Warn(const std::shared_ptr<SubscriptionState>& state, std::string_view mess
   EmitLog(state->log_sink, LogLevel::kWarning, "ParamSubscription", message);
 }
 
-void Error(const std::shared_ptr<SubscriptionState>& state, std::string_view message) {
+void Error(const std::shared_ptr<SubscriptionState>& state, std::string_view message) noexcept {
   EmitLog(state->log_sink, LogLevel::kError, "ParamSubscription", message);
 }
 
-template <typename ErrorHandler>
-bool InvokeTestHook(const std::shared_ptr<const SubscriptionTestHooks>& hooks,
-                    std::function<void()> SubscriptionTestHooks::*member,
-                    ErrorHandler&& on_error) noexcept {
+bool InvokeSilentTestHook(const std::shared_ptr<const SubscriptionTestHooks>& hooks,
+                          std::function<void()> SubscriptionTestHooks::*member) noexcept {
   if (!hooks || !(hooks.get()->*member)) return true;
   try {
     (hooks.get()->*member)();
     return true;
-  } catch (const std::exception& exception) {
-    try {
-      on_error(exception.what());
-    } catch (...) {
-    }
   } catch (...) {
-    try {
-      on_error("ParamSubscription internal test hook failed");
-    } catch (...) {
-    }
+    return false;
   }
-  return false;
 }
 
-bool InvokeTestHook(const std::shared_ptr<const SubscriptionTestHooks>& hooks,
-                    std::function<void()> SubscriptionTestHooks::*member) noexcept {
-  return InvokeTestHook(hooks, member, [](std::string_view) {});
+bool InvokeDecodeTestHook(const std::shared_ptr<SubscriptionState>& state) noexcept {
+  const auto& hooks = state->hooks;
+  if (!hooks || !hooks->decode) return true;
+  try {
+    hooks->decode();
+    return true;
+  } catch (const std::exception& exception) {
+    Error(state, exception.what());
+  } catch (...) {
+    Error(state, "ParamSubscription internal test hook failed");
+  }
+  return false;
 }
 
 std::vector<ParamChange> DecodeDelete(const std::shared_ptr<SubscriptionState>& state,
@@ -237,10 +235,7 @@ void Deliver(const std::shared_ptr<SubscriptionState>& state,
 
   std::optional<std::vector<ParamChange>> changes;
   try {
-    if (!InvokeTestHook(state->hooks, &SubscriptionTestHooks::decode,
-                        [&state](std::string_view message) { Error(state, message); })) {
-      return;
-    }
+    if (!InvokeDecodeTestHook(state)) return;
     changes = Decode(state, item->sample);
   } catch (const std::exception& exception) {
     Error(state, exception.what());
@@ -307,7 +302,7 @@ void OnSample(const std::shared_ptr<SubscriptionState>& state, const TransportSa
     std::shared_ptr<SubscriptionState> state;
   };
   NativeGuard guard(state);
-  InvokeTestHook(state->hooks, &SubscriptionTestHooks::native_entry);
+  InvokeSilentTestHook(state->hooks, &SubscriptionTestHooks::native_entry);
 
   std::vector<std::byte> payload(sample.payload.begin(), sample.payload.end());
   OwnedSample owned{sample.key, std::move(payload), sample.encoding, sample.kind};
@@ -352,7 +347,7 @@ void FailStaging(const std::shared_ptr<SubscriptionState>& state) {
   std::unique_lock<std::mutex> lock(state->mutex);
   state->accepting = false;
   lock.unlock();
-  InvokeTestHook(state->hooks, &SubscriptionTestHooks::fail_staging);
+  InvokeSilentTestHook(state->hooks, &SubscriptionTestHooks::fail_staging);
   lock.lock();
   state->condition.wait(lock, [&state] { return state->native_in_flight == 0; });
   state->queue.clear();
@@ -372,11 +367,11 @@ void CloseState(const std::shared_ptr<SubscriptionState>& state) noexcept {
     state->accepting = false;
     state->staging = false;
   }
-  InvokeTestHook(state->hooks, &SubscriptionTestHooks::close_admission);
+  InvokeSilentTestHook(state->hooks, &SubscriptionTestHooks::close_admission);
 
   {
     std::lock_guard<std::mutex> declaration_lock(state->control->mutex);
-    InvokeTestHook(state->hooks, &SubscriptionTestHooks::close_reset);
+    InvokeSilentTestHook(state->hooks, &SubscriptionTestHooks::close_reset);
     state->native = Subscription{};
   }
 

--- a/src/transport/zenoh_transport.cpp
+++ b/src/transport/zenoh_transport.cpp
@@ -523,6 +523,7 @@ void DropSubscriberContext(void* context) noexcept {
 struct Subscription::Impl {
   z_owned_subscriber_t subscriber{};
   std::shared_ptr<SubscriberState> callback_state;
+  std::function<void()> reset_observer;
 };
 
 namespace {
@@ -576,6 +577,14 @@ void Subscription::Reset() noexcept {
     if (impl_->callback_state) {
       impl_->callback_state->active.store(false, std::memory_order_release);
     }
+    if (impl_->reset_observer) {
+      auto observer = std::move(impl_->reset_observer);
+      try {
+        observer();
+      } catch (...) {
+        // Keep the internal test observer contained at this noexcept boundary.
+      }
+    }
     z_drop(z_move(impl_->subscriber));
     impl_.reset();
   }
@@ -614,6 +623,13 @@ Subscription SubscriptionTestAccess::Make(std::string_view keyexpr,
 
   subscription.impl_ = std::move(impl);
   return subscription;
+}
+
+bool SubscriptionTestAccess::SetResetObserver(Subscription& subscription,
+                                                   std::function<void()> observer) {
+  if (!subscription.impl_) return false;
+  subscription.impl_->reset_observer = std::move(observer);
+  return true;
 }
 
 bool SubscriptionTestAccess::Publish(std::string_view keyexpr) {

--- a/src/transport/zenoh_transport_test_access.hpp
+++ b/src/transport/zenoh_transport_test_access.hpp
@@ -42,6 +42,7 @@ class SubscriptionTestAccess {
   static bool IsAvailable();
   static void Shutdown();
   static Subscription Make(std::string_view keyexpr, std::function<void()> callback);
+  static bool SetResetObserver(Subscription& subscription, std::function<void()> observer);
   static bool Publish(std::string_view keyexpr);
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -107,6 +107,7 @@ gtest_add_tests(TARGET sitos_param_store_test SOURCES unit/param_store_test.cpp)
 
 add_executable(sitos_param_store_subscribe_test unit/param_store_subscribe_test.cpp)
 target_link_libraries(sitos_param_store_subscribe_test PRIVATE GTest::gtest_main sitos::sitos)
+target_include_directories(sitos_param_store_subscribe_test PRIVATE ${PROJECT_SOURCE_DIR}/src)
 sitos_enable_warnings(sitos_param_store_subscribe_test)
 gtest_add_tests(
   TARGET sitos_param_store_subscribe_test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -269,6 +269,16 @@ if(SITOS_WITH_ZENOH)
     TARGET sitos_param_store_integration_test
     SOURCES integration/param_store_test.cpp)
 
+  add_executable(sitos_param_store_subscribe_integration_test
+    integration/param_store_subscribe_test.cpp)
+  target_link_libraries(sitos_param_store_subscribe_integration_test
+    PRIVATE GTest::gtest_main sitos::sitos)
+  sitos_enable_warnings(sitos_param_store_subscribe_integration_test)
+  sitos_copy_zenohc(sitos_param_store_subscribe_integration_test)
+  gtest_add_tests(
+    TARGET sitos_param_store_subscribe_integration_test
+    SOURCES integration/param_store_subscribe_test.cpp)
+
   add_executable(sitos_session_view_integration_test
     integration/session_view_test.cpp)
   target_link_libraries(sitos_session_view_integration_test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -102,6 +102,13 @@ if(SITOS_WITH_ZENOH)
 endif()
 gtest_add_tests(TARGET sitos_param_store_test SOURCES unit/param_store_test.cpp)
 
+add_executable(sitos_param_store_subscribe_test unit/param_store_subscribe_test.cpp)
+target_link_libraries(sitos_param_store_subscribe_test PRIVATE GTest::gtest_main sitos::sitos)
+sitos_enable_warnings(sitos_param_store_subscribe_test)
+gtest_add_tests(
+  TARGET sitos_param_store_subscribe_test
+  SOURCES unit/param_store_subscribe_test.cpp)
+
 add_executable(sitos_client_transport_factory_test unit/client_transport_factory_test.cpp)
 target_link_libraries(sitos_client_transport_factory_test PRIVATE GTest::gtest_main sitos::sitos)
 if(SITOS_WITH_ZENOH)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,12 +38,15 @@ add_sitos_public_header_compile_test(
 add_sitos_public_header_compile_test(
   sitos_list_sink_header_compile_test consumer/list_sink_header_compile.cpp)
 add_sitos_public_header_compile_test(
+  sitos_param_subscription_header_compile_test consumer/param_subscription_header_compile.cpp)
+add_sitos_public_header_compile_test(
   sitos_session_view_header_compile_test consumer/session_view_header_compile.cpp)
 if(SITOS_WITH_ZENOH)
   sitos_copy_zenohc(sitos_param_store_header_compile_test)
   sitos_copy_zenohc(sitos_param_cache_header_compile_test)
   sitos_copy_zenohc(sitos_param_concepts_header_compile_test)
   sitos_copy_zenohc(sitos_list_sink_header_compile_test)
+  sitos_copy_zenohc(sitos_param_subscription_header_compile_test)
   sitos_copy_zenohc(sitos_session_view_header_compile_test)
 endif()
 

--- a/tests/consumer/param_subscription_header_compile.cpp
+++ b/tests/consumer/param_subscription_header_compile.cpp
@@ -1,0 +1,13 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/param_subscription.hpp"
+
+#include <type_traits>
+
+int main() {
+  static_assert(!std::is_default_constructible_v<sitos::ParamSubscription>);
+  static_assert(!std::is_copy_constructible_v<sitos::ParamSubscription>);
+  static_assert(std::is_move_constructible_v<sitos::ParamSubscription>);
+  return 0;
+}

--- a/tests/consumer/param_subscription_header_compile.cpp
+++ b/tests/consumer/param_subscription_header_compile.cpp
@@ -8,6 +8,8 @@
 int main() {
   static_assert(!std::is_default_constructible_v<sitos::ParamSubscription>);
   static_assert(!std::is_copy_constructible_v<sitos::ParamSubscription>);
+  static_assert(!std::is_copy_assignable_v<sitos::ParamSubscription>);
   static_assert(std::is_move_constructible_v<sitos::ParamSubscription>);
+  static_assert(std::is_move_assignable_v<sitos::ParamSubscription>);
   return 0;
 }

--- a/tests/integration/param_store_subscribe_test.cpp
+++ b/tests/integration/param_store_subscribe_test.cpp
@@ -1,0 +1,133 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/param_store.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace {
+
+class ParamStoreSubscribeIntegrationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto transport_result = sitos::OpenZenohTransport();
+    ASSERT_TRUE(transport_result.IsOk());
+    transport_ = std::shared_ptr<sitos::Transport>(std::move(transport_result).Value());
+    config_.prefix = "sitos/param_subscribe_integration";
+    auto store_result = sitos::ParamStore::Open(transport_, config_);
+    ASSERT_TRUE(store_result.IsOk());
+    store_ = std::move(store_result).Value();
+  }
+
+  void TearDown() override {
+    control_ = sitos::Subscription{};
+    store_.reset();
+    transport_.reset();
+  }
+
+  std::shared_ptr<sitos::Transport> transport_;
+  sitos::ClientConfig config_;
+  std::optional<sitos::ParamStore> store_;
+  sitos::Subscription control_;
+};
+
+TEST_F(ParamStoreSubscribeIntegrationTest, ReceivesPutDeleteAndStopsAfterClose) {
+  std::mutex mutex;
+  std::condition_variable condition;
+  int control_count = 0;
+  int callback_count = 0;
+  std::vector<sitos::ParamChange> changes;
+  auto control_result = transport_->DeclareSubscriber(
+      config_.prefix + "/base/**", [&](const sitos::TransportSample&) {
+        {
+          std::lock_guard<std::mutex> lock(mutex);
+          ++control_count;
+        }
+        condition.notify_all();
+      });
+  ASSERT_TRUE(control_result.IsOk());
+  control_ = std::move(control_result).Value();
+
+  auto subscription = store_->Subscribe("base", "", [&](const sitos::ParamChange& change) {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      ++callback_count;
+      changes.push_back(change);
+    }
+    condition.notify_all();
+  });
+  ASSERT_TRUE(subscription.IsOk());
+
+  const auto key = sitos::BuildKey(config_.prefix, "base", "value");
+  ASSERT_TRUE(key.has_value());
+  const auto payload = sitos::ParamValue(true).Encode();
+  ASSERT_TRUE(transport_->Put(*key, payload,
+                              sitos::Encoding{std::string(sitos::Encoding::kSitosV1)}, {})
+                  .IsOk());
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(5),
+                                   [&] { return control_count >= 1 && callback_count >= 1; }));
+  }
+  ASSERT_EQ(changes.size(), 1U);
+  EXPECT_EQ(changes.front().kind, sitos::ParamChangeKind::kPut);
+  EXPECT_EQ(changes.front().key, "value");
+
+  const int callback_baseline = callback_count;
+  const int control_baseline = control_count;
+  subscription.Value().Close();
+  ASSERT_TRUE(transport_->Delete(*key, {}).IsOk());
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(5),
+                                   [&] { return control_count > control_baseline; }));
+  }
+  EXPECT_EQ(callback_count, callback_baseline);
+}
+
+TEST_F(ParamStoreSubscribeIntegrationTest, ExpandsCanonicalBatchInOrder) {
+  std::mutex mutex;
+  std::condition_variable condition;
+  std::vector<sitos::ParamChange> changes;
+  auto subscription = store_->Subscribe("base", "", [&](const sitos::ParamChange& change) {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      changes.push_back(change);
+    }
+    condition.notify_all();
+  });
+  ASSERT_TRUE(subscription.IsOk());
+
+  std::vector<sitos::BatchEntry> entries{
+      {"one", sitos::ParamValue(std::int64_t{1})},
+      {"two", sitos::ParamValue(std::int64_t{2})},
+      {"one", sitos::ParamValue(std::int64_t{3})}};
+  const auto key = sitos::BuildBatchKey(config_.prefix, "base");
+  ASSERT_TRUE(key.has_value());
+  const auto payload = sitos::EncodeBatch(entries);
+  ASSERT_TRUE(transport_->Put(*key, payload,
+                              sitos::Encoding{std::string(sitos::Encoding::kSitosV1Batch)}, {})
+                  .IsOk());
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(5),
+                                   [&] { return changes.size() >= entries.size(); }));
+  }
+  ASSERT_EQ(changes.size(), entries.size());
+  EXPECT_EQ(changes[0].key, "one");
+  EXPECT_EQ(changes[1].key, "two");
+  EXPECT_EQ(changes[2].key, "one");
+}
+
+}  // namespace

--- a/tests/integration/param_store_subscribe_test.cpp
+++ b/tests/integration/param_store_subscribe_test.cpp
@@ -105,12 +105,10 @@ TEST_F(ParamStoreSubscribeIntegrationTest, ReceivesPutUnknownBytesDeleteAndStops
 
   std::vector<sitos::ParamChange> observed;
   int callback_baseline = 0;
-  int control_baseline = 0;
   {
     std::lock_guard<std::mutex> lock(mutex);
     observed = changes;
     callback_baseline = callback_count;
-    control_baseline = control_count;
   }
   ASSERT_EQ(observed.size(), 3U);
   EXPECT_EQ(observed[0].kind, sitos::ParamChangeKind::kPut);

--- a/tests/integration/param_store_subscribe_test.cpp
+++ b/tests/integration/param_store_subscribe_test.cpp
@@ -42,7 +42,7 @@ class ParamStoreSubscribeIntegrationTest : public ::testing::Test {
   sitos::Subscription control_;
 };
 
-TEST_F(ParamStoreSubscribeIntegrationTest, ReceivesPutDeleteAndStopsAfterClose) {
+TEST_F(ParamStoreSubscribeIntegrationTest, ReceivesPutUnknownBytesDeleteAndStopsAfterClose) {
   std::mutex mutex;
   std::condition_variable condition;
   int control_count = 0;
@@ -69,10 +69,12 @@ TEST_F(ParamStoreSubscribeIntegrationTest, ReceivesPutDeleteAndStopsAfterClose) 
   });
   ASSERT_TRUE(subscription.IsOk());
 
-  const auto key = sitos::BuildKey(config_.prefix, "base", "value");
-  ASSERT_TRUE(key.has_value());
+  const auto value_key = sitos::BuildKey(config_.prefix, "base", "value");
+  const auto opaque_key = sitos::BuildKey(config_.prefix, "base", "opaque");
+  ASSERT_TRUE(value_key.has_value());
+  ASSERT_TRUE(opaque_key.has_value());
   const auto payload = sitos::ParamValue(true).Encode();
-  ASSERT_TRUE(transport_->Put(*key, payload,
+  ASSERT_TRUE(transport_->Put(*value_key, payload,
                               sitos::Encoding{std::string(sitos::Encoding::kSitosV1)}, {})
                   .IsOk());
   {
@@ -80,20 +82,57 @@ TEST_F(ParamStoreSubscribeIntegrationTest, ReceivesPutDeleteAndStopsAfterClose) 
     ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(5),
                                    [&] { return control_count >= 1 && callback_count >= 1; }));
   }
-  ASSERT_EQ(changes.size(), 1U);
-  EXPECT_EQ(changes.front().kind, sitos::ParamChangeKind::kPut);
-  EXPECT_EQ(changes.front().key, "value");
 
-  const int callback_baseline = callback_count;
-  const int control_baseline = control_count;
+  const std::vector<std::byte> opaque_payload{std::byte{0x11}, std::byte{0x22}, std::byte{0x33}};
+  ASSERT_TRUE(transport_->Put(*opaque_key, opaque_payload,
+                              sitos::Encoding{"application/octet-stream"}, {})
+                  .IsOk());
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(5),
+                                   [&] { return control_count >= 2 && callback_count >= 2; }));
+  }
+
+  ASSERT_TRUE(transport_->Delete(*value_key, {}).IsOk());
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(5),
+                                   [&] { return control_count >= 3 && callback_count >= 3; }));
+  }
+
+  std::vector<sitos::ParamChange> observed;
+  int callback_baseline = 0;
+  int control_baseline = 0;
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    observed = changes;
+    callback_baseline = callback_count;
+    control_baseline = control_count;
+  }
+  ASSERT_EQ(observed.size(), 3U);
+  EXPECT_EQ(observed[0].kind, sitos::ParamChangeKind::kPut);
+  EXPECT_EQ(observed[0].key, "value");
+  EXPECT_EQ(observed[1].key, "opaque");
+  ASSERT_TRUE(observed[1].value.has_value());
+  const auto opaque_value = observed[1].value->As<std::vector<std::byte>>();
+  ASSERT_TRUE(opaque_value.has_value());
+  EXPECT_EQ(*opaque_value, opaque_payload);
+  EXPECT_EQ(observed[2].kind, sitos::ParamChangeKind::kDelete);
+  EXPECT_EQ(observed[2].key, "value");
+  EXPECT_FALSE(observed[2].value.has_value());
+
   subscription.Value().Close();
-  ASSERT_TRUE(transport_->Delete(*key, {}).IsOk());
+  const auto post_close_key = sitos::BuildKey(config_.prefix, "base", "post-close");
+  ASSERT_TRUE(post_close_key.has_value());
+  ASSERT_TRUE(transport_->Put(*post_close_key, payload,
+                              sitos::Encoding{std::string(sitos::Encoding::kSitosV1)}, {})
+                  .IsOk());
   {
     std::unique_lock<std::mutex> lock(mutex);
     ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(5),
                                    [&] { return control_count > control_baseline; }));
+    EXPECT_EQ(callback_count, callback_baseline);
   }
-  EXPECT_EQ(callback_count, callback_baseline);
 }
 
 TEST_F(ParamStoreSubscribeIntegrationTest, ExpandsCanonicalBatchInOrder) {
@@ -124,10 +163,15 @@ TEST_F(ParamStoreSubscribeIntegrationTest, ExpandsCanonicalBatchInOrder) {
     ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(5),
                                    [&] { return changes.size() >= entries.size(); }));
   }
-  ASSERT_EQ(changes.size(), entries.size());
-  EXPECT_EQ(changes[0].key, "one");
-  EXPECT_EQ(changes[1].key, "two");
-  EXPECT_EQ(changes[2].key, "one");
+  std::vector<sitos::ParamChange> observed;
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    observed = changes;
+  }
+  ASSERT_EQ(observed.size(), entries.size());
+  EXPECT_EQ(observed[0].key, "one");
+  EXPECT_EQ(observed[1].key, "two");
+  EXPECT_EQ(observed[2].key, "one");
 }
 
 }  // namespace

--- a/tests/integration/param_store_subscribe_test.cpp
+++ b/tests/integration/param_store_subscribe_test.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <condition_variable>
 #include <cstddef>
@@ -47,12 +48,14 @@ TEST_F(ParamStoreSubscribeIntegrationTest, ReceivesPutUnknownBytesDeleteAndStops
   std::condition_variable condition;
   int control_count = 0;
   int callback_count = 0;
+  std::vector<std::string> control_keys;
   std::vector<sitos::ParamChange> changes;
   auto control_result = transport_->DeclareSubscriber(
-      config_.prefix + "/base/**", [&](const sitos::TransportSample&) {
+      config_.prefix + "/base/**", [&](const sitos::TransportSample& sample) {
         {
           std::lock_guard<std::mutex> lock(mutex);
           ++control_count;
+          control_keys.emplace_back(sample.key);
         }
         condition.notify_all();
       });
@@ -129,8 +132,10 @@ TEST_F(ParamStoreSubscribeIntegrationTest, ReceivesPutUnknownBytesDeleteAndStops
                   .IsOk());
   {
     std::unique_lock<std::mutex> lock(mutex);
-    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(5),
-                                   [&] { return control_count > control_baseline; }));
+    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(5), [&] {
+      return std::find(control_keys.begin(), control_keys.end(), *post_close_key) !=
+             control_keys.end();
+    }));
     EXPECT_EQ(callback_count, callback_baseline);
   }
 }

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -133,6 +133,96 @@ TEST_F(SubscriptionTest, MoveAssignmentTransfersSubscriber) {
   EXPECT_TRUE(WaitForNoNewCallback(&old_callbacks, old_baseline));
 }
 
+TEST_F(SubscriptionTest, ResetPreservesEnteredSubscriberCallbackLifetime) {
+  using sitos::transport_test_access::SubscriptionTestAccess;
+  ASSERT_TRUE(SubscriptionTestAccess::IsAvailable());
+
+  std::mutex callback_mutex;
+  std::condition_variable callback_condition;
+  bool callback_entered = false;
+  bool release_callback = false;
+  bool callback_returned = false;
+  bool publish_succeeded = false;
+  bool reset_started = false;
+  bool reset_returned = false;
+  auto subscription = SubscriptionTestAccess::Make(
+      "sitos/test/subscription/reset-quiescence", [&] {
+        {
+          std::lock_guard<std::mutex> lock(callback_mutex);
+          callback_entered = true;
+        }
+        callback_condition.notify_all();
+        std::unique_lock<std::mutex> lock(callback_mutex);
+        callback_condition.wait(lock, [&] { return release_callback; });
+        callback_returned = true;
+        lock.unlock();
+        callback_condition.notify_all();
+      });
+
+  std::thread publisher([&] {
+    const bool published =
+        SubscriptionTestAccess::Publish("sitos/test/subscription/reset-quiescence");
+    {
+      std::lock_guard<std::mutex> lock(callback_mutex);
+      publish_succeeded = published;
+    }
+    callback_condition.notify_all();
+  });
+
+  bool entered = false;
+  {
+    std::unique_lock<std::mutex> lock(callback_mutex);
+    entered = callback_condition.wait_for(lock, std::chrono::seconds(3),
+                                          [&] { return callback_entered; });
+  }
+  if (!entered) {
+    {
+      std::lock_guard<std::mutex> lock(callback_mutex);
+      release_callback = true;
+    }
+    callback_condition.notify_all();
+    publisher.join();
+    ADD_FAILURE() << "subscriber callback did not enter";
+    return;
+  }
+
+  std::thread reset_thread([&] {
+    {
+      std::lock_guard<std::mutex> lock(callback_mutex);
+      reset_started = true;
+    }
+    callback_condition.notify_all();
+    subscription = sitos::Subscription{};
+    {
+      std::lock_guard<std::mutex> lock(callback_mutex);
+      reset_returned = true;
+    }
+    callback_condition.notify_all();
+  });
+
+  bool reset_started_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(callback_mutex);
+    reset_started_in_time = callback_condition.wait_for(
+        lock, std::chrono::seconds(3), [&] { return reset_started; });
+  }
+  {
+    std::lock_guard<std::mutex> lock(callback_mutex);
+    release_callback = true;
+  }
+  callback_condition.notify_all();
+  reset_thread.join();
+  publisher.join();
+
+  EXPECT_TRUE(reset_started_in_time);
+  EXPECT_TRUE(publish_succeeded);
+  EXPECT_TRUE(reset_returned);
+  {
+    std::lock_guard<std::mutex> lock(callback_mutex);
+    EXPECT_TRUE(callback_returned);
+  }
+}
+
 TEST_F(SubscriptionTest, DestructionStopsSubscriber) {
   using sitos::transport_test_access::SubscriptionTestAccess;
   ASSERT_TRUE(SubscriptionTestAccess::IsAvailable());

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -144,6 +144,7 @@ TEST_F(SubscriptionTest, ResetPreservesEnteredSubscriberCallbackLifetime) {
   bool callback_returned = false;
   bool publish_succeeded = false;
   bool reset_started = false;
+  bool reset_boundary_observed = false;
   bool reset_returned = false;
   auto subscription = SubscriptionTestAccess::Make(
       "sitos/test/subscription/reset-quiescence", [&] {
@@ -158,6 +159,13 @@ TEST_F(SubscriptionTest, ResetPreservesEnteredSubscriberCallbackLifetime) {
         lock.unlock();
         callback_condition.notify_all();
       });
+  ASSERT_TRUE(SubscriptionTestAccess::SetResetObserver(subscription, [&] {
+    {
+      std::lock_guard<std::mutex> lock(callback_mutex);
+      reset_boundary_observed = true;
+    }
+    callback_condition.notify_all();
+  }));
 
   std::thread publisher([&] {
     const bool published =
@@ -206,6 +214,36 @@ TEST_F(SubscriptionTest, ResetPreservesEnteredSubscriberCallbackLifetime) {
     reset_started_in_time = callback_condition.wait_for(
         lock, std::chrono::seconds(3), [&] { return reset_started; });
   }
+  if (!reset_started_in_time) {
+    {
+      std::lock_guard<std::mutex> lock(callback_mutex);
+      release_callback = true;
+    }
+    callback_condition.notify_all();
+    reset_thread.join();
+    publisher.join();
+    ADD_FAILURE() << "subscription Reset thread did not start";
+    return;
+  }
+
+  bool reset_boundary_observed_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(callback_mutex);
+    reset_boundary_observed_in_time = callback_condition.wait_for(
+        lock, std::chrono::seconds(3), [&] { return reset_boundary_observed; });
+  }
+  if (!reset_boundary_observed_in_time) {
+    {
+      std::lock_guard<std::mutex> lock(callback_mutex);
+      release_callback = true;
+    }
+    callback_condition.notify_all();
+    reset_thread.join();
+    publisher.join();
+    ADD_FAILURE() << "production Reset did not reach the native drop boundary";
+    return;
+  }
+
   bool reset_returned_before_release = false;
   {
     std::lock_guard<std::mutex> lock(callback_mutex);

--- a/tests/integration/transport_test.cpp
+++ b/tests/integration/transport_test.cpp
@@ -206,10 +206,13 @@ TEST_F(SubscriptionTest, ResetPreservesEnteredSubscriberCallbackLifetime) {
     reset_started_in_time = callback_condition.wait_for(
         lock, std::chrono::seconds(3), [&] { return reset_started; });
   }
+  bool reset_returned_before_release = false;
   {
     std::lock_guard<std::mutex> lock(callback_mutex);
+    reset_returned_before_release = reset_returned;
     release_callback = true;
   }
+  EXPECT_FALSE(reset_returned_before_release);
   callback_condition.notify_all();
   reset_thread.join();
   publisher.join();

--- a/tests/unit/client_config_test.cpp
+++ b/tests/unit/client_config_test.cpp
@@ -16,6 +16,13 @@ TEST(ClientConfigTest, HasRequiredDefaults) {
   EXPECT_EQ(config.prefix, "sitos");
   EXPECT_FALSE(config.zenoh_config_json.has_value());
   EXPECT_EQ(config.query_timeout, std::chrono::milliseconds(5000));
+  EXPECT_NE(config.log_sink, nullptr);
+  EXPECT_TRUE(ValidateClientConfig(config).IsOk());
+}
+
+TEST(ClientConfigTest, NullLogSinkDisablesDiagnosticsWithoutInvalidatingConfig) {
+  ClientConfig config;
+  config.log_sink = nullptr;
   EXPECT_TRUE(ValidateClientConfig(config).IsOk());
 }
 

--- a/tests/unit/param_store_subscribe_test.cpp
+++ b/tests/unit/param_store_subscribe_test.cpp
@@ -117,6 +117,31 @@ class FakeTransport final : public sitos::Transport {
     for (const auto& callback : callbacks) callback(sample);
   }
 
+  void EmitToSelector(std::string_view fragment, const sitos::TransportSample& sample) {
+    std::function<void(const sitos::TransportSample&)> callback;
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      for (std::size_t index = 0; index < subscribers.size(); ++index) {
+        if (subscriber_selectors[index].find(fragment) != std::string::npos) {
+          callback = subscribers[index];
+          break;
+        }
+      }
+    }
+    ASSERT_TRUE(callback);
+    callback(sample);
+  }
+
+  void EmitTo(std::size_t index, const sitos::TransportSample& sample) {
+    std::function<void(const sitos::TransportSample&)> callback;
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      ASSERT_LT(index, subscribers.size());
+      callback = subscribers[index];
+    }
+    callback(sample);
+  }
+
   void EmitPut(std::string key, const sitos::ParamValue& value,
                std::string encoding = std::string(sitos::Encoding::kSitosV1)) {
     auto payload = value.Encode();
@@ -148,6 +173,7 @@ class FakeTransport final : public sitos::Transport {
     {
       std::lock_guard<std::mutex> lock(mutex);
       subscribers.push_back(callback);
+      subscriber_selectors.emplace_back(keyexpr);
       subscriber = callback;
     }
     if (sample_during_declaration.has_value()) {
@@ -176,6 +202,7 @@ class FakeTransport final : public sitos::Transport {
   int declaration_count = 0;
   std::function<void(const sitos::TransportSample&)> subscriber;
   std::vector<std::function<void(const sitos::TransportSample&)>> subscribers;
+  std::vector<std::string> subscriber_selectors;
   std::mutex mutex;
   std::optional<sitos::TransportSample> sample_during_declaration;
   std::optional<sitos::Result<sitos::Subscription>> declaration_error;
@@ -291,8 +318,15 @@ TEST(ParamStoreSubscribeTest, CloseWaitsForBlockedCallback) {
   std::condition_variable condition;
   bool entered = false;
   bool release = false;
-  bool close_started = false;
+  bool close_admission_observed = false;
   std::atomic<bool> close_returned = false;
+  sitos::param_store_test_access::ParamStoreTestAccess::SetLifecycleHooks(store, {}, [&] {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      close_admission_observed = true;
+    }
+    condition.notify_all();
+  });
   auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange&) {
     {
       std::lock_guard<std::mutex> lock(mutex);
@@ -305,26 +339,24 @@ TEST(ParamStoreSubscribeTest, CloseWaitsForBlockedCallback) {
   ASSERT_TRUE(subscription.IsOk());
 
   std::thread emitter([&] { transport->EmitPut("sitos/base/value", sitos::ParamValue(true)); });
+  bool callback_entered_in_time = false;
   {
     std::unique_lock<std::mutex> lock(mutex);
-    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(3), [&] { return entered; }));
+    callback_entered_in_time =
+        condition.wait_for(lock, std::chrono::seconds(3), [&] { return entered; });
   }
   std::thread closer([&] {
-    {
-      std::lock_guard<std::mutex> lock(mutex);
-      close_started = true;
-    }
-    condition.notify_all();
     subscription.Value().Close();
     close_returned.store(true, std::memory_order_release);
   });
-  bool closer_started_in_time = false;
+  bool close_admission_in_time = false;
   {
     std::unique_lock<std::mutex> lock(mutex);
-    closer_started_in_time = condition.wait_for(lock, std::chrono::seconds(3),
-                                                [&] { return close_started; });
+    close_admission_in_time = condition.wait_for(
+        lock, std::chrono::seconds(3), [&] { return close_admission_observed; });
   }
-  EXPECT_TRUE(closer_started_in_time);
+  EXPECT_TRUE(callback_entered_in_time);
+  EXPECT_TRUE(close_admission_in_time);
   EXPECT_FALSE(close_returned.load(std::memory_order_acquire));
   {
     std::lock_guard<std::mutex> lock(mutex);
@@ -334,6 +366,86 @@ TEST(ParamStoreSubscribeTest, CloseWaitsForBlockedCallback) {
   emitter.join();
   closer.join();
   EXPECT_TRUE(close_returned.load(std::memory_order_acquire));
+}
+
+TEST(ParamStoreSubscribeTest, CloseDeliversAdmittedSampleBeforeReturning) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool native_entered = false;
+  bool release_native = false;
+  bool close_admission = false;
+  bool callback_delivered = false;
+  bool close_returned = false;
+  sitos::param_store_test_access::ParamStoreTestAccess::SetNativeEntryHook(store, [&] {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      native_entered = true;
+    }
+    condition.notify_all();
+    std::unique_lock<std::mutex> lock(mutex);
+    condition.wait(lock, [&] { return release_native; });
+  });
+  sitos::param_store_test_access::ParamStoreTestAccess::SetLifecycleHooks(store, {}, [&] {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      close_admission = true;
+    }
+    condition.notify_all();
+  });
+  auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange&) {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      callback_delivered = true;
+    }
+    condition.notify_all();
+  });
+  ASSERT_TRUE(subscription.IsOk());
+
+  std::thread emitter([&] {
+    transport->EmitPut("sitos/base/admitted", sitos::ParamValue(true));
+  });
+  bool native_entered_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    native_entered_in_time =
+        condition.wait_for(lock, std::chrono::seconds(3), [&] { return native_entered; });
+  }
+  std::thread closer([&] {
+    subscription.Value().Close();
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      close_returned = true;
+    }
+    condition.notify_all();
+  });
+  bool close_admission_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    close_admission_in_time =
+        condition.wait_for(lock, std::chrono::seconds(3), [&] { return close_admission; });
+  }
+  bool returned_before_release = false;
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    returned_before_release = close_returned;
+  }
+  EXPECT_TRUE(native_entered_in_time);
+  EXPECT_TRUE(close_admission_in_time);
+  EXPECT_FALSE(returned_before_release);
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    release_native = true;
+  }
+  condition.notify_all();
+  emitter.join();
+  closer.join();
+  EXPECT_TRUE(callback_delivered);
+  EXPECT_TRUE(close_returned);
 }
 
 TEST(ParamStoreSubscribeTest, ReentrantEmissionIsQueuedAfterCurrentCallback) {
@@ -399,6 +511,16 @@ TEST(ParamStoreSubscribeTest, CloseWaitsForBlockedLogSink) {
   auto store_result = sitos::ParamStore::Open(transport, config);
   ASSERT_TRUE(store_result.IsOk());
   auto store = std::move(store_result).Value();
+  std::mutex close_mutex;
+  std::condition_variable close_condition;
+  bool close_admission = false;
+  sitos::param_store_test_access::ParamStoreTestAccess::SetLifecycleHooks(store, {}, [&] {
+    {
+      std::lock_guard<std::mutex> lock(close_mutex);
+      close_admission = true;
+    }
+    close_condition.notify_all();
+  });
   auto subscription = store.Subscribe("base", "", [](const sitos::ParamChange&) {});
   ASSERT_TRUE(subscription.IsOk());
 
@@ -412,26 +534,18 @@ TEST(ParamStoreSubscribeTest, CloseWaitsForBlockedLogSink) {
     ADD_FAILURE() << "log sink did not enter";
     return;
   }
-  bool close_started = false;
   std::atomic<bool> close_returned = false;
-  std::mutex close_mutex;
-  std::condition_variable close_condition;
   std::thread closer([&] {
-    {
-      std::lock_guard<std::mutex> lock(close_mutex);
-      close_started = true;
-    }
-    close_condition.notify_all();
     subscription.Value().Close();
     close_returned.store(true, std::memory_order_release);
   });
-  bool close_started_in_time = false;
+  bool close_admission_in_time = false;
   {
     std::unique_lock<std::mutex> lock(close_mutex);
-    close_started_in_time = close_condition.wait_for(
-        lock, std::chrono::seconds(3), [&] { return close_started; });
+    close_admission_in_time = close_condition.wait_for(
+        lock, std::chrono::seconds(3), [&] { return close_admission; });
   }
-  EXPECT_TRUE(close_started_in_time);
+  EXPECT_TRUE(close_admission_in_time);
   EXPECT_FALSE(close_returned.load(std::memory_order_acquire));
   sink->Release();
   emitter.join();
@@ -450,13 +564,15 @@ TEST(ParamStoreSubscribeTest, ThrowingLogSinkIsContained) {
   auto store_result = sitos::ParamStore::Open(transport, config);
   ASSERT_TRUE(store_result.IsOk());
   auto store = std::move(store_result).Value();
-  auto subscription = store.Subscribe("base", "", [](const sitos::ParamChange&) {
+  int callbacks = 0;
+  auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange&) {
+    ++callbacks;
     throw std::runtime_error("callback failed");
   });
   ASSERT_TRUE(subscription.IsOk());
-  EXPECT_NO_THROW(transport->EmitRaw("sitos/base/malformed", {},
-                                     std::string(sitos::Encoding::kSitosV1)));
-  EXPECT_NO_THROW(transport->EmitPut("sitos/base/value", sitos::ParamValue(true)));
+  EXPECT_NO_THROW(transport->EmitPut("sitos/base/first", sitos::ParamValue(true)));
+  EXPECT_NO_THROW(transport->EmitPut("sitos/base/second", sitos::ParamValue(false)));
+  EXPECT_EQ(callbacks, 2);
 }
 
 TEST(ParamStoreSubscribeTest, SubscriptionSurvivesParamStoreMoveAndDestruction) {
@@ -479,19 +595,116 @@ TEST(ParamStoreSubscribeTest, SubscriptionSurvivesParamStoreMoveAndDestruction) 
   subscription->Close();
 }
 
+TEST(ParamStoreSubscribeTest, ParamSubscriptionOwnsAndReleasesDependencies) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto sink = std::make_shared<CaptureSink>();
+  const std::weak_ptr<FakeTransport> weak_transport = transport;
+  const std::weak_ptr<CaptureSink> weak_sink = sink;
+  std::optional<sitos::ParamSubscription> subscription;
+  {
+    sitos::ClientConfig config;
+    config.log_sink = sink;
+    auto store_result = sitos::ParamStore::Open(transport, config);
+    ASSERT_TRUE(store_result.IsOk());
+    auto store = std::move(store_result).Value();
+    auto result = store.Subscribe("base", "", [](const sitos::ParamChange&) {});
+    ASSERT_TRUE(result.IsOk());
+    subscription.emplace(std::move(result).Value());
+  }
+  transport.reset();
+  sink.reset();
+  EXPECT_FALSE(weak_transport.expired());
+  EXPECT_FALSE(weak_sink.expired());
+  auto held_transport = weak_transport.lock();
+  ASSERT_TRUE(held_transport);
+  held_transport->EmitRaw("sitos/base/malformed", {}, std::string(sitos::Encoding::kSitosV1));
+  held_transport.reset();
+  subscription->Close();
+  EXPECT_TRUE(weak_transport.expired());
+  EXPECT_TRUE(weak_sink.expired());
+}
+
 TEST(ParamStoreSubscribeTest, ConcurrentRepeatedCloseIsSafe) {
   auto transport = std::make_shared<FakeTransport>();
   auto store_result = sitos::ParamStore::Open(transport);
   ASSERT_TRUE(store_result.IsOk());
   auto store = std::move(store_result).Value();
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool native_entered = false;
+  bool release_native = false;
+  bool close_admission = false;
+  int started = 0;
+  int returned = 0;
+  sitos::param_store_test_access::ParamStoreTestAccess::SetNativeEntryHook(store, [&] {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      native_entered = true;
+    }
+    condition.notify_all();
+    std::unique_lock<std::mutex> lock(mutex);
+    condition.wait(lock, [&] { return release_native; });
+  });
+  sitos::param_store_test_access::ParamStoreTestAccess::SetLifecycleHooks(store, {}, [&] {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      close_admission = true;
+    }
+    condition.notify_all();
+  });
   auto subscription = store.Subscribe("base", "", [](const sitos::ParamChange&) {});
   ASSERT_TRUE(subscription.IsOk());
+  std::thread emitter([&] {
+    transport->EmitPut("sitos/base/admitted", sitos::ParamValue(true));
+  });
+  bool native_entered_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    native_entered_in_time =
+        condition.wait_for(lock, std::chrono::seconds(3), [&] { return native_entered; });
+  }
   std::vector<std::thread> closers;
   for (int i = 0; i < 4; ++i) {
-    closers.emplace_back([&] { subscription.Value().Close(); });
+    closers.emplace_back([&] {
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        ++started;
+      }
+      condition.notify_all();
+      subscription.Value().Close();
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        ++returned;
+      }
+      condition.notify_all();
+    });
   }
+  bool all_started_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    all_started_in_time = condition.wait_for(
+        lock, std::chrono::seconds(3), [&] { return started == 4; });
+  }
+  bool close_admission_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    close_admission_in_time = condition.wait_for(
+        lock, std::chrono::seconds(3), [&] { return close_admission; });
+  }
+  bool all_blocked = false;
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    all_blocked = returned == 0;
+    release_native = true;
+  }
+  condition.notify_all();
+  emitter.join();
   for (auto& closer : closers) closer.join();
-  subscription.Value().Close();
+  EXPECT_TRUE(native_entered_in_time);
+  EXPECT_TRUE(all_started_in_time);
+  EXPECT_TRUE(close_admission_in_time);
+  EXPECT_TRUE(all_blocked);
+  EXPECT_EQ(returned, 4);
   EXPECT_NO_THROW(transport->EmitPut("sitos/base/after", sitos::ParamValue(true)));
 }
 
@@ -514,8 +727,8 @@ TEST(ParamStoreSubscribeTest, RejectsMalformedBatchInputsWithoutCallbacks) {
       "sitos/base/:batch", malformed,
       sitos::Encoding{std::string(sitos::Encoding::kSitosV1Batch)}, std::nullopt,
       sitos::TransportSample::Kind::Put});
-  auto invalid_entries =
-      std::vector<sitos::BatchEntry>{{"invalid*key", sitos::ParamValue(true)}};
+  auto invalid_entries = std::vector<sitos::BatchEntry>{{"valid-before-invalid", sitos::ParamValue(true)},
+                                                          {"invalid*key", sitos::ParamValue(true)}};
   const auto invalid_batch = sitos::EncodeBatch(invalid_entries);
   transport->Emit(sitos::TransportSample{
       "sitos/base/:batch", invalid_batch,
@@ -662,12 +875,19 @@ TEST(ParamStoreSubscribeTest, ConcurrentNativeCallbacksAreSerialized) {
   constexpr int kEmitters = 4;
   std::mutex mutex;
   std::condition_variable condition;
-  int started = 0;
+  int admitted = 0;
   int finished = 0;
   int callbacks = 0;
   int active = 0;
   int max_active = 0;
   bool release = false;
+  sitos::param_store_test_access::ParamStoreTestAccess::SetNativeEntryHook(store, [&] {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      ++admitted;
+    }
+    condition.notify_all();
+  });
   auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange&) {
     {
       std::lock_guard<std::mutex> lock(mutex);
@@ -686,11 +906,6 @@ TEST(ParamStoreSubscribeTest, ConcurrentNativeCallbacksAreSerialized) {
   std::vector<std::thread> emitters;
   for (int i = 0; i < kEmitters; ++i) {
     emitters.emplace_back([&, i] {
-      {
-        std::lock_guard<std::mutex> lock(mutex);
-        ++started;
-      }
-      condition.notify_all();
       transport->EmitPut("sitos/base/value" + std::to_string(i), sitos::ParamValue(true));
       {
         std::lock_guard<std::mutex> lock(mutex);
@@ -699,13 +914,13 @@ TEST(ParamStoreSubscribeTest, ConcurrentNativeCallbacksAreSerialized) {
       condition.notify_all();
     });
   }
-  bool all_started_in_time = false;
+  bool all_admitted_in_time = false;
   {
     std::unique_lock<std::mutex> lock(mutex);
-    all_started_in_time = condition.wait_for(lock, std::chrono::seconds(3),
-                                             [&] { return started == kEmitters; });
+    all_admitted_in_time = condition.wait_for(lock, std::chrono::seconds(3),
+                                              [&] { return admitted == kEmitters; });
   }
-  EXPECT_TRUE(all_started_in_time);
+  EXPECT_TRUE(all_admitted_in_time);
   {
     std::lock_guard<std::mutex> lock(mutex);
     EXPECT_EQ(finished, 0);
@@ -727,32 +942,109 @@ TEST(ParamStoreSubscribeTest, ConcurrentSubscribeHasIndependentQueues) {
   ASSERT_TRUE(store_result.IsOk());
   auto store = std::move(store_result).Value();
   std::mutex mutex;
-  std::vector<std::string> first_keys;
-  std::vector<std::string> second_keys;
+  std::condition_variable condition;
+  int ready = 0;
+  bool start = false;
+  bool first_entered = false;
+  bool release_first = false;
+  bool second_delivered = false;
   std::optional<sitos::Result<sitos::ParamSubscription>> first;
   std::optional<sitos::Result<sitos::ParamSubscription>> second;
   std::thread first_thread([&] {
-    first.emplace(store.Subscribe("base", "first", [&](const sitos::ParamChange& change) {
-      std::lock_guard<std::mutex> lock(mutex);
-      first_keys.push_back(change.key);
+    {
+      std::unique_lock<std::mutex> lock(mutex);
+      ++ready;
+      condition.notify_all();
+      condition.wait(lock, [&] { return start; });
+    }
+    first.emplace(store.Subscribe("base", "first", [&](const sitos::ParamChange&) {
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        first_entered = true;
+      }
+      condition.notify_all();
+      std::unique_lock<std::mutex> lock(mutex);
+      condition.wait(lock, [&] { return release_first; });
     }));
   });
   std::thread second_thread([&] {
-    second.emplace(store.Subscribe("base", "second", [&](const sitos::ParamChange& change) {
-      std::lock_guard<std::mutex> lock(mutex);
-      second_keys.push_back(change.key);
+    {
+      std::unique_lock<std::mutex> lock(mutex);
+      ++ready;
+      condition.notify_all();
+      condition.wait(lock, [&] { return start; });
+    }
+    second.emplace(store.Subscribe("base", "second", [&](const sitos::ParamChange&) {
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        second_delivered = true;
+      }
+      condition.notify_all();
     }));
   });
+  bool ready_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ready_in_time = condition.wait_for(lock, std::chrono::seconds(3), [&] { return ready == 2; });
+    start = true;
+  }
+  EXPECT_TRUE(ready_in_time);
+  condition.notify_all();
   first_thread.join();
   second_thread.join();
   ASSERT_TRUE(first.has_value());
   ASSERT_TRUE(second.has_value());
   ASSERT_TRUE(first->IsOk());
   ASSERT_TRUE(second->IsOk());
-  transport->EmitPut("sitos/base/first/value", sitos::ParamValue(true));
-  transport->EmitPut("sitos/base/second/value", sitos::ParamValue(true));
-  EXPECT_EQ(first_keys, std::vector<std::string>{"first/value"});
-  EXPECT_EQ(second_keys, std::vector<std::string>{"second/value"});
+
+  auto first_sample = MakePutSample();
+  first_sample.key = "sitos/base/first/value";
+  auto second_sample = MakePutSample();
+  second_sample.key = "sitos/base/second/value";
+  std::size_t first_index = 0;
+  std::thread first_emitter([&] { transport->EmitTo(0, first_sample); });
+  bool first_entered_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    first_entered_in_time =
+        condition.wait_for(lock, std::chrono::seconds(3), [&] { return first_entered; });
+  }
+  if (!first_entered_in_time) {
+    first_emitter.join();
+    first_index = 1;
+    first_emitter = std::thread([&] { transport->EmitTo(1, first_sample); });
+    {
+      std::unique_lock<std::mutex> lock(mutex);
+      first_entered_in_time =
+          condition.wait_for(lock, std::chrono::seconds(3), [&] { return first_entered; });
+    }
+  }
+  EXPECT_TRUE(first_entered_in_time);
+  if (!first_entered_in_time) {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      release_first = true;
+    }
+    condition.notify_all();
+    first_emitter.join();
+    return;
+  }
+  const std::size_t second_index = first_index == 0 ? 1 : 0;
+  std::thread second_emitter([&] { transport->EmitTo(second_index, second_sample); });
+  bool second_delivered_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    second_delivered_in_time =
+        condition.wait_for(lock, std::chrono::seconds(3), [&] { return second_delivered; });
+  }
+  EXPECT_TRUE(second_delivered_in_time);
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    release_first = true;
+  }
+  condition.notify_all();
+  first_emitter.join();
+  second_emitter.join();
 }
 
 TEST(ParamStoreSubscribeTest, BatchDoesNotInterleaveConcurrentOrdinarySample) {
@@ -763,8 +1055,21 @@ TEST(ParamStoreSubscribeTest, BatchDoesNotInterleaveConcurrentOrdinarySample) {
   std::mutex mutex;
   std::condition_variable condition;
   bool first_entered = false;
+  bool ordinary_admitted = false;
+  bool ordinary_finished = false;
   bool release = false;
+  bool release_ordinary = false;
+  int native_admitted = 0;
   std::vector<std::string> keys;
+  sitos::param_store_test_access::ParamStoreTestAccess::SetNativeEntryHook(store, [&] {
+    std::unique_lock<std::mutex> lock(mutex);
+    ++native_admitted;
+    if (native_admitted == 2) {
+      ordinary_admitted = true;
+      condition.notify_all();
+      condition.wait(lock, [&] { return release_ordinary; });
+    }
+  });
   auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange& change) {
     bool first = false;
     {
@@ -796,15 +1101,29 @@ TEST(ParamStoreSubscribeTest, BatchDoesNotInterleaveConcurrentOrdinarySample) {
   }
   std::thread ordinary_thread([&] {
     transport->EmitPut("sitos/base/ordinary", sitos::ParamValue(true));
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      ordinary_finished = true;
+    }
+    condition.notify_all();
   });
+  bool ordinary_admitted_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ordinary_admitted_in_time = condition.wait_for(
+        lock, std::chrono::seconds(3), [&] { return ordinary_admitted; });
+  }
+  EXPECT_TRUE(entered_in_time);
+  EXPECT_TRUE(ordinary_admitted_in_time);
   {
     std::lock_guard<std::mutex> lock(mutex);
+    EXPECT_FALSE(ordinary_finished);
     release = true;
+    release_ordinary = true;
   }
   condition.notify_all();
   batch_thread.join();
   ordinary_thread.join();
-  EXPECT_TRUE(entered_in_time);
   std::vector<std::string> observed;
   {
     std::lock_guard<std::mutex> lock(mutex);
@@ -889,10 +1208,21 @@ TEST(ParamStoreSubscribeTest, ValidationPrecedesDeclaration) {
   auto malformed = store.Subscribe("base", "bad*prefix", [](const sitos::ParamChange&) {});
   EXPECT_FALSE(malformed.IsOk());
   EXPECT_EQ(malformed.StatusCode(), sitos::Status::InvalidKey);
+  auto empty_and_malformed = store.Subscribe("bad scope", "bad*prefix", {});
+  EXPECT_FALSE(empty_and_malformed.IsOk());
+  EXPECT_EQ(empty_and_malformed.StatusCode(), sitos::Status::InvalidArgument);
+  auto malformed_scope_and_prefix =
+      store.Subscribe("session", "bad*prefix", [](const sitos::ParamChange&) {});
+  EXPECT_FALSE(malformed_scope_and_prefix.IsOk());
+  EXPECT_EQ(malformed_scope_and_prefix.StatusCode(), sitos::Status::InvalidKey);
+  auto snapshot_and_prefix =
+      store.Subscribe("snap/session", "bad*prefix", [](const sitos::ParamChange&) {});
+  EXPECT_FALSE(snapshot_and_prefix.IsOk());
+  EXPECT_EQ(snapshot_and_prefix.StatusCode(), sitos::Status::InvalidArgument);
   auto moved_store = std::move(store);
-  auto moved_from = store.Subscribe("base", "", [](const sitos::ParamChange&) {});
-  EXPECT_FALSE(moved_from.IsOk());
-  EXPECT_EQ(moved_from.StatusCode(), sitos::Status::InvalidArgument);
+  auto moved_and_malformed = store.Subscribe("bad scope", "bad*prefix", {});
+  EXPECT_FALSE(moved_and_malformed.IsOk());
+  EXPECT_EQ(moved_and_malformed.StatusCode(), sitos::Status::InvalidArgument);
   EXPECT_EQ(transport->declaration_count, 0);
 }
 
@@ -925,9 +1255,17 @@ TEST(ParamStoreSubscribeTest, DeclarationFailureWaitsForAdmittedCallbackCopy) {
   std::mutex mutex;
   std::condition_variable condition;
   std::atomic<bool> hook_entered = false;
+  bool fail_staging_entered = false;
   bool release_hook = false;
   bool subscribe_finished = false;
   int callback_count = 0;
+  sitos::param_store_test_access::ParamStoreTestAccess::SetLifecycleHooks(store, [&] {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      fail_staging_entered = true;
+    }
+    condition.notify_all();
+  }, {});
   transport->declaration_callback_admitted =
       [&] { return hook_entered.load(std::memory_order_acquire); };
   sitos::param_store_test_access::ParamStoreTestAccess::SetNativeEntryHook(store, [&] {
@@ -959,7 +1297,14 @@ TEST(ParamStoreSubscribeTest, DeclarationFailureWaitsForAdmittedCallbackCopy) {
       return hook_entered.load(std::memory_order_acquire);
     });
   }
+  bool fail_staging_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    fail_staging_in_time = condition.wait_for(
+        lock, std::chrono::seconds(3), [&] { return fail_staging_entered; });
+  }
   EXPECT_TRUE(hook_entered_in_time);
+  EXPECT_TRUE(fail_staging_in_time);
   {
     std::lock_guard<std::mutex> lock(mutex);
     EXPECT_FALSE(subscribe_finished);

--- a/tests/unit/param_store_subscribe_test.cpp
+++ b/tests/unit/param_store_subscribe_test.cpp
@@ -804,8 +804,10 @@ TEST(ParamStoreSubscribeTest, CloseDrainsPendingBatchAndBlocksPostCloseDiagnosti
   std::mutex mutex;
   std::condition_variable condition;
   bool entered = false;
+  bool final_entered = false;
   bool close_admission = false;
-  bool release = false;
+  bool release_first = false;
+  bool release_final = false;
   std::vector<std::string> keys;
   sitos::param_store_test_access::ParamStoreTestAccess::SetLifecycleHooks(store, {}, [&] {
     {
@@ -819,16 +821,23 @@ TEST(ParamStoreSubscribeTest, CloseDrainsPendingBatchAndBlocksPostCloseDiagnosti
       std::lock_guard<std::mutex> lock(mutex);
       keys.push_back(change.key);
       if (keys.size() == 1U) entered = true;
+      if (keys.size() == 3U) final_entered = true;
     }
     bool first = false;
+    bool final = false;
     {
       std::lock_guard<std::mutex> lock(mutex);
       first = keys.size() == 1U;
+      final = keys.size() == 3U;
     }
     condition.notify_all();
     if (first) {
       std::unique_lock<std::mutex> lock(mutex);
-      condition.wait(lock, [&] { return release; });
+      condition.wait(lock, [&] { return release_first; });
+    }
+    if (final) {
+      std::unique_lock<std::mutex> lock(mutex);
+      condition.wait(lock, [&] { return release_final; });
     }
   });
   ASSERT_TRUE(subscription.IsOk());
@@ -862,7 +871,21 @@ TEST(ParamStoreSubscribeTest, CloseDrainsPendingBatchAndBlocksPostCloseDiagnosti
   EXPECT_FALSE(close_returned.load(std::memory_order_acquire));
   {
     std::lock_guard<std::mutex> lock(mutex);
-    release = true;
+    release_first = true;
+  }
+  condition.notify_all();
+  bool final_entered_in_time = false;
+  if (entered_in_time && close_admission_in_time) {
+    std::unique_lock<std::mutex> lock(mutex);
+    final_entered_in_time =
+        condition.wait_for(lock, std::chrono::seconds(3), [&] { return final_entered; });
+  }
+  EXPECT_TRUE(final_entered_in_time);
+  EXPECT_FALSE(close_returned.load(std::memory_order_acquire));
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    release_first = true;
+    release_final = true;
   }
   condition.notify_all();
   emitter.join();

--- a/tests/unit/param_store_subscribe_test.cpp
+++ b/tests/unit/param_store_subscribe_test.cpp
@@ -6,10 +6,12 @@
 #include <gtest/gtest.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -31,9 +33,32 @@ class FakeTransport final : public sitos::Transport {
     return sitos::Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
   }
 
+  void Emit(const sitos::TransportSample& sample) {
+    ASSERT_TRUE(static_cast<bool>(subscriber));
+    subscriber(sample);
+  }
+
+  void EmitPut(std::string key, const sitos::ParamValue& value,
+               std::string encoding = std::string(sitos::Encoding::kSitosV1)) {
+    auto payload = value.Encode();
+    Emit(sitos::TransportSample{std::move(key), payload, sitos::Encoding{std::move(encoding)},
+                                std::nullopt, sitos::TransportSample::Kind::Put});
+  }
+
+  void EmitRaw(std::string key, std::vector<std::byte> payload, std::string encoding) {
+    Emit(sitos::TransportSample{std::move(key), payload, sitos::Encoding{std::move(encoding)},
+                                std::nullopt, sitos::TransportSample::Kind::Put});
+  }
+
+  void EmitDelete(std::string key) {
+    Emit(sitos::TransportSample{std::move(key), {}, {}, std::nullopt,
+                                sitos::TransportSample::Kind::Delete});
+  }
+
   sitos::Result<sitos::Subscription> DeclareSubscriber(
       std::string_view keyexpr,
       std::function<void(const sitos::TransportSample&)> callback) override {
+    ++declaration_count;
     declared_keyexpr = std::string(keyexpr);
     subscriber = std::move(callback);
     if (declaration_error.has_value()) return std::move(*declaration_error);
@@ -48,13 +73,14 @@ class FakeTransport final : public sitos::Transport {
   }
 
   std::string declared_keyexpr;
+  int declaration_count = 0;
   std::function<void(const sitos::TransportSample&)> subscriber;
   std::optional<sitos::TransportSample> sample_during_declaration;
   std::optional<sitos::Result<sitos::Subscription>> declaration_error;
 };
 
 sitos::TransportSample MakePutSample() {
-  const auto payload = sitos::ParamValue(true).Encode();
+  static const auto payload = sitos::ParamValue(true).Encode();
   return sitos::TransportSample{"sitos/base/flag", payload,
                                 sitos::Encoding{std::string(sitos::Encoding::kSitosV1)},
                                 std::nullopt, sitos::TransportSample::Kind::Put};
@@ -78,6 +104,104 @@ TEST(ParamStoreSubscribeTest, SynchronousDeclarationSampleIsStagedAndDrained) {
   EXPECT_EQ(changes.front().key, "flag");
   ASSERT_TRUE(changes.front().value.has_value());
   EXPECT_EQ(changes.front().value->As<bool>(), true);
+}
+
+TEST(ParamStoreSubscribeTest, DeliversDeleteAndUnknownEncodingAsBytes) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  std::vector<sitos::ParamChange> changes;
+  auto subscription = store.Subscribe("base", "foo", [&](const sitos::ParamChange& change) {
+    changes.push_back(change);
+  });
+  ASSERT_TRUE(subscription.IsOk());
+
+  transport->EmitPut("sitos/base/foobar", sitos::ParamValue(true), "application/octet-stream");
+  transport->EmitDelete("sitos/base/foo");
+  ASSERT_EQ(changes.size(), 2U);
+  EXPECT_EQ(changes[0].key, "foobar");
+  ASSERT_TRUE(changes[0].value.has_value());
+  ASSERT_TRUE(changes[0].value->As<std::vector<std::byte>>().has_value());
+  EXPECT_EQ(changes[1].kind, sitos::ParamChangeKind::kDelete);
+  EXPECT_EQ(changes[1].key, "foo");
+  EXPECT_FALSE(changes[1].value.has_value());
+}
+
+TEST(ParamStoreSubscribeTest, BatchPreservesOrderAndDuplicates) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  std::vector<sitos::ParamChange> changes;
+  auto subscription = store.Subscribe("base", "foo", [&](const sitos::ParamChange& change) {
+    changes.push_back(change);
+  });
+  ASSERT_TRUE(subscription.IsOk());
+
+  std::vector<sitos::BatchEntry> entries;
+  entries.push_back({"foo/one", sitos::ParamValue(std::int64_t{1})});
+  entries.push_back({"foobar", sitos::ParamValue(std::int64_t{2})});
+  entries.push_back({"foo/one", sitos::ParamValue(std::int64_t{3})});
+  auto payload = sitos::EncodeBatch(entries);
+  transport->Emit(sitos::TransportSample{"sitos/base/:batch", payload,
+                                          sitos::Encoding{std::string(sitos::Encoding::kSitosV1Batch)},
+                                          std::nullopt, sitos::TransportSample::Kind::Put});
+
+  ASSERT_EQ(changes.size(), 3U);
+  EXPECT_EQ(changes[0].key, "foo/one");
+  EXPECT_EQ(changes[1].key, "foobar");
+  EXPECT_EQ(changes[2].key, "foo/one");
+  EXPECT_EQ(changes[0].value->As<std::int64_t>(), 1);
+  EXPECT_EQ(changes[2].value->As<std::int64_t>(), 3);
+}
+
+TEST(ParamStoreSubscribeTest, CloseStopsDelivery) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  int callback_count = 0;
+  auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange&) {
+    ++callback_count;
+  });
+  ASSERT_TRUE(subscription.IsOk());
+  transport->EmitPut("sitos/base/value", sitos::ParamValue(true));
+  ASSERT_EQ(callback_count, 1);
+  subscription.Value().Close();
+  subscription.Value().Close();
+  transport->EmitPut("sitos/base/value", sitos::ParamValue(false));
+  EXPECT_EQ(callback_count, 1);
+}
+
+TEST(ParamStoreSubscribeTest, ValidationPrecedesDeclaration) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  auto snapshot = store.Subscribe("snap/session", "", [](const sitos::ParamChange&) {});
+  EXPECT_FALSE(snapshot.IsOk());
+  EXPECT_EQ(snapshot.StatusCode(), sitos::Status::InvalidArgument);
+  auto malformed = store.Subscribe("base", "bad*prefix", [](const sitos::ParamChange&) {});
+  EXPECT_FALSE(malformed.IsOk());
+  EXPECT_EQ(malformed.StatusCode(), sitos::Status::InvalidKey);
+  EXPECT_EQ(transport->declaration_count, 0);
+}
+
+TEST(ParamStoreSubscribeTest, CallbackExceptionsDoNotStopSubscription) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  int callback_count = 0;
+  auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange&) {
+    ++callback_count;
+    throw std::runtime_error("callback failed");
+  });
+  ASSERT_TRUE(subscription.IsOk());
+  transport->EmitPut("sitos/base/one", sitos::ParamValue(true));
+  transport->EmitPut("sitos/base/two", sitos::ParamValue(false));
+  EXPECT_EQ(callback_count, 2);
 }
 
 TEST(ParamStoreSubscribeTest, DeclarationFailureDiscardsSynchronousSample) {

--- a/tests/unit/param_store_subscribe_test.cpp
+++ b/tests/unit/param_store_subscribe_test.cpp
@@ -326,7 +326,7 @@ TEST(ParamStoreSubscribeTest, CloseWaitsForBlockedCallback) {
       close_admission_observed = true;
     }
     condition.notify_all();
-  });
+  }, {});
   auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange&) {
     {
       std::lock_guard<std::mutex> lock(mutex);
@@ -379,6 +379,7 @@ TEST(ParamStoreSubscribeTest, CloseDeliversAdmittedSampleBeforeReturning) {
   bool native_entered = false;
   bool release_native = false;
   bool close_admission = false;
+  bool close_reset_started = false;
   bool callback_delivered = false;
   bool close_returned = false;
   sitos::param_store_test_access::ParamStoreTestAccess::SetNativeEntryHook(store, [&] {
@@ -394,6 +395,12 @@ TEST(ParamStoreSubscribeTest, CloseDeliversAdmittedSampleBeforeReturning) {
     {
       std::lock_guard<std::mutex> lock(mutex);
       close_admission = true;
+    }
+    condition.notify_all();
+  }, [&] {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      close_reset_started = true;
     }
     condition.notify_all();
   });
@@ -429,6 +436,12 @@ TEST(ParamStoreSubscribeTest, CloseDeliversAdmittedSampleBeforeReturning) {
     close_admission_in_time =
         condition.wait_for(lock, std::chrono::seconds(3), [&] { return close_admission; });
   }
+  bool close_reset_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    close_reset_in_time = condition.wait_for(
+        lock, std::chrono::seconds(3), [&] { return close_reset_started; });
+  }
   bool returned_before_release = false;
   {
     std::lock_guard<std::mutex> lock(mutex);
@@ -436,6 +449,7 @@ TEST(ParamStoreSubscribeTest, CloseDeliversAdmittedSampleBeforeReturning) {
   }
   EXPECT_TRUE(native_entered_in_time);
   EXPECT_TRUE(close_admission_in_time);
+  EXPECT_TRUE(close_reset_in_time);
   EXPECT_FALSE(returned_before_release);
   {
     std::lock_guard<std::mutex> lock(mutex);
@@ -520,7 +534,7 @@ TEST(ParamStoreSubscribeTest, CloseWaitsForBlockedLogSink) {
       close_admission = true;
     }
     close_condition.notify_all();
-  });
+  }, {});
   auto subscription = store.Subscribe("base", "", [](const sitos::ParamChange&) {});
   ASSERT_TRUE(subscription.IsOk());
 
@@ -651,7 +665,7 @@ TEST(ParamStoreSubscribeTest, ConcurrentRepeatedCloseIsSafe) {
       close_admission = true;
     }
     condition.notify_all();
-  });
+  }, {});
   auto subscription = store.Subscribe("base", "", [](const sitos::ParamChange&) {});
   ASSERT_TRUE(subscription.IsOk());
   std::thread emitter([&] {
@@ -1266,7 +1280,7 @@ TEST(ParamStoreSubscribeTest, DeclarationFailureWaitsForAdmittedCallbackCopy) {
       fail_staging_entered = true;
     }
     condition.notify_all();
-  }, {});
+  }, {}, {});
   transport->declaration_callback_admitted =
       [&] { return hook_entered.load(std::memory_order_acquire); };
   sitos::param_store_test_access::ParamStoreTestAccess::SetNativeEntryHook(store, [&] {

--- a/tests/unit/param_store_subscribe_test.cpp
+++ b/tests/unit/param_store_subscribe_test.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sitos/param_store.hpp"
+#include "param_store_test_access.hpp"
 
 #include <gtest/gtest.h>
 
@@ -51,6 +52,45 @@ class CaptureSink final : public sitos::LogSink {
   std::vector<std::string> messages;
 };
 
+class BlockingSink final : public sitos::LogSink {
+ public:
+  void Write(const sitos::LogRecord&) override {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      entered_ = true;
+      ++writes_;
+    }
+    condition_.notify_all();
+    std::unique_lock<std::mutex> lock(mutex_);
+    condition_.wait(lock, [&] { return release_; });
+  }
+
+  bool WaitForEntry() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return condition_.wait_for(lock, std::chrono::seconds(3), [&] { return entered_; });
+  }
+
+  void Release() {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      release_ = true;
+    }
+    condition_.notify_all();
+  }
+
+  int Writes() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return writes_;
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  std::condition_variable condition_;
+  bool entered_ = false;
+  bool release_ = false;
+  int writes_ = 0;
+};
+
 class FakeTransport final : public sitos::Transport {
  public:
   sitos::Result<void> Put(std::string_view, std::span<const std::byte>, sitos::Encoding,
@@ -68,8 +108,13 @@ class FakeTransport final : public sitos::Transport {
   }
 
   void Emit(const sitos::TransportSample& sample) {
-    ASSERT_TRUE(static_cast<bool>(subscriber));
-    subscriber(sample);
+    std::vector<std::function<void(const sitos::TransportSample&)>> callbacks;
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      callbacks = subscribers;
+    }
+    ASSERT_FALSE(callbacks.empty());
+    for (const auto& callback : callbacks) callback(sample);
   }
 
   void EmitPut(std::string key, const sitos::ParamValue& value,
@@ -89,14 +134,28 @@ class FakeTransport final : public sitos::Transport {
                                 sitos::TransportSample::Kind::Delete});
   }
 
+  ~FakeTransport() {
+    if (declaration_thread.joinable()) declaration_thread.join();
+  }
+
   sitos::Result<sitos::Subscription> DeclareSubscriber(
       std::string_view keyexpr,
       std::function<void(const sitos::TransportSample&)> callback) override {
     ++declaration_count;
     declared_keyexpr = std::string(keyexpr);
-    subscriber = std::move(callback);
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      subscribers.push_back(callback);
+      subscriber = callback;
+    }
+    if (sample_during_declaration.has_value()) {
+      if (async_declaration_sample) {
+        declaration_thread = std::thread([callback, this] { callback(*sample_during_declaration); });
+      } else {
+        callback(*sample_during_declaration);
+      }
+    }
     if (declaration_error.has_value()) return std::move(*declaration_error);
-    if (sample_during_declaration.has_value()) subscriber(*sample_during_declaration);
     return sitos::Result<sitos::Subscription>::Ok(sitos::Subscription{});
   }
 
@@ -109,8 +168,12 @@ class FakeTransport final : public sitos::Transport {
   std::string declared_keyexpr;
   int declaration_count = 0;
   std::function<void(const sitos::TransportSample&)> subscriber;
+  std::vector<std::function<void(const sitos::TransportSample&)>> subscribers;
+  std::mutex mutex;
   std::optional<sitos::TransportSample> sample_during_declaration;
   std::optional<sitos::Result<sitos::Subscription>> declaration_error;
+  bool async_declaration_sample = false;
+  std::thread declaration_thread;
 };
 
 sitos::TransportSample MakePutSample() {
@@ -308,11 +371,65 @@ TEST(ParamStoreSubscribeTest, CapturesWarningsAndErrorsAndSupportsDisabledLoggin
   auto disabled_store_result = sitos::ParamStore::Open(disabled_transport, disabled_config);
   ASSERT_TRUE(disabled_store_result.IsOk());
   auto disabled_store = std::move(disabled_store_result).Value();
+  int disabled_callbacks = 0;
   auto disabled_subscription = disabled_store.Subscribe(
-      "base", "", [](const sitos::ParamChange&) {});
+      "base", "", [&](const sitos::ParamChange&) { ++disabled_callbacks; });
   ASSERT_TRUE(disabled_subscription.IsOk());
   EXPECT_NO_THROW(disabled_transport->EmitRaw("sitos/base/malformed", {},
                                                std::string(sitos::Encoding::kSitosV1)));
+  disabled_transport->EmitPut("sitos/base/valid", sitos::ParamValue(true));
+  EXPECT_EQ(disabled_callbacks, 1);
+}
+
+TEST(ParamStoreSubscribeTest, CloseWaitsForBlockedLogSink) {
+  auto sink = std::make_shared<BlockingSink>();
+  auto transport = std::make_shared<FakeTransport>();
+  sitos::ClientConfig config;
+  config.log_sink = sink;
+  auto store_result = sitos::ParamStore::Open(transport, config);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  auto subscription = store.Subscribe("base", "", [](const sitos::ParamChange&) {});
+  ASSERT_TRUE(subscription.IsOk());
+
+  std::thread emitter([&] {
+    transport->EmitRaw("sitos/base/malformed", {}, std::string(sitos::Encoding::kSitosV1));
+  });
+  const bool sink_entered = sink->WaitForEntry();
+  if (!sink_entered) {
+    sink->Release();
+    emitter.join();
+    ADD_FAILURE() << "log sink did not enter";
+    return;
+  }
+  bool close_started = false;
+  std::atomic<bool> close_returned = false;
+  std::mutex close_mutex;
+  std::condition_variable close_condition;
+  std::thread closer([&] {
+    {
+      std::lock_guard<std::mutex> lock(close_mutex);
+      close_started = true;
+    }
+    close_condition.notify_all();
+    subscription.Value().Close();
+    close_returned.store(true, std::memory_order_release);
+  });
+  bool close_started_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(close_mutex);
+    close_started_in_time = close_condition.wait_for(
+        lock, std::chrono::seconds(3), [&] { return close_started; });
+  }
+  EXPECT_TRUE(close_started_in_time);
+  EXPECT_FALSE(close_returned.load(std::memory_order_acquire));
+  sink->Release();
+  emitter.join();
+  closer.join();
+  EXPECT_TRUE(close_returned.load(std::memory_order_acquire));
+  const int writes = sink->Writes();
+  transport->EmitRaw("sitos/base/after-close", {}, std::string(sitos::Encoding::kSitosV1));
+  EXPECT_EQ(sink->Writes(), writes);
 }
 
 TEST(ParamStoreSubscribeTest, ThrowingLogSinkIsContained) {
@@ -478,11 +595,33 @@ TEST(ParamStoreSubscribeTest, CloseDrainsPendingBatchAndBlocksPostCloseDiagnosti
                                                 std::string(sitos::Encoding::kSitosV1Batch)},
                                             std::nullopt, sitos::TransportSample::Kind::Put});
   });
+  bool entered_in_time = false;
   {
     std::unique_lock<std::mutex> lock(mutex);
-    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(3), [&] { return entered; }));
+    entered_in_time = condition.wait_for(lock, std::chrono::seconds(3), [&] { return entered; });
   }
-  std::thread closer([&] { subscription.Value().Close(); });
+  bool close_started = false;
+  std::atomic<bool> close_returned = false;
+  std::mutex close_mutex;
+  std::condition_variable close_condition;
+  std::thread closer([&] {
+    {
+      std::lock_guard<std::mutex> lock(close_mutex);
+      close_started = true;
+    }
+    close_condition.notify_all();
+    subscription.Value().Close();
+    close_returned.store(true, std::memory_order_release);
+  });
+  bool close_started_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(close_mutex);
+    close_started_in_time = close_condition.wait_for(
+        lock, std::chrono::seconds(3), [&] { return close_started; });
+  }
+  EXPECT_TRUE(entered_in_time);
+  EXPECT_TRUE(close_started_in_time);
+  EXPECT_FALSE(close_returned.load(std::memory_order_acquire));
   {
     std::lock_guard<std::mutex> lock(mutex);
     release = true;
@@ -490,10 +629,16 @@ TEST(ParamStoreSubscribeTest, CloseDrainsPendingBatchAndBlocksPostCloseDiagnosti
   condition.notify_all();
   emitter.join();
   closer.join();
-  ASSERT_EQ(keys.size(), entries.size());
-  EXPECT_EQ(keys[0], "one");
-  EXPECT_EQ(keys[1], "two");
-  EXPECT_EQ(keys[2], "three");
+  EXPECT_TRUE(close_returned.load(std::memory_order_acquire));
+  std::vector<std::string> observed_keys;
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    observed_keys = keys;
+  }
+  ASSERT_EQ(observed_keys.size(), entries.size());
+  EXPECT_EQ(observed_keys[0], "one");
+  EXPECT_EQ(observed_keys[1], "two");
+  EXPECT_EQ(observed_keys[2], "three");
   const auto log_count = sink->Size();
   transport->EmitRaw("sitos/base/after", {}, std::string(sitos::Encoding::kSitosV1));
   EXPECT_EQ(sink->Size(), log_count);
@@ -508,6 +653,7 @@ TEST(ParamStoreSubscribeTest, ConcurrentNativeCallbacksAreSerialized) {
   std::mutex mutex;
   std::condition_variable condition;
   int started = 0;
+  int finished = 0;
   int callbacks = 0;
   int active = 0;
   int max_active = 0;
@@ -536,12 +682,23 @@ TEST(ParamStoreSubscribeTest, ConcurrentNativeCallbacksAreSerialized) {
       }
       condition.notify_all();
       transport->EmitPut("sitos/base/value" + std::to_string(i), sitos::ParamValue(true));
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        ++finished;
+      }
+      condition.notify_all();
     });
   }
+  bool all_started_in_time = false;
   {
     std::unique_lock<std::mutex> lock(mutex);
-    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(3),
-                                   [&] { return started == kEmitters; }));
+    all_started_in_time = condition.wait_for(lock, std::chrono::seconds(3),
+                                             [&] { return started == kEmitters; });
+  }
+  EXPECT_TRUE(all_started_in_time);
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    EXPECT_EQ(finished, 0);
   }
   {
     std::lock_guard<std::mutex> lock(mutex);
@@ -549,8 +706,156 @@ TEST(ParamStoreSubscribeTest, ConcurrentNativeCallbacksAreSerialized) {
   }
   condition.notify_all();
   for (auto& emitter : emitters) emitter.join();
+  EXPECT_EQ(finished, kEmitters);
   EXPECT_EQ(callbacks, kEmitters);
   EXPECT_EQ(max_active, 1);
+}
+
+TEST(ParamStoreSubscribeTest, ConcurrentSubscribeHasIndependentQueues) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  std::mutex mutex;
+  std::vector<std::string> first_keys;
+  std::vector<std::string> second_keys;
+  std::optional<sitos::Result<sitos::ParamSubscription>> first;
+  std::optional<sitos::Result<sitos::ParamSubscription>> second;
+  std::thread first_thread([&] {
+    first.emplace(store.Subscribe("base", "first", [&](const sitos::ParamChange& change) {
+      std::lock_guard<std::mutex> lock(mutex);
+      first_keys.push_back(change.key);
+    }));
+  });
+  std::thread second_thread([&] {
+    second.emplace(store.Subscribe("base", "second", [&](const sitos::ParamChange& change) {
+      std::lock_guard<std::mutex> lock(mutex);
+      second_keys.push_back(change.key);
+    }));
+  });
+  first_thread.join();
+  second_thread.join();
+  ASSERT_TRUE(first.has_value());
+  ASSERT_TRUE(second.has_value());
+  ASSERT_TRUE(first->IsOk());
+  ASSERT_TRUE(second->IsOk());
+  transport->EmitPut("sitos/base/first/value", sitos::ParamValue(true));
+  transport->EmitPut("sitos/base/second/value", sitos::ParamValue(true));
+  EXPECT_EQ(first_keys, std::vector<std::string>{"first/value"});
+  EXPECT_EQ(second_keys, std::vector<std::string>{"second/value"});
+}
+
+TEST(ParamStoreSubscribeTest, BatchDoesNotInterleaveConcurrentOrdinarySample) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool first_entered = false;
+  bool release = false;
+  std::vector<std::string> keys;
+  auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange& change) {
+    bool first = false;
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      keys.push_back(change.key);
+      first = keys.size() == 1U;
+      if (first) first_entered = true;
+    }
+    condition.notify_all();
+    if (first) {
+      std::unique_lock<std::mutex> lock(mutex);
+      condition.wait(lock, [&] { return release; });
+    }
+  });
+  ASSERT_TRUE(subscription.IsOk());
+  std::vector<sitos::BatchEntry> entries{
+      {"batch/one", sitos::ParamValue(true)}, {"batch/two", sitos::ParamValue(false)}};
+  std::thread batch_thread([&] {
+    transport->Emit(sitos::TransportSample{"sitos/base/:batch", sitos::EncodeBatch(entries),
+                                            sitos::Encoding{
+                                                std::string(sitos::Encoding::kSitosV1Batch)},
+                                            std::nullopt, sitos::TransportSample::Kind::Put});
+  });
+  bool entered_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    entered_in_time = condition.wait_for(lock, std::chrono::seconds(3),
+                                         [&] { return first_entered; });
+  }
+  std::thread ordinary_thread([&] {
+    transport->EmitPut("sitos/base/ordinary", sitos::ParamValue(true));
+  });
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    release = true;
+  }
+  condition.notify_all();
+  batch_thread.join();
+  ordinary_thread.join();
+  EXPECT_TRUE(entered_in_time);
+  std::vector<std::string> observed;
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    observed = keys;
+  }
+  ASSERT_EQ(observed.size(), 3U);
+  EXPECT_EQ(observed[0], "batch/one");
+  EXPECT_EQ(observed[1], "batch/two");
+  EXPECT_EQ(observed[2], "ordinary");
+}
+
+TEST(ParamStoreSubscribeTest, MoveAssignmentClosesDestinationAndDestructorStopsDelivery) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  int old_callbacks = 0;
+  int source_callbacks = 0;
+  auto old = store.Subscribe("base", "old", [&](const sitos::ParamChange&) { ++old_callbacks; });
+  auto source = store.Subscribe("base", "source", [&](const sitos::ParamChange&) {
+    ++source_callbacks;
+  });
+  ASSERT_TRUE(old.IsOk());
+  ASSERT_TRUE(source.IsOk());
+  old.Value() = std::move(source).Value();
+  transport->EmitPut("sitos/base/old/value", sitos::ParamValue(true));
+  transport->EmitPut("sitos/base/source/value", sitos::ParamValue(true));
+  EXPECT_EQ(old_callbacks, 0);
+  EXPECT_EQ(source_callbacks, 1);
+
+  int destroyed_callbacks = 0;
+  {
+    auto temporary = store.Subscribe("base", "destroyed", [&](const sitos::ParamChange&) {
+      ++destroyed_callbacks;
+    });
+    ASSERT_TRUE(temporary.IsOk());
+  }
+  transport->EmitPut("sitos/base/destroyed/value", sitos::ParamValue(true));
+  EXPECT_EQ(destroyed_callbacks, 0);
+}
+
+TEST(ParamStoreSubscribeTest, TransportAndLogSinkSurviveParamStoreDestruction) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto sink = std::make_shared<CaptureSink>();
+  std::optional<sitos::ParamSubscription> subscription;
+  int callbacks = 0;
+  {
+    sitos::ClientConfig config;
+    config.log_sink = sink;
+    auto store_result = sitos::ParamStore::Open(transport, config);
+    ASSERT_TRUE(store_result.IsOk());
+    auto store = std::move(store_result).Value();
+    auto result = store.Subscribe("base", "", [&](const sitos::ParamChange&) { ++callbacks; });
+    ASSERT_TRUE(result.IsOk());
+    subscription.emplace(std::move(result).Value());
+  }
+  transport->EmitPut("sitos/base/value", sitos::ParamValue(true));
+  transport->EmitRaw("sitos/base/malformed", {}, std::string(sitos::Encoding::kSitosV1));
+  EXPECT_EQ(callbacks, 1);
+  EXPECT_EQ(sink->Count(sitos::LogLevel::kWarning), 1U);
+  subscription->Close();
 }
 
 TEST(ParamStoreSubscribeTest, ValidationPrecedesDeclaration) {
@@ -595,6 +900,65 @@ TEST(ParamStoreSubscribeTest, CallbackExceptionsDoNotStopSubscription) {
   transport->EmitPut("sitos/base/one", sitos::ParamValue(true));
   transport->EmitPut("sitos/base/two", sitos::ParamValue(false));
   EXPECT_EQ(callback_count, 2);
+}
+
+TEST(ParamStoreSubscribeTest, DeclarationFailureWaitsForAdmittedCallbackCopy) {
+  auto transport = std::make_shared<FakeTransport>();
+  transport->sample_during_declaration = MakePutSample();
+  transport->declaration_error = sitos::Result<sitos::Subscription>::Err(
+      sitos::Status::Disconnected, "declaration failed", std::make_error_code(std::errc::io_error));
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool hook_entered = false;
+  bool release_hook = false;
+  bool subscribe_finished = false;
+  int callback_count = 0;
+  sitos::param_store_test_access::ParamStoreTestAccess::SetNativeEntryHook(store, [&] {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      hook_entered = true;
+    }
+    condition.notify_all();
+    std::unique_lock<std::mutex> lock(mutex);
+    condition.wait(lock, [&] { return release_hook; });
+  });
+
+  std::optional<sitos::Result<sitos::ParamSubscription>> result;
+  std::thread subscriber_thread([&] {
+    result.emplace(store.Subscribe("base", "", [&](const sitos::ParamChange&) {
+      ++callback_count;
+    }));
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      subscribe_finished = true;
+    }
+    condition.notify_all();
+  });
+  bool hook_entered_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    hook_entered_in_time = condition.wait_for(lock, std::chrono::seconds(3),
+                                               [&] { return hook_entered; });
+  }
+  EXPECT_TRUE(hook_entered_in_time);
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    EXPECT_FALSE(subscribe_finished);
+    release_hook = true;
+  }
+  condition.notify_all();
+  subscriber_thread.join();
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_FALSE(result->IsOk());
+  EXPECT_EQ(result->StatusCode(), sitos::Status::Disconnected);
+  EXPECT_EQ(result->Message(), "declaration failed");
+  EXPECT_EQ(result->Error(), std::make_error_code(std::errc::io_error));
+  EXPECT_EQ(callback_count, 0);
 }
 
 TEST(ParamStoreSubscribeTest, DeclarationFailureDiscardsSynchronousSample) {

--- a/tests/unit/param_store_subscribe_test.cpp
+++ b/tests/unit/param_store_subscribe_test.cpp
@@ -727,8 +727,9 @@ TEST(ParamStoreSubscribeTest, RejectsMalformedBatchInputsWithoutCallbacks) {
       "sitos/base/:batch", malformed,
       sitos::Encoding{std::string(sitos::Encoding::kSitosV1Batch)}, std::nullopt,
       sitos::TransportSample::Kind::Put});
-  auto invalid_entries = std::vector<sitos::BatchEntry>{{"valid-before-invalid", sitos::ParamValue(true)},
-                                                          {"invalid*key", sitos::ParamValue(true)}};
+  auto invalid_entries = std::vector<sitos::BatchEntry>{
+      {"valid-before-invalid", sitos::ParamValue(true)},
+      {"invalid*key", sitos::ParamValue(true)}};
   const auto invalid_batch = sitos::EncodeBatch(invalid_entries);
   transport->Emit(sitos::TransportSample{
       "sitos/base/:batch", invalid_batch,

--- a/tests/unit/param_store_subscribe_test.cpp
+++ b/tests/unit/param_store_subscribe_test.cpp
@@ -1,0 +1,104 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/param_store.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+class FakeTransport final : public sitos::Transport {
+ public:
+  sitos::Result<void> Put(std::string_view, std::span<const std::byte>, sitos::Encoding,
+                          sitos::PutOptions) override {
+    return sitos::Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
+  }
+
+  sitos::Result<void> Delete(std::string_view, sitos::PutOptions) override {
+    return sitos::Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
+  }
+
+  sitos::Result<void> Get(std::string_view, const QueryResultSink&, std::chrono::milliseconds) override {
+    return sitos::Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
+  }
+
+  sitos::Result<sitos::Subscription> DeclareSubscriber(
+      std::string_view keyexpr,
+      std::function<void(const sitos::TransportSample&)> callback) override {
+    declared_keyexpr = std::string(keyexpr);
+    subscriber = std::move(callback);
+    if (declaration_error.has_value()) return std::move(*declaration_error);
+    if (sample_during_declaration.has_value()) subscriber(*sample_during_declaration);
+    return sitos::Result<sitos::Subscription>::Ok(sitos::Subscription{});
+  }
+
+  sitos::Result<sitos::Queryable> DeclareQueryable(
+      std::string_view, std::function<void(sitos::TransportQuery&)>) override {
+    return sitos::Result<sitos::Queryable>::Err(
+        std::make_error_code(std::errc::operation_not_supported));
+  }
+
+  std::string declared_keyexpr;
+  std::function<void(const sitos::TransportSample&)> subscriber;
+  std::optional<sitos::TransportSample> sample_during_declaration;
+  std::optional<sitos::Result<sitos::Subscription>> declaration_error;
+};
+
+sitos::TransportSample MakePutSample() {
+  const auto payload = sitos::ParamValue(true).Encode();
+  return sitos::TransportSample{"sitos/base/flag", payload,
+                                sitos::Encoding{std::string(sitos::Encoding::kSitosV1)},
+                                std::nullopt, sitos::TransportSample::Kind::Put};
+}
+
+TEST(ParamStoreSubscribeTest, SynchronousDeclarationSampleIsStagedAndDrained) {
+  auto transport = std::make_shared<FakeTransport>();
+  transport->sample_during_declaration = MakePutSample();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+
+  std::vector<sitos::ParamChange> changes;
+  auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange& change) {
+    changes.push_back(change);
+  });
+
+  ASSERT_TRUE(subscription.IsOk());
+  ASSERT_EQ(changes.size(), 1U);
+  EXPECT_EQ(changes.front().kind, sitos::ParamChangeKind::kPut);
+  EXPECT_EQ(changes.front().key, "flag");
+  ASSERT_TRUE(changes.front().value.has_value());
+  EXPECT_EQ(changes.front().value->As<bool>(), true);
+}
+
+TEST(ParamStoreSubscribeTest, DeclarationFailureDiscardsSynchronousSample) {
+  auto transport = std::make_shared<FakeTransport>();
+  transport->sample_during_declaration = MakePutSample();
+  transport->declaration_error = sitos::Result<sitos::Subscription>::Err(
+      sitos::Status::Disconnected, "declaration failed", std::make_error_code(std::errc::io_error));
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+
+  int callback_count = 0;
+  auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange&) {
+    ++callback_count;
+  });
+
+  ASSERT_FALSE(subscription.IsOk());
+  EXPECT_EQ(subscription.StatusCode(), sitos::Status::Disconnected);
+  EXPECT_EQ(subscription.Message(), "declaration failed");
+  EXPECT_EQ(subscription.Error(), std::make_error_code(std::errc::io_error));
+  EXPECT_EQ(callback_count, 0);
+}
+
+}  // namespace

--- a/tests/unit/param_store_subscribe_test.cpp
+++ b/tests/unit/param_store_subscribe_test.cpp
@@ -589,6 +589,107 @@ TEST(ParamStoreSubscribeTest, ThrowingLogSinkIsContained) {
   EXPECT_EQ(callbacks, 2);
 }
 
+TEST(ParamStoreSubscribeTest, InternalDecodeFailureCompletesAndContinuesDrain) {
+  auto sink = std::make_shared<CaptureSink>();
+  auto transport = std::make_shared<FakeTransport>();
+  sitos::ClientConfig config;
+  config.log_sink = sink;
+  auto store_result = sitos::ParamStore::Open(transport, config);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool decode_entered = false;
+  bool release_decode = false;
+  int admitted = 0;
+  bool second_finished = false;
+  bool close_finished = false;
+  std::vector<std::string> keys;
+  sitos::param_store_test_access::ParamStoreTestAccess::SetNativeEntryHook(store, [&] {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      ++admitted;
+    }
+    condition.notify_all();
+  });
+  sitos::param_store_test_access::ParamStoreTestAccess::SetDecodeHook(store, [&] {
+    std::unique_lock<std::mutex> lock(mutex);
+    if (admitted == 1) {
+      decode_entered = true;
+      condition.notify_all();
+      condition.wait(lock, [&] { return release_decode; });
+      throw std::runtime_error("internal decode failure");
+    }
+  });
+  auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange& change) {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      keys.push_back(change.key);
+    }
+    condition.notify_all();
+  });
+  ASSERT_TRUE(subscription.IsOk());
+
+  std::thread first_emitter([&] {
+    transport->EmitPut("sitos/base/first", sitos::ParamValue(true));
+  });
+  bool decode_entered_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    decode_entered_in_time =
+        condition.wait_for(lock, std::chrono::seconds(3), [&] { return decode_entered; });
+  }
+  std::thread second_emitter([&] {
+    transport->EmitPut("sitos/base/second", sitos::ParamValue(false));
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      second_finished = true;
+    }
+    condition.notify_all();
+  });
+  bool second_admitted_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    second_admitted_in_time = condition.wait_for(
+        lock, std::chrono::seconds(3), [&] { return admitted >= 2; });
+  }
+  EXPECT_TRUE(decode_entered_in_time);
+  EXPECT_TRUE(second_admitted_in_time);
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    release_decode = true;
+  }
+  condition.notify_all();
+  first_emitter.join();
+  second_emitter.join();
+  bool second_finished_in_time = false;
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    second_finished_in_time = second_finished;
+  }
+  EXPECT_TRUE(second_finished_in_time);
+  EXPECT_EQ(keys, std::vector<std::string>{"second"});
+  EXPECT_GE(sink->Count(sitos::LogLevel::kError), 1U);
+
+  std::thread closer([&] {
+    subscription.Value().Close();
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      close_finished = true;
+    }
+    condition.notify_all();
+  });
+  bool close_finished_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    close_finished_in_time =
+        condition.wait_for(lock, std::chrono::seconds(3), [&] { return close_finished; });
+  }
+  closer.join();
+  EXPECT_TRUE(close_finished_in_time);
+}
+
 TEST(ParamStoreSubscribeTest, SubscriptionSurvivesParamStoreMoveAndDestruction) {
   auto transport = std::make_shared<FakeTransport>();
   int callbacks = 0;
@@ -756,6 +857,30 @@ TEST(ParamStoreSubscribeTest, RejectsMalformedBatchInputsWithoutCallbacks) {
   transport->EmitDelete("sitos/base/:batch");
   EXPECT_EQ(callbacks, 0);
   EXPECT_EQ(sink->Count(sitos::LogLevel::kWarning), 4U);
+}
+
+TEST(ParamStoreSubscribeTest, MalformedTransportKeyWarnsAndOutOfScopeIsSilent) {
+  auto sink = std::make_shared<CaptureSink>();
+  auto transport = std::make_shared<FakeTransport>();
+  sitos::ClientConfig config;
+  config.log_sink = sink;
+  auto store_result = sitos::ParamStore::Open(transport, config);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  int callbacks = 0;
+  auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange&) {
+    ++callbacks;
+  });
+  ASSERT_TRUE(subscription.IsOk());
+  transport->EmitPut("sitos/base/bad*key", sitos::ParamValue(true));
+  EXPECT_EQ(callbacks, 0);
+  EXPECT_EQ(sink->Count(sitos::LogLevel::kWarning), 1U);
+  transport->EmitPut("sitos/base/$batch", sitos::ParamValue(true));
+  EXPECT_EQ(callbacks, 0);
+  EXPECT_EQ(sink->Count(sitos::LogLevel::kWarning), 2U);
+  transport->EmitPut("sitos/session/other/value", sitos::ParamValue(true));
+  EXPECT_EQ(callbacks, 0);
+  EXPECT_EQ(sink->Count(sitos::LogLevel::kWarning), 2U);
 }
 
 TEST(ParamStoreSubscribeTest, RejectsMalformedOrdinaryPayloadsWithoutCallbacks) {

--- a/tests/unit/param_store_subscribe_test.cpp
+++ b/tests/unit/param_store_subscribe_test.cpp
@@ -6,6 +6,9 @@
 #include <gtest/gtest.h>
 
 #include <cstddef>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -13,6 +16,7 @@
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -172,6 +176,79 @@ TEST(ParamStoreSubscribeTest, CloseStopsDelivery) {
   subscription.Value().Close();
   transport->EmitPut("sitos/base/value", sitos::ParamValue(false));
   EXPECT_EQ(callback_count, 1);
+}
+
+TEST(ParamStoreSubscribeTest, CloseWaitsForBlockedCallback) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool entered = false;
+  bool release = false;
+  bool close_started = false;
+  std::atomic<bool> close_returned = false;
+  auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange&) {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      entered = true;
+    }
+    condition.notify_all();
+    std::unique_lock<std::mutex> lock(mutex);
+    condition.wait(lock, [&] { return release; });
+  });
+  ASSERT_TRUE(subscription.IsOk());
+
+  std::thread emitter([&] { transport->EmitPut("sitos/base/value", sitos::ParamValue(true)); });
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(3), [&] { return entered; }));
+  }
+  std::thread closer([&] {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      close_started = true;
+    }
+    condition.notify_all();
+    subscription.Value().Close();
+    close_returned.store(true, std::memory_order_release);
+  });
+  bool closer_started_in_time = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    closer_started_in_time = condition.wait_for(lock, std::chrono::seconds(3),
+                                                [&] { return close_started; });
+  }
+  EXPECT_TRUE(closer_started_in_time);
+  EXPECT_FALSE(close_returned.load(std::memory_order_acquire));
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    release = true;
+  }
+  condition.notify_all();
+  emitter.join();
+  closer.join();
+  EXPECT_TRUE(close_returned.load(std::memory_order_acquire));
+}
+
+TEST(ParamStoreSubscribeTest, ReentrantEmissionIsQueuedAfterCurrentCallback) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  std::vector<std::string> keys;
+  auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange& change) {
+    keys.push_back(change.key);
+    if (keys.size() == 1U) {
+      transport->EmitPut("sitos/base/reentrant", sitos::ParamValue(true));
+    }
+  });
+  ASSERT_TRUE(subscription.IsOk());
+  transport->EmitPut("sitos/base/first", sitos::ParamValue(true));
+  ASSERT_EQ(keys.size(), 2U);
+  EXPECT_EQ(keys[0], "first");
+  EXPECT_EQ(keys[1], "reentrant");
 }
 
 TEST(ParamStoreSubscribeTest, ValidationPrecedesDeclaration) {

--- a/tests/unit/param_store_subscribe_test.cpp
+++ b/tests/unit/param_store_subscribe_test.cpp
@@ -138,6 +138,8 @@ class FakeTransport final : public sitos::Transport {
     if (declaration_thread.joinable()) declaration_thread.join();
   }
 
+  void NotifyDeclarationProgress() { declaration_condition.notify_all(); }
+
   sitos::Result<sitos::Subscription> DeclareSubscriber(
       std::string_view keyexpr,
       std::function<void(const sitos::TransportSample&)> callback) override {
@@ -150,7 +152,12 @@ class FakeTransport final : public sitos::Transport {
     }
     if (sample_during_declaration.has_value()) {
       if (async_declaration_sample) {
-        declaration_thread = std::thread([callback, this] { callback(*sample_during_declaration); });
+        declaration_thread = std::thread(
+            [callback, this] { callback(*sample_during_declaration); });
+        if (declaration_callback_admitted) {
+          std::unique_lock<std::mutex> lock(declaration_mutex);
+          declaration_condition.wait(lock, [&] { return declaration_callback_admitted(); });
+        }
       } else {
         callback(*sample_during_declaration);
       }
@@ -174,6 +181,9 @@ class FakeTransport final : public sitos::Transport {
   std::optional<sitos::Result<sitos::Subscription>> declaration_error;
   bool async_declaration_sample = false;
   std::thread declaration_thread;
+  std::function<bool()> declaration_callback_admitted;
+  std::mutex declaration_mutex;
+  std::condition_variable declaration_condition;
 };
 
 sitos::TransportSample MakePutSample() {
@@ -905,6 +915,7 @@ TEST(ParamStoreSubscribeTest, CallbackExceptionsDoNotStopSubscription) {
 TEST(ParamStoreSubscribeTest, DeclarationFailureWaitsForAdmittedCallbackCopy) {
   auto transport = std::make_shared<FakeTransport>();
   transport->sample_during_declaration = MakePutSample();
+  transport->async_declaration_sample = true;
   transport->declaration_error = sitos::Result<sitos::Subscription>::Err(
       sitos::Status::Disconnected, "declaration failed", std::make_error_code(std::errc::io_error));
   auto store_result = sitos::ParamStore::Open(transport);
@@ -913,14 +924,17 @@ TEST(ParamStoreSubscribeTest, DeclarationFailureWaitsForAdmittedCallbackCopy) {
 
   std::mutex mutex;
   std::condition_variable condition;
-  bool hook_entered = false;
+  std::atomic<bool> hook_entered = false;
   bool release_hook = false;
   bool subscribe_finished = false;
   int callback_count = 0;
+  transport->declaration_callback_admitted =
+      [&] { return hook_entered.load(std::memory_order_acquire); };
   sitos::param_store_test_access::ParamStoreTestAccess::SetNativeEntryHook(store, [&] {
+    hook_entered.store(true, std::memory_order_release);
+    transport->NotifyDeclarationProgress();
     {
       std::lock_guard<std::mutex> lock(mutex);
-      hook_entered = true;
     }
     condition.notify_all();
     std::unique_lock<std::mutex> lock(mutex);
@@ -941,8 +955,9 @@ TEST(ParamStoreSubscribeTest, DeclarationFailureWaitsForAdmittedCallbackCopy) {
   bool hook_entered_in_time = false;
   {
     std::unique_lock<std::mutex> lock(mutex);
-    hook_entered_in_time = condition.wait_for(lock, std::chrono::seconds(3),
-                                               [&] { return hook_entered; });
+    hook_entered_in_time = condition.wait_for(lock, std::chrono::seconds(3), [&] {
+      return hook_entered.load(std::memory_order_acquire);
+    });
   }
   EXPECT_TRUE(hook_entered_in_time);
   {

--- a/tests/unit/param_store_subscribe_test.cpp
+++ b/tests/unit/param_store_subscribe_test.cpp
@@ -804,8 +804,16 @@ TEST(ParamStoreSubscribeTest, CloseDrainsPendingBatchAndBlocksPostCloseDiagnosti
   std::mutex mutex;
   std::condition_variable condition;
   bool entered = false;
+  bool close_admission = false;
   bool release = false;
   std::vector<std::string> keys;
+  sitos::param_store_test_access::ParamStoreTestAccess::SetLifecycleHooks(store, {}, [&] {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      close_admission = true;
+    }
+    condition.notify_all();
+  }, {});
   auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange& change) {
     {
       std::lock_guard<std::mutex> lock(mutex);
@@ -838,27 +846,19 @@ TEST(ParamStoreSubscribeTest, CloseDrainsPendingBatchAndBlocksPostCloseDiagnosti
     std::unique_lock<std::mutex> lock(mutex);
     entered_in_time = condition.wait_for(lock, std::chrono::seconds(3), [&] { return entered; });
   }
-  bool close_started = false;
   std::atomic<bool> close_returned = false;
-  std::mutex close_mutex;
-  std::condition_variable close_condition;
   std::thread closer([&] {
-    {
-      std::lock_guard<std::mutex> lock(close_mutex);
-      close_started = true;
-    }
-    close_condition.notify_all();
     subscription.Value().Close();
     close_returned.store(true, std::memory_order_release);
   });
-  bool close_started_in_time = false;
+  bool close_admission_in_time = false;
   {
-    std::unique_lock<std::mutex> lock(close_mutex);
-    close_started_in_time = close_condition.wait_for(
-        lock, std::chrono::seconds(3), [&] { return close_started; });
+    std::unique_lock<std::mutex> lock(mutex);
+    close_admission_in_time =
+        condition.wait_for(lock, std::chrono::seconds(3), [&] { return close_admission; });
   }
   EXPECT_TRUE(entered_in_time);
-  EXPECT_TRUE(close_started_in_time);
+  EXPECT_TRUE(close_admission_in_time);
   EXPECT_FALSE(close_returned.load(std::memory_order_acquire));
   {
     std::lock_guard<std::mutex> lock(mutex);

--- a/tests/unit/param_store_subscribe_test.cpp
+++ b/tests/unit/param_store_subscribe_test.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <atomic>
 #include <chrono>
@@ -21,6 +22,34 @@
 #include <vector>
 
 namespace {
+
+class CaptureSink final : public sitos::LogSink {
+ public:
+  explicit CaptureSink(bool throw_on_write = false) : throw_on_write_(throw_on_write) {}
+
+  void Write(const sitos::LogRecord& record) override {
+    if (throw_on_write_) throw std::runtime_error("log sink failed");
+    std::lock_guard<std::mutex> lock(mutex_);
+    levels.push_back(record.level);
+    messages.emplace_back(record.message);
+  }
+
+  std::size_t Count(sitos::LogLevel level) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return static_cast<std::size_t>(std::count(levels.begin(), levels.end(), level));
+  }
+
+  std::size_t Size() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return levels.size();
+  }
+
+ private:
+  bool throw_on_write_;
+  mutable std::mutex mutex_;
+  std::vector<sitos::LogLevel> levels;
+  std::vector<std::string> messages;
+};
 
 class FakeTransport final : public sitos::Transport {
  public:
@@ -253,17 +282,302 @@ TEST(ParamStoreSubscribeTest, ReentrantEmissionIsQueuedAfterCurrentCallback) {
   EXPECT_EQ(keys[1], "reentrant");
 }
 
+TEST(ParamStoreSubscribeTest, CapturesWarningsAndErrorsAndSupportsDisabledLogging) {
+  auto sink = std::make_shared<CaptureSink>();
+  auto transport = std::make_shared<FakeTransport>();
+  sitos::ClientConfig config;
+  config.log_sink = sink;
+  auto store_result = sitos::ParamStore::Open(transport, config);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  int callbacks = 0;
+  auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange&) {
+    ++callbacks;
+    throw std::runtime_error("callback failed");
+  });
+  ASSERT_TRUE(subscription.IsOk());
+  transport->EmitRaw("sitos/base/malformed", {}, std::string(sitos::Encoding::kSitosV1));
+  transport->EmitPut("sitos/base/unknown", sitos::ParamValue(true), "application/octet-stream");
+  EXPECT_EQ(callbacks, 1);
+  EXPECT_GE(sink->Count(sitos::LogLevel::kWarning), 2U);
+  EXPECT_EQ(sink->Count(sitos::LogLevel::kError), 1U);
+
+  auto disabled_transport = std::make_shared<FakeTransport>();
+  sitos::ClientConfig disabled_config;
+  disabled_config.log_sink = nullptr;
+  auto disabled_store_result = sitos::ParamStore::Open(disabled_transport, disabled_config);
+  ASSERT_TRUE(disabled_store_result.IsOk());
+  auto disabled_store = std::move(disabled_store_result).Value();
+  auto disabled_subscription = disabled_store.Subscribe(
+      "base", "", [](const sitos::ParamChange&) {});
+  ASSERT_TRUE(disabled_subscription.IsOk());
+  EXPECT_NO_THROW(disabled_transport->EmitRaw("sitos/base/malformed", {},
+                                               std::string(sitos::Encoding::kSitosV1)));
+}
+
+TEST(ParamStoreSubscribeTest, ThrowingLogSinkIsContained) {
+  auto sink = std::make_shared<CaptureSink>(true);
+  auto transport = std::make_shared<FakeTransport>();
+  sitos::ClientConfig config;
+  config.log_sink = sink;
+  auto store_result = sitos::ParamStore::Open(transport, config);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  auto subscription = store.Subscribe("base", "", [](const sitos::ParamChange&) {
+    throw std::runtime_error("callback failed");
+  });
+  ASSERT_TRUE(subscription.IsOk());
+  EXPECT_NO_THROW(transport->EmitRaw("sitos/base/malformed", {},
+                                     std::string(sitos::Encoding::kSitosV1)));
+  EXPECT_NO_THROW(transport->EmitPut("sitos/base/value", sitos::ParamValue(true)));
+}
+
+TEST(ParamStoreSubscribeTest, SubscriptionSurvivesParamStoreMoveAndDestruction) {
+  auto transport = std::make_shared<FakeTransport>();
+  int callbacks = 0;
+  std::optional<sitos::ParamSubscription> subscription;
+  {
+    auto store_result = sitos::ParamStore::Open(transport);
+    ASSERT_TRUE(store_result.IsOk());
+    auto store = std::move(store_result).Value();
+    auto result = store.Subscribe("base", "", [&](const sitos::ParamChange&) { ++callbacks; });
+    ASSERT_TRUE(result.IsOk());
+    subscription.emplace(std::move(result).Value());
+    auto moved_store = std::move(store);
+    EXPECT_FALSE(store.Put("base", "moved", sitos::ParamValue(true)).IsOk());
+  }
+  ASSERT_TRUE(subscription.has_value());
+  transport->EmitPut("sitos/base/value", sitos::ParamValue(true));
+  EXPECT_EQ(callbacks, 1);
+  subscription->Close();
+}
+
+TEST(ParamStoreSubscribeTest, ConcurrentRepeatedCloseIsSafe) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  auto subscription = store.Subscribe("base", "", [](const sitos::ParamChange&) {});
+  ASSERT_TRUE(subscription.IsOk());
+  std::vector<std::thread> closers;
+  for (int i = 0; i < 4; ++i) {
+    closers.emplace_back([&] { subscription.Value().Close(); });
+  }
+  for (auto& closer : closers) closer.join();
+  subscription.Value().Close();
+  EXPECT_NO_THROW(transport->EmitPut("sitos/base/after", sitos::ParamValue(true)));
+}
+
+TEST(ParamStoreSubscribeTest, RejectsMalformedBatchInputsWithoutCallbacks) {
+  auto sink = std::make_shared<CaptureSink>();
+  auto transport = std::make_shared<FakeTransport>();
+  sitos::ClientConfig config;
+  config.log_sink = sink;
+  auto store_result = sitos::ParamStore::Open(transport, config);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  int callbacks = 0;
+  auto subscription = store.Subscribe(
+      "base", "", [&](const sitos::ParamChange&) { ++callbacks; });
+  ASSERT_TRUE(subscription.IsOk());
+  auto valid_entries = std::vector<sitos::BatchEntry>{{"valid", sitos::ParamValue(true)}};
+  auto malformed = sitos::EncodeBatch(valid_entries);
+  malformed.pop_back();
+  transport->Emit(sitos::TransportSample{
+      "sitos/base/:batch", malformed,
+      sitos::Encoding{std::string(sitos::Encoding::kSitosV1Batch)}, std::nullopt,
+      sitos::TransportSample::Kind::Put});
+  auto invalid_entries =
+      std::vector<sitos::BatchEntry>{{"invalid*key", sitos::ParamValue(true)}};
+  const auto invalid_batch = sitos::EncodeBatch(invalid_entries);
+  transport->Emit(sitos::TransportSample{
+      "sitos/base/:batch", invalid_batch,
+      sitos::Encoding{std::string(sitos::Encoding::kSitosV1Batch)}, std::nullopt,
+      sitos::TransportSample::Kind::Put});
+  const auto wrong_encoding_batch = sitos::EncodeBatch(valid_entries);
+  transport->Emit(sitos::TransportSample{
+      "sitos/base/:batch", wrong_encoding_batch, sitos::Encoding{"application/octet-stream"},
+      std::nullopt, sitos::TransportSample::Kind::Put});
+  transport->EmitDelete("sitos/base/:batch");
+  EXPECT_EQ(callbacks, 0);
+  EXPECT_EQ(sink->Count(sitos::LogLevel::kWarning), 4U);
+}
+
+TEST(ParamStoreSubscribeTest, RejectsMalformedOrdinaryPayloadsWithoutCallbacks) {
+  auto sink = std::make_shared<CaptureSink>();
+  auto transport = std::make_shared<FakeTransport>();
+  sitos::ClientConfig config;
+  config.log_sink = sink;
+  auto store_result = sitos::ParamStore::Open(transport, config);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  int callbacks = 0;
+  auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange&) { ++callbacks; });
+  ASSERT_TRUE(subscription.IsOk());
+  transport->EmitRaw("sitos/base/value", {}, std::string(sitos::Encoding::kSitosV1));
+  transport->EmitRaw("sitos/base/value", sitos::ParamValue(true).Encode(),
+                     std::string(sitos::Encoding::kSitosV1Batch));
+  EXPECT_EQ(callbacks, 0);
+  EXPECT_EQ(sink->Count(sitos::LogLevel::kWarning), 2U);
+}
+
+TEST(ParamStoreSubscribeTest, RawPrefixBoundaryAndTrailingSlashArePreserved) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  std::vector<std::string> keys;
+  auto subscription = store.Subscribe("base", "foo/", [&](const sitos::ParamChange& change) {
+    keys.push_back(change.key);
+  });
+  ASSERT_TRUE(subscription.IsOk());
+  transport->EmitPut("sitos/base/foo", sitos::ParamValue(true));
+  transport->EmitPut("sitos/base/foo/bar", sitos::ParamValue(true));
+  transport->EmitPut("sitos/base/foobar", sitos::ParamValue(true));
+  ASSERT_EQ(keys.size(), 1U);
+  EXPECT_EQ(keys.front(), "foo/bar");
+}
+
+TEST(ParamStoreSubscribeTest, CloseDrainsPendingBatchAndBlocksPostCloseDiagnostics) {
+  auto sink = std::make_shared<CaptureSink>();
+  auto transport = std::make_shared<FakeTransport>();
+  sitos::ClientConfig config;
+  config.log_sink = sink;
+  auto store_result = sitos::ParamStore::Open(transport, config);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool entered = false;
+  bool release = false;
+  std::vector<std::string> keys;
+  auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange& change) {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      keys.push_back(change.key);
+      if (keys.size() == 1U) entered = true;
+    }
+    bool first = false;
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      first = keys.size() == 1U;
+    }
+    condition.notify_all();
+    if (first) {
+      std::unique_lock<std::mutex> lock(mutex);
+      condition.wait(lock, [&] { return release; });
+    }
+  });
+  ASSERT_TRUE(subscription.IsOk());
+  std::vector<sitos::BatchEntry> entries{
+      {"one", sitos::ParamValue(true)}, {"two", sitos::ParamValue(false)},
+      {"three", sitos::ParamValue(true)}};
+  std::thread emitter([&] {
+    transport->Emit(sitos::TransportSample{"sitos/base/:batch", sitos::EncodeBatch(entries),
+                                            sitos::Encoding{
+                                                std::string(sitos::Encoding::kSitosV1Batch)},
+                                            std::nullopt, sitos::TransportSample::Kind::Put});
+  });
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(3), [&] { return entered; }));
+  }
+  std::thread closer([&] { subscription.Value().Close(); });
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    release = true;
+  }
+  condition.notify_all();
+  emitter.join();
+  closer.join();
+  ASSERT_EQ(keys.size(), entries.size());
+  EXPECT_EQ(keys[0], "one");
+  EXPECT_EQ(keys[1], "two");
+  EXPECT_EQ(keys[2], "three");
+  const auto log_count = sink->Size();
+  transport->EmitRaw("sitos/base/after", {}, std::string(sitos::Encoding::kSitosV1));
+  EXPECT_EQ(sink->Size(), log_count);
+}
+
+TEST(ParamStoreSubscribeTest, ConcurrentNativeCallbacksAreSerialized) {
+  auto transport = std::make_shared<FakeTransport>();
+  auto store_result = sitos::ParamStore::Open(transport);
+  ASSERT_TRUE(store_result.IsOk());
+  auto store = std::move(store_result).Value();
+  constexpr int kEmitters = 4;
+  std::mutex mutex;
+  std::condition_variable condition;
+  int started = 0;
+  int callbacks = 0;
+  int active = 0;
+  int max_active = 0;
+  bool release = false;
+  auto subscription = store.Subscribe("base", "", [&](const sitos::ParamChange&) {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      ++active;
+      ++callbacks;
+      max_active = std::max(max_active, active);
+    }
+    condition.notify_all();
+    std::unique_lock<std::mutex> lock(mutex);
+    condition.wait(lock, [&] { return release; });
+    --active;
+    lock.unlock();
+    condition.notify_all();
+  });
+  ASSERT_TRUE(subscription.IsOk());
+  std::vector<std::thread> emitters;
+  for (int i = 0; i < kEmitters; ++i) {
+    emitters.emplace_back([&, i] {
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        ++started;
+      }
+      condition.notify_all();
+      transport->EmitPut("sitos/base/value" + std::to_string(i), sitos::ParamValue(true));
+    });
+  }
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(condition.wait_for(lock, std::chrono::seconds(3),
+                                   [&] { return started == kEmitters; }));
+  }
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    release = true;
+  }
+  condition.notify_all();
+  for (auto& emitter : emitters) emitter.join();
+  EXPECT_EQ(callbacks, kEmitters);
+  EXPECT_EQ(max_active, 1);
+}
+
 TEST(ParamStoreSubscribeTest, ValidationPrecedesDeclaration) {
   auto transport = std::make_shared<FakeTransport>();
   auto store_result = sitos::ParamStore::Open(transport);
   ASSERT_TRUE(store_result.IsOk());
   auto store = std::move(store_result).Value();
+  auto empty_callback = store.Subscribe("base", "", {});
+  EXPECT_FALSE(empty_callback.IsOk());
+  EXPECT_EQ(empty_callback.StatusCode(), sitos::Status::InvalidArgument);
   auto snapshot = store.Subscribe("snap/session", "", [](const sitos::ParamChange&) {});
   EXPECT_FALSE(snapshot.IsOk());
   EXPECT_EQ(snapshot.StatusCode(), sitos::Status::InvalidArgument);
+  auto malformed_scope = store.Subscribe("session", "", [](const sitos::ParamChange&) {});
+  EXPECT_FALSE(malformed_scope.IsOk());
+  EXPECT_EQ(malformed_scope.StatusCode(), sitos::Status::InvalidKey);
+  auto malformed_session = store.Subscribe("session/bad$id", "",
+                                            [](const sitos::ParamChange&) {});
+  EXPECT_FALSE(malformed_session.IsOk());
+  EXPECT_EQ(malformed_session.StatusCode(), sitos::Status::InvalidKey);
   auto malformed = store.Subscribe("base", "bad*prefix", [](const sitos::ParamChange&) {});
   EXPECT_FALSE(malformed.IsOk());
   EXPECT_EQ(malformed.StatusCode(), sitos::Status::InvalidKey);
+  auto moved_store = std::move(store);
+  auto moved_from = store.Subscribe("base", "", [](const sitos::ParamChange&) {});
+  EXPECT_FALSE(moved_from.IsOk());
+  EXPECT_EQ(moved_from.StatusCode(), sitos::Status::InvalidArgument);
   EXPECT_EQ(transport->declaration_count, 0);
 }
 

--- a/tests/unit/param_store_subscribe_test.cpp
+++ b/tests/unit/param_store_subscribe_test.cpp
@@ -33,7 +33,8 @@ class FakeTransport final : public sitos::Transport {
     return sitos::Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
   }
 
-  sitos::Result<void> Get(std::string_view, const QueryResultSink&, std::chrono::milliseconds) override {
+  sitos::Result<void> Get(std::string_view, const QueryResultSink&,
+                          std::chrono::milliseconds) override {
     return sitos::Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
   }
 
@@ -149,7 +150,8 @@ TEST(ParamStoreSubscribeTest, BatchPreservesOrderAndDuplicates) {
   entries.push_back({"foo/one", sitos::ParamValue(std::int64_t{3})});
   auto payload = sitos::EncodeBatch(entries);
   transport->Emit(sitos::TransportSample{"sitos/base/:batch", payload,
-                                          sitos::Encoding{std::string(sitos::Encoding::kSitosV1Batch)},
+                                          sitos::Encoding{
+                                              std::string(sitos::Encoding::kSitosV1Batch)},
                                           std::nullopt, sitos::TransportSample::Kind::Put});
 
   ASSERT_EQ(changes.size(), 3U);

--- a/tests/unit/param_store_subscribe_test.cpp
+++ b/tests/unit/param_store_subscribe_test.cpp
@@ -168,10 +168,10 @@ class FakeTransport final : public sitos::Transport {
   sitos::Result<sitos::Subscription> DeclareSubscriber(
       std::string_view keyexpr,
       std::function<void(const sitos::TransportSample&)> callback) override {
-    ++declaration_count;
-    declared_keyexpr = std::string(keyexpr);
     {
       std::lock_guard<std::mutex> lock(mutex);
+      ++declaration_count;
+      declared_keyexpr = std::string(keyexpr);
       subscribers.push_back(callback);
       subscriber_selectors.emplace_back(keyexpr);
       subscriber = callback;
@@ -188,7 +188,9 @@ class FakeTransport final : public sitos::Transport {
         callback(*sample_during_declaration);
       }
     }
-    if (declaration_error.has_value()) return std::move(*declaration_error);
+    if (declaration_error.has_value()) {
+      return sitos::Result<sitos::Subscription>::ErrFrom(*declaration_error);
+    }
     return sitos::Result<sitos::Subscription>::Ok(sitos::Subscription{});
   }
 
@@ -196,6 +198,16 @@ class FakeTransport final : public sitos::Transport {
       std::string_view, std::function<void(sitos::TransportQuery&)>) override {
     return sitos::Result<sitos::Queryable>::Err(
         std::make_error_code(std::errc::operation_not_supported));
+  }
+
+  int DeclarationCount() {
+    std::lock_guard<std::mutex> lock(mutex);
+    return declaration_count;
+  }
+
+  std::string DeclaredKeyexpr() {
+    std::lock_guard<std::mutex> lock(mutex);
+    return declared_keyexpr;
   }
 
   std::string declared_keyexpr;
@@ -1386,7 +1398,7 @@ TEST(ParamStoreSubscribeTest, ValidationPrecedesDeclaration) {
   auto moved_and_malformed = store.Subscribe("bad scope", "bad*prefix", {});
   EXPECT_FALSE(moved_and_malformed.IsOk());
   EXPECT_EQ(moved_and_malformed.StatusCode(), sitos::Status::InvalidArgument);
-  EXPECT_EQ(transport->declaration_count, 0);
+  EXPECT_EQ(transport->DeclarationCount(), 0);
 }
 
 TEST(ParamStoreSubscribeTest, CallbackExceptionsDoNotStopSubscription) {


### PR DESCRIPTION
## Summary

Closes #16

- Add the move-only, callback-quiescent `ParamSubscription` C++ API.
- Stage declaration-time samples, decode ordinary and canonical `:batch` samples, and deliver ordered owned PUT/DELETE changes through a single-flight drainer.
- Add client-level injectable `LogSink`, callback exception containment, same-session Zenoh integration coverage, and Accepted ADR-0030.

## Original scope checklist

- [x] `Subscribe(scope, prefix, cb) -> SubscriptionHandle`
- [x] Return `ParamChange{kind: Put/Delete, key, value}`
- [x] Subscription lifecycle is Transport-managed RAII

## Requirements and contract registry

- Implements F13. Python callback/GIL behavior remains Issue #26.
- Reuses existing key-space, Encoding, payload-v1, and batch-v1 registry rows.
- Contract Registry: N/A; no new wire surface or stable persisted identifier.
- ADR-0030 was owner-accepted on 2026-07-26. ADR-0029 remains reserved for #106.

## TDD evidence and provenance

The first acceptance-test commit was `1de2692` before production code. The canonical Zenoh-ON RED
build failed because the requested API did not exist:

```text
tests/unit/param_store_subscribe_test.cpp(70): error C2039: 'ParamChange': 'sitos' has no member
tests/unit/param_store_subscribe_test.cpp(71): error C2039: 'Subscribe': 'sitos::ParamStore' has no member
```

The prerequisite native subscriber-lifetime regression was added before ParamSubscription production
code. Its first harness timed out because publication was called synchronously on the test thread;
the corrected test moved publication to a separate publisher thread. This is recorded honestly as a
harness correction, not fabricated RED evidence.

The additional coverage in commits `36049c6`, `848d2e8`, `d30d26a`, `395d39f`, `672aab9`,
`a5fbac1`, `09698b6`, `35c954a`, `00f6e12`, `59e5e6d`, `0ac368a`, `cec700e`, and `69e058e` were review-driven and added after production
code; they are not claimed as pre-production RED. The production refactor commit `cec700e` precedes
the test/contract commit `69e058e`; the owner-approved Issue #16-only TDD-order exception is
recorded on the Issue and PR.

## Native lifetime prerequisite

`SubscriptionTest.ResetPreservesEnteredSubscriberCallbackLifetime` passes with the corrected
publisher-thread handshake. It races reset/destruction with an entered callback and joins
publisher/reset threads without requiring reset to block. It passes in the focused and full Zenoh-ON
suites.

## Acceptance verification

- Declaration-time samples are staged and drained only after successful declaration.
- Declaration failures preserve Status/message/cause and invoke zero callbacks.
- Raw-prefix boundary/trailing-slash filtering, ordinary DELETE, unknown-Encoding BYTES fallback,
  malformed known payload handling, canonical batch order, duplicates, malformed/invalid/wrong-
  Encoding/batch-DELETE rejection, and ordinary-key batch-Encoding rejection are covered.
- Capture and throwing LogSink behavior plus nullptr logging disablement are covered.
- Callback exceptions are contained through `EmitLog` and later delivery continues.
- Subscription survival after ParamStore move/destruction, concurrent/repeated Close, blocked callback
  Close quiescence, pending full-batch drain, callback serialization, and no post-Close diagnostics
  are covered.
- Same-session Zenoh integration observes valid PUT, unknown-Encoding exact BYTES, valid DELETE,
  canonical batch order/duplicates, and uses a separate control subscriber that copies concrete keys
  under mutex to prove exact post-Close wire delivery without a ParamSubscription callback.
- An internal non-installed test seam deterministically holds an admitted declaration callback while
  declaration returns an error, proving FailStaging waits before discarding staged work.
- Close admission and native-reset progression, admitted-sample delivery, concurrent Close,
  independent subscription queues, ownership release, combined validation precedence, and
  valid-leading/invalid-later batch rejection are covered with condition-variable handshakes.
- Public header is self-contained and has direct consumer compilation coverage.
- Internal decode failure completion/continuation and malformed/reserved-key warning versus
  out-of-scope silence are covered with non-installed test seams.
- Public Doxygen states that same-callback Close, destruction, and move assignment are forbidden.

## Validation

- Zenoh-OFF focused review suite: 28/28 passed.
- Zenoh-OFF full CTest: 306/306 passed.
- Zenoh-ON focused review suite at exact head `69e058e`: 37/37 passed.
- Zenoh-ON full CTest at exact head `69e058e`: 356/356 passed.
- GCC portability fix: removed obsolete `control_baseline`; exact-key control predicate remains mutex-safe.
- Sol round 6: pending-batch test waits for actual Close admission, final callback entry, and release
  barriers before asserting ordered drain and post-Close diagnostic suppression.
- Refreshed package validation after the final test/seam changes: clean install, relocation, OFF/ON
  consumers passed.
- `git diff --check`: passed.
- Windows MSVC/Ninja builds passed for Zenoh OFF and canonical Zenoh ON.

The review-only coverage remains truthfully classified as post-production review-driven coverage;
it is not claimed as pre-production RED. Linux sanitizer execution was not available in the local
Windows environment; the new fake-Transport
focused test is included in the CI sanitizer regex, and GitHub sanitizer jobs remain required.

## Terra round 4 follow-up

Commit `2388311` adds a Zenoh-only, non-installed `SubscriptionTestAccess` observer owned by each
native `Subscription::Impl`. The production `Subscription::Reset()` path invokes it immediately
before native subscriber drop; observer exceptions are contained at the `noexcept` boundary and the
unset hook is inert. The lifetime regression waits for that production observation, verifies Reset
has not returned while the callback remains blocked, then releases the callback and joins both
threads on every timeout/failure path. The public Doxygen now forbids Close, destruction, and move
assignment from either the subscription's `ParamCallback` or its owned `LogSink::Write` context.

This round's changes are review-driven and are not claimed as pre-production RED evidence. At exact
head `2388311`, the lifetime regression passed 10 consecutive repetitions, Zenoh-ON focused CTest
passed 37/37, Zenoh-ON full CTest passed 356/356, Zenoh-OFF focused tests passed 28/28, and
`git diff --check` passed.

## Opus findings 1 and 4 follow-up

Commit `3ff8af4` isolates all five review-only subscription hooks from the installed public
`ParamStore` header. A nullable internal `SubscriptionTestHooks` aggregate is stored behind
`DeclarationControl`, copied on write under its mutex, and snapshotted into each subscription as a
`shared_ptr<const ...>`. Close clears that pointer after quiescence. Hook invocation uses one
exception-contained helper, including the `noexcept` CloseState path, while preserving existing
lock ordering. ParamStore move construction and assignment are defaulted again in the public header;
no public test-hook storage remains.

This is review-driven refactoring and is not claimed as pre-production RED evidence. At exact head
`3ff8af4`, Zenoh-OFF focused tests passed 28/28, canonical Zenoh-ON focused tests passed 37/37,
Zenoh-ON full CTest passed 356/356, installed CMake package validation passed, an external installed
consumer compiled, the installed ParamStore header contained no hook storage, commit metadata audit
passed, and `git diff --check` passed.

## Sonar empty-handler follow-up

Commit `8627135` applies the five approved empty-handler findings only. It replaces the template
and on-error lambda design with `InvokeSilentTestHook` for silently contained native/lifecycle hooks
and `InvokeDecodeTestHook` for decode-hook exceptions, which logs standard and non-standard failures
through the now-`noexcept` `Error` wrapper. Absent and successful hooks still return true; lifecycle
exceptions remain silent and contained, decode exceptions remain logged and complete the WorkItem,
and no exception escapes `CloseState noexcept`. The intentional S6012 lock_guard finding was not
changed.

This is review-driven cleanup and is not claimed as pre-production RED evidence. At exact head
`8627135`, Zenoh-OFF focused tests passed 28/28, canonical Zenoh-ON focused tests passed 37/37,
and `git diff --check` passed.

## ADR acceptance

Commit `7276715` records the owner-approved acceptance of ADR-0030 on 2026-07-26, aligns its
`Options Considered` heading with the ADR template, and removes stale Proposed references from the
architecture and issue-breakdown documents.

## Residual risks

- Native subscriber closure safety is empirically covered for the pinned zenoh-c runtime, while the
  low-level Transport contract remains implementation-specific.
- No Python callback API, acknowledgement semantics, reconnect behavior, worker thread, queue limit,
  or overflow policy is introduced.










