### PR TITLE
docs(roadmap): remove stale v0.4 documentation (#123)

### DIFF
--- a/docs/04_api_cpp.md
+++ b/docs/04_api_cpp.md
@@ -215,10 +215,6 @@ public:
     Result<void> Start(std::shared_ptr<StorageEngine> engine, Transport& transport,
                        Config config);
 
-    /// In-process direct access to engine (no zenoh round trip).
-    /// For fast reads in the host process (controller/orchestrator).
-    const StorageEngine& engine() const;
-
     // ---- session management (equivalent to SessionController) ----
     Result<void> CreateSession(std::string_view sid);   // [F05]
     Result<void> CloseSession(std::string_view sid);    // [F10]

--- a/docs/05_api_python.md
+++ b/docs/05_api_python.md
@@ -205,6 +205,5 @@ Wheel structure and build are described in [06_build_test_packaging.md](06_build
 The standard wheel installed by `pip install sitos` bundles InMemoryEngine + zenoh-c,
 and has only NumPy as an additional runtime dependency (simplified as a required dependency,
 not optional `sitos[numpy]`) [P03].
-RocksDBEngine is provided as a `sitos-rocksdb` wheel or as a future optional extra.
 
 (END OF DOCUMENT)

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -40,8 +40,6 @@ sitos/
   - **zenoh-c**: First choice is to use official prebuilt releases via
     `find_package(zenohc)`. CI pins versions with FetchContent.
     Also provide a Corrosion (Rust) path for environments that need source builds
-  - **RocksDB** (when `SITOS_WITH_ROCKSDB=ON`): `find_package(RocksDB)`.
-    Supplied by vcpkg / apt / brew
   - **gtest / benchmark**: FetchContent
 * Presets: define `dev-windows`, `dev-linux`, `release`, and `python-wheel` in
   `CMakePresets.json`
@@ -128,8 +126,7 @@ the check derives the CMake version and rejects RocksDB, GoogleTest, GoogleMock,
 and build-tree artifacts and requires `_sitos` plus exactly one zenoh-c runtime. The installed wheel
 does not require Rust, CMake, Ninja, or a C++ compiler.
 
-RocksDBEngine is separated as a `sitos-rocksdb` wheel or a future optional extra. Runtime dependency:
-`numpy>=2.0`.
+The standard wheel runtime dependency is `numpy>=2.0`.
 
 ## 5. Test strategy
 

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -40,6 +40,7 @@ sitos/
   - **zenoh-c**: First choice is to use official prebuilt releases via
     `find_package(zenohc)`. CI pins versions with FetchContent.
     Also provide a Corrosion (Rust) path for environments that need source builds
+  - **RocksDB** (when `SITOS_WITH_ROCKSDB=ON`): `find_package(RocksDB)`.
   - **gtest / benchmark**: FetchContent
 * Presets: define `dev-windows`, `dev-linux`, `release`, and `python-wheel` in
   `CMakePresets.json`

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -18,7 +18,7 @@ Milestone = release boundary).
 | **v0.1** | The zenoh-independent core works. Payload fixtures and InMemoryEngine contract tests are green | #1, #4, #5, #6, #7 |
 | **v0.2** | StorageNode/ParamStore/ParamCache work in C++ through same-process zenoh sessions | #2, #3, #9–#13, #15, #18, #19, #21 |
 | **v0.3** | Basic Python APIs work (InMemory, ParamStore, ParamCache, NumPy read) | #16, #22, #23, #24, #25, #27 |
-| **v0.4** | Cross-platform vcpkg foundation, RocksDB engine, raw-Zenoh interop, session-scoped buffers, benchmarks, and C++/Python examples are in place | #122, #8, #29, #31, #32, #33, #56 |
+| **v0.4** | Cross-platform vcpkg foundation, RocksDB engine, process-isolated raw-Zenoh interop, session-scoped buffers, benchmarks, and C++/Python examples are in place | #122, #8, #29, #31, #32, #33, #56 |
 | **v0.5** | Reliable and durable session-buffer delivery is ready for downstream application integration | #14, #17, #99, #105–#109 |
 | **v1.0** | Public OSS quality, reconnect recovery, advanced Python extensions, raw batch/ack interop, documentation, and publication readiness are complete | #20, #26, #28, #30, #34, #35 |
 

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -18,12 +18,15 @@ Milestone = release boundary).
 | **v0.1** | The zenoh-independent core works. Payload fixtures and InMemoryEngine contract tests are green | #1, #4, #5, #6, #7 |
 | **v0.2** | StorageNode/ParamStore/ParamCache work in C++ through same-process zenoh sessions | #2, #3, #9–#13, #15, #18, #19, #21 |
 | **v0.3** | Basic Python APIs work (InMemory, ParamStore, ParamCache, NumPy read) | #16, #22, #23, #24, #25, #27 |
