### PR TITLE
test(store): fix intermittent subscription TSan hangs (#125)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,18 @@ jobs:
       - name: Build
         run: cmake --build build/sanitizer-${{ matrix.name }} --parallel 2
 
+      - name: Stress subscription lifecycle under TSan
+        if: matrix.name == 'tsan'
+        env:
+          TSAN_OPTIONS: halt_on_error=1
+        run: |
+          ctest --test-dir build/sanitizer-tsan --output-on-failure --timeout 60 \
+            --repeat until-fail:100 \
+            -R 'ParamStoreSubscribeTest.(CloseWaitsForBlockedCallback|DeclarationFailureWaitsForAdmittedCallbackCopy)'
+          ctest --test-dir build/sanitizer-tsan --output-on-failure --timeout 60 \
+            --repeat until-fail:10 \
+            -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|TransportGetCompletionTest|ParamStoreSubscribeTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
+
       - name: Run lifecycle tests
         env:
           TSAN_OPTIONS: halt_on_error=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
 
   lifecycle-sanitizers:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       contents: read
     strategy:
@@ -143,7 +144,7 @@ jobs:
           UBSAN_OPTIONS: halt_on_error=1
         run: >-
           ctest --test-dir build/sanitizer-${{ matrix.name }}
-          --output-on-failure -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|TransportGetCompletionTest|ParamStoreSubscribeTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
+          --output-on-failure --timeout 60 -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|TransportGetCompletionTest|ParamStoreSubscribeTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
 
   build-windows:
     runs-on: windows-latest

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -190,6 +190,10 @@ ctest --test-dir build/asan --output-on-failure --timeout 60 \
   -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|TransportGetCompletionTest|ParamStoreSubscribeTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
 ```
 
+The TSan CI lane additionally repeats the two subscription lifecycle regressions 100 times and the
+complete lifecycle selection 10 times. Each sanitizer test has a 60-second CTest timeout, and each
+sanitizer job has a 15-minute timeout.
+
 For a platform where the zenoh-c standalone runtime supports sanitizer instrumentation,
 repeat the ASan/UBSan configuration with `-DSITOS_WITH_ZENOH=ON` and run the lifecycle
 integration targets. The CI sanitizer job uses zenoh OFF to keep TSan independent of

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -180,13 +180,13 @@ zenoh-independent fake-Transport paths; ASan/UBSan runs the same paths separatel
 cmake -S . -B build/tsan -G Ninja -DCMAKE_BUILD_TYPE=Debug \
   -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF -DSITOS_ENABLE_TSAN=ON
 cmake --build build/tsan
-ctest --test-dir build/tsan --output-on-failure \
+ctest --test-dir build/tsan --output-on-failure --timeout 60 \
   -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|TransportGetCompletionTest|ParamStoreSubscribeTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
 
 cmake -S . -B build/asan -G Ninja -DCMAKE_BUILD_TYPE=Debug \
   -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF -DSITOS_ENABLE_ASAN_UBSAN=ON
 cmake --build build/asan
-ctest --test-dir build/asan --output-on-failure \
+ctest --test-dir build/asan --output-on-failure --timeout 60 \
   -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|TransportGetCompletionTest|ParamStoreSubscribeTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
 ```
 

--- a/tests/unit/param_store_subscribe_test.cpp
+++ b/tests/unit/param_store_subscribe_test.cpp
@@ -159,11 +159,20 @@ class FakeTransport final : public sitos::Transport {
                                 sitos::TransportSample::Kind::Delete});
   }
 