-| **v0.4** | RocksDB, single-value interop, bench, examples, and session-scoped buffers are in place | #8, #29, #31, #32, #33, #56 |
+| **v0.4** | RocksDB, single-value interop, bench, examples, and session-scoped buffers are in place | #122, #8, #29, #31, #32, #33, #56 |
 | **v0.5** | Reliable and durable session-buffer delivery is ready for downstream application integration | #14, #17, #99, #105–#109 |
 | **v1.0** | Public OSS quality, reconnect recovery, advanced Python extensions, raw batch/ack interop, documentation, and publication readiness are complete | #20, #26, #28, #30, #34, #35 |
 
 `ack`-related work (#14, #17) is useful, but implementation is heavy relative to initial value,
 so it is not a v0.2 blocker. Include it by v0.5.
+
+For v0.4, #122 precedes #8; #8 precedes the RocksDB-dependent #31, #33, and #56; #29 precedes
+raw-Zenoh consumers such as #32 and #56.
 
 ---
 

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -18,7 +18,7 @@ Milestone = release boundary).
 | **v0.1** | The zenoh-independent core works. Payload fixtures and InMemoryEngine contract tests are green | #1, #4, #5, #6, #7 |
 | **v0.2** | StorageNode/ParamStore/ParamCache work in C++ through same-process zenoh sessions | #2, #3, #9–#13, #15, #18, #19, #21 |
 | **v0.3** | Basic Python APIs work (InMemory, ParamStore, ParamCache, NumPy read) | #16, #22, #23, #24, #25, #27 |
-| **v0.4** | RocksDB, single-value interop, bench, examples, and session-scoped buffers are in place | #122, #8, #29, #31, #32, #33, #56 |
+| **v0.4** | Cross-platform vcpkg foundation, RocksDB engine, raw-Zenoh interop, session-scoped buffers, benchmarks, and C++/Python examples are in place | #122, #8, #29, #31, #32, #33, #56 |
 | **v0.5** | Reliable and durable session-buffer delivery is ready for downstream application integration | #14, #17, #99, #105–#109 |
 | **v1.0** | Public OSS quality, reconnect recovery, advanced Python extensions, raw batch/ack interop, documentation, and publication readiness are complete | #20, #26, #28, #30, #34, #35 |
 

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -197,7 +197,5 @@ The following must not change after zenoh updates:
 ## 7. RocksDB / Python dependencies
 
 As with zenoh, monitor RocksDB and Python packaging with locked versions + latest CI.
-However, RocksDB is optional (`sitos-rocksdb`) and must not impair availability of the standard
-wheel.
 
 (END OF DOCUMENT)

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -197,5 +197,6 @@ The following must not change after zenoh updates:
 ## 7. RocksDB / Python dependencies
 
 As with zenoh, monitor RocksDB and Python packaging with locked versions + latest CI.
+However, RocksDB is optional and must not impair availability of the standard wheel.
 
 (END OF DOCUMENT)


### PR DESCRIPTION
Closes #123

## Summary

- Removed the nonexistent `StorageNode::engine()` accessor guidance from the C++ API document.
- Removed stale `sitos-rocksdb` wheel ownership claims from the Python API, packaging, and dependency-policy documents.
- Removed the stale `vcpkg / apt / brew` provider enumeration while preserving the provider-neutral `find_package(RocksDB)` consumption boundary.
- Removed stale `sitos-rocksdb` ownership while retaining the policy that optional RocksDB must not impair the standard wheel.
- Added #122 to the v0.4 required-Issue set, aligned the target description with the milestone, and recorded the corrected dependency order: #122 before #8, #8 before RocksDB-dependent #31/#33/#56, and #29 before raw-Zenoh consumers.

## Issue checklist

- [x] Remove nonexistent `StorageNode::engine()` guidance.
- [x] Remove or defer stale `sitos-rocksdb` wheel ownership claims in docs/05, docs/06, and docs/09.
- [x] Remove the stale `vcpkg / apt / brew` provider enumeration without pre-publishing ADR-0031 policy.
- [x] Add #122 and the corrected dependency order to docs/07.
- [x] Preserve unrelated content and limit the diff to the five authorized documentation files.

## Requirements

- **Requirements: N/A** — Issue #123 is documentation-state cleanup with no F/N/C/P/X requirement mapping.

## TDD and evidence provenance

This is documentation-state cleanup, not behavioral implementation. No behavioral RED test is claimed. The required pre-edit focused searches were captured before editing:

```text
StorageNode::engine
(no matches from: rg -n -F 'StorageNode::engine' docs)

sitos-rocksdb
 docs/06_build_test_packaging.md:131:RocksDBEngine is separated as a `sitos-rocksdb` wheel or a future optional extra. Runtime dependency:
 docs/05_api_python.md:208:RocksDBEngine is provided as a `sitos-rocksdb` wheel or as a future optional extra.
 docs/09_dependency_policy.md:200:However, RocksDB is optional (`sitos-rocksdb`) and must not impair availability of the standard

vcpkg / apt / brew
 docs/06_build_test_packaging.md:44:    Supplied by vcpkg / apt / brew
```