-  ~FakeTransport() {
+  ~FakeTransport() { JoinDeclarationThread(); }
+
+  void JoinDeclarationThread() {
     if (declaration_thread.joinable()) declaration_thread.join();
   }
 
-  void NotifyDeclarationProgress() { declaration_condition.notify_all(); }
+  void MarkDeclarationCallbackAdmitted() {
+    // The predicate update must use the waiter's mutex to prevent a lost notification.
+    {
+      std::lock_guard<std::mutex> lock(declaration_mutex);
+      declaration_callback_admitted = true;
+    }
+    declaration_condition.notify_all();
+  }
 
   sitos::Result<sitos::Subscription> DeclareSubscriber(
       std::string_view keyexpr,
@@ -178,11 +187,15 @@ class FakeTransport final : public sitos::Transport {
     }
     if (sample_during_declaration.has_value()) {
       if (async_declaration_sample) {
+        if (wait_for_declaration_callback_admission) {
+          std::lock_guard<std::mutex> lock(declaration_mutex);
+          declaration_callback_admitted = false;
+        }
         declaration_thread = std::thread(
             [callback, this] { callback(*sample_during_declaration); });
-        if (declaration_callback_admitted) {
+        if (wait_for_declaration_callback_admission) {
           std::unique_lock<std::mutex> lock(declaration_mutex);
-          declaration_condition.wait(lock, [&] { return declaration_callback_admitted(); });
+          declaration_condition.wait(lock, [&] { return declaration_callback_admitted; });
         }
       } else {
         callback(*sample_during_declaration);
@@ -220,7 +233,8 @@ class FakeTransport final : public sitos::Transport {
   std::optional<sitos::Result<sitos::Subscription>> declaration_error;
   bool async_declaration_sample = false;
   std::thread declaration_thread;
-  std::function<bool()> declaration_callback_admitted;
+  bool wait_for_declaration_callback_admission = false;
+  bool declaration_callback_admitted = false;
   std::mutex declaration_mutex;
   std::condition_variable declaration_condition;
 };
@@ -1441,11 +1455,10 @@ TEST(ParamStoreSubscribeTest, DeclarationFailureWaitsForAdmittedCallbackCopy) {
     }
     condition.notify_all();
   }, {}, {});
-  transport->declaration_callback_admitted =
-      [&] { return hook_entered.load(std::memory_order_acquire); };
+  transport->wait_for_declaration_callback_admission = true;
   sitos::param_store_test_access::ParamStoreTestAccess::SetNativeEntryHook(store, [&] {
     hook_entered.store(true, std::memory_order_release);
-    transport->NotifyDeclarationProgress();
+    transport->MarkDeclarationCallbackAdmitted();
     {
       std::lock_guard<std::mutex> lock(mutex);
     }
@@ -1487,6 +1500,7 @@ TEST(ParamStoreSubscribeTest, DeclarationFailureWaitsForAdmittedCallbackCopy) {
   }
   condition.notify_all();
   subscriber_thread.join();
+  transport->JoinDeclarationThread();
 
   ASSERT_TRUE(result.has_value());
   EXPECT_FALSE(result->IsOk());


### PR DESCRIPTION
## Summary

- Fix the test-only declaration callback handshake that could lose a condition-variable notification under TSan scheduling.
- Join the asynchronous fake-Transport declaration callback before borrowed test synchronization state is destroyed.
- Bound each sanitizer test to 60 seconds and each sanitizer job to 15 minutes.
- Make GitHub TSan repeat both implicated subscription lifecycle tests 100 times and the complete lifecycle selection 10 times.

## Issue checklist

- [x] Reproduce and preserve the genuine CI hang evidence.
- [x] Identify the deterministic synchronization and lifetime defects in the declaration-failure harness.
- [x] Preserve ADR-0030 production lifecycle semantics; no production code changes.
- [x] Make the declaration callback handshake and join ownership explicit and failure-safe.
- [x] Add CTest per-test timeout coverage.
- [x] Add a bounded sanitizer job timeout.
- [x] Keep TSan and ASan/UBSan coverage enabled.
- [x] Document the sanitizer timeout and stress policy.

## Requirements

- **Requirements: N/A** — this PR repairs test synchronization and CI containment without changing an F/N/C/P/X product contract.

## Root cause

### Lost declaration-admission notification

`FakeTransport::DeclareSubscriber` waited on `declaration_condition` while its predicate read an external atomic callback flag. The callback updated that atomic and notified without acquiring `declaration_mutex`. A callback could therefore notify after the waiter observed `false` but before the waiter slept, losing the notification permanently.

The replacement keeps `declaration_callback_admitted` under `declaration_mutex`; both the predicate update and wait use that same mutex.

### Borrowed test-state lifetime

The asynchronous declaration thread was joined only by `FakeTransport` destruction. Because the transport was declared before the test mutex/condition variables, the join occurred after borrowed synchronization locals had begun destruction. Repeated Windows process execution exposed this as exit code 3 after GoogleTest reported the test body passed.

The regression now explicitly joins the declaration callback immediately after the subscribing thread completes, before inspecting results or destroying borrowed test state. The destructor retains the same join as a fallback.

`CloseWaitsForBlockedCallback` did not reproduce a separate defect in 1,000 Windows process repetitions. The GitHub TSan lane now repeats it 100 times together with the declaration-failure regression and applies bounded failure if it hangs again.

## TDD and RED evidence

The following are genuine pre-fix behavioral RED evidence and are not retrospective simulations:

- Main TSan job hung for six hours after starting `CloseWaitsForBlockedCallback`: https://github.com/tetsuh/sitos/actions/runs/30189774968/job/89760814754
- PR #120 TSan jobs repeatedly hung after starting `DeclarationFailureWaitsForAdmittedCallbackCopy`:
  - https://github.com/tetsuh/sitos/actions/runs/30187377221/job/89754351757
  - https://github.com/tetsuh/sitos/actions/runs/30185491502/job/89749279553
  - https://github.com/tetsuh/sitos/actions/runs/30185056119/job/89748111711
- PR #124 exact-head rerun attempt 2 hung at the same declaration-failure test and required cancellation: https://github.com/tetsuh/sitos/actions/runs/30206471333/job/89810846827
- Before the explicit early join, repeated MSVC execution intermittently returned exit code 3 after GoogleTest printed a passing test body. After the join, 1,000 external-process repetitions passed.

No history was rewritten and no behavioral RED claim was fabricated.

## Validation

### Completed locally

- Zenoh-OFF MSVC full suite: **306/306 passed**.
- Canonical `build-on` Zenoh-ON MSVC full suite: **356/356 passed**.
- MSVC CTest focused repetitions: both implicated tests passed **100/100**.
- MSVC external-process repetitions:
  - `CloseWaitsForBlockedCallback`: **1,000/1,000 passed**.
  - `DeclarationFailureWaitsForAdmittedCallbackCopy`: **1,000/1,000 passed**.
- Bounded-timeout proof using a temporary non-repository 30-second sleeper:

```text
Test #1: BlockedProcess ... ***Timeout 1.05 sec
exit=8 elapsed_seconds=2
```

- `git diff --check`: passed.
- Commit-message audit: no literal `\\n` sequences.


### Completed on GitHub ubuntu-24.04

Authoritative TSan job: https://github.com/tetsuh/sitos/actions/runs/30210082737/job/89814707100

- TSan configure/build: passed.
- Both implicated subscription lifecycle tests: **100/100 repetitions passed**.
- Complete lifecycle sanitizer selection: **10/10 repetitions passed**.
- Normal bounded lifecycle selection: passed.
- The stress step completed in 28 seconds; the complete TSan job completed successfully in under two minutes.

### Platform note

Local WSL2 TSan cannot initialize on this host and exits during GoogleTest discovery with the known environment error:

```text
FATAL: ThreadSanitizer: unexpected memory mapping
```

Therefore the ubuntu-24.04 GitHub TSan lane is the authoritative TSan validation. This PR makes that lane run the required focused 100 repetitions and full-selection 10 repetitions with bounded timeouts.

## Contract / ADR assessment

- Contract Registry: **N/A** — no wire key, payload, Encoding, or stable identifier changes.
- ADR: no new ADR is required; ADR-0030 callback admission, quiescent Close, and declaration rollback semantics are unchanged.
- Production source and public API: unchanged.

## Commits

- `7b49376 test(ci): bound lifecycle sanitizer hangs (#125)`
- `b62d597 test(store): fix declaration callback synchronization (#125)`
- `76bfcd9 test(ci): stress subscription lifecycle under TSan (#125)`

Closes #125