The broader pre-edit inspection also identified the C++ declaration as `const StorageEngine& engine() const;` in docs/04; that declaration is removed by this PR.

## AC verification logs

### AC1–AC3: stale guidance and provider text are absent

```text
$ git grep -n -E 'StorageNode::engine\(\)|const StorageEngine& engine\(\) const|sitos-rocksdb|vcpkg / apt / brew' -- docs
(no matches; git grep exit 1 means no match)
```

Expected no-match status was observed. No ADR-0031 provider, pin, triplet, or cache policy text was added. The valid pre-existing constraints were independently retained:

```text
$ git grep -n -F 'find_package(RocksDB)' -- docs/06_build_test_packaging.md
docs/06_build_test_packaging.md:43:  - **RocksDB** (when `SITOS_WITH_ROCKSDB=ON`): `find_package(RocksDB)`.

$ git grep -n -F 'RocksDB is optional and must not impair availability of the standard wheel.' -- docs/09_dependency_policy.md
docs/09_dependency_policy.md:200:However, RocksDB is optional and must not impair availability of the standard wheel.
```

Both preservation checks exited 0.

### AC4: v0.4 required set and dependency order

```text
$ git grep -n -A2 -F 'For v0.4, #122 precedes #8' -- docs/07_issue_breakdown.md
docs/07_issue_breakdown.md:28:For v0.4, #122 precedes #8; #8 precedes the RocksDB-dependent #31, #33, and #56; #29 precedes
docs/07_issue_breakdown.md-29-raw-Zenoh consumers such as #32 and #56.
docs/07_issue_breakdown.md-30-

$ git grep -n -F '| **v0.4** |' -- docs/07_issue_breakdown.md
docs/07_issue_breakdown.md:21:| **v0.4** | Cross-platform vcpkg foundation, RocksDB engine, process-isolated raw-Zenoh interop, session-scoped buffers, benchmarks, and C++/Python examples are in place | #122, #8, #29, #31, #32, #33, #56 |
```

Both commands exited 0.

### AC5: changed-file boundary

```text
$ git diff --name-only origin/main...HEAD
docs/04_api_cpp.md
docs/05_api_python.md
docs/06_build_test_packaging.md
docs/07_issue_breakdown.md
docs/09_dependency_policy.md
```

Command exited 0; exactly the five authorized documentation files changed.

### AC6: links and diff hygiene

```text
$ python C:/Users/tetet/AppData/Local/Temp/issue123_check_links.py
checked 5 changed Markdown files; all relative links resolve

$ git diff --check origin/main...HEAD
(no output; exit 0)
```

The link checker parsed relative Markdown links in each of the five changed files, resolved each target relative to its source file, and exited nonzero on any missing target. Both validations exited 0.

No tests were added or updated because this PR changes documentation only.

## Opus review dispositions

1. **Accepted and fixed:** restored the provider-neutral `find_package(RocksDB)` line; only the stale provider enumeration remains removed.
2. **Accepted and fixed:** restored the valid optional-RocksDB/standard-wheel availability policy without the stale `sitos-rocksdb` owner.
3. **Accepted as a governance finding without widening this PR:** the `SessionController` term remains a conceptual architecture label, not a public API type. Ownership is recorded on #31 at https://github.com/tetsuh/sitos/issues/31#issuecomment-5083912361 and cross-referenced by #121 and #123. Issue #31 owns later example/documentation terminology clarification.
4. **Accepted and fixed:** aligned the `docs/07_issue_breakdown.md` v0.4 target description with the GitHub milestone.

## Sol follow-up disposition

- **Accepted and fixed** in `4482cdd`: the v0.4 target now states **process-isolated raw-Zenoh interop**, preserving the accepted topology constraint from the GitHub milestone rather than the broader `raw-Zenoh interop` wording.

## Current-main synchronization

- `35b4c40` merges current `main`, including Issue #125's bounded TSan lifecycle fix, without changing this PR's five-file documentation diff.
- All 16 exact-head checks passed against the current main branch, including the bounded repeated TSan lifecycle job, ASan/UBSan, Linux/Windows builds and packages, Linux/Windows wheels, CodeQL, CodeRabbit, and SonarCloud.
- The prior cancelled TSan result is superseded by the successful exact-head job: https://github.com/tetsuh/sitos/actions/runs/30223635881/job/89850214758

## Contract / ADR assessment

- Contract Registry: **N/A** — no wire surface, stable identifier, API contract, or registry row changes.
- No ADR is needed for removal of stale documentation.
- #121 remains open as the milestone governance gate and is not closed by this PR.
- ADR-0031 and ADR-0032 policy is not pre-published or treated as accepted by this PR.

## Commits

- `6aace67 docs(roadmap): remove stale v0.4 documentation (#123)`
- `90accd7 docs(roadmap): preserve valid dependency guidance (#123)`
- `4482cdd docs(roadmap): state raw-Zenoh process isolation (#123)`
- `35b4c40 chore(docs): sync sanitizer fix from main (#123)`





