### PR TITLE
feat(vcpkg): add cross-platform foundation (#122)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,8 +212,6 @@ jobs:
 
   vcpkg-linux:
     runs-on: ubuntu-24.04
-    env:
-      VCPKG_BINARY_SOURCES: clear
     timeout-minutes: 180
     permissions:
       contents: read
@@ -226,6 +224,46 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build libssl-dev
+
+      - name: Resolve vcpkg cache outer compatibility boundary
+        id: vcpkg-cache-identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${ImageOS:-}" || -z "${ImageVersion:-}" ]]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          identity="${ImageOS}-${ImageVersion}"
+          identity="${identity//[^a-zA-Z0-9._-]/-}"
+          echo "available=true" >> "$GITHUB_OUTPUT"
+          echo "value=$identity" >> "$GITHUB_OUTPUT"
+
+      - name: Restore vcpkg binary archives
+        if: steps.vcpkg-cache-identity.outputs.available == 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+        id: vcpkg-binary-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/vcpkg-binary-cache
+          key: vcpkg-files-v2-${{ runner.os }}-${{ runner.arch }}-x64-linux-${{ hashFiles('vcpkg.json') }}-${{ steps.vcpkg-cache-identity.outputs.value }}
+          restore-keys: |
+            vcpkg-files-v2-${{ runner.os }}-${{ runner.arch }}-x64-linux-${{ hashFiles('vcpkg.json') }}-
+            vcpkg-files-v1-${{ runner.os }}-${{ runner.arch }}-x64-linux-${{ hashFiles('vcpkg.json') }}
+
+      - name: Configure vcpkg filesystem binary cache
+        shell: bash
+        run: |
+          set -euo pipefail
+          cache_available='${{ steps.vcpkg-cache-identity.outputs.available }}'
+          if [[ "$cache_available" == "true" &&
+                ("$GITHUB_EVENT_NAME" == "pull_request" ||
+                 ("$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main")) ]]; then
+            mkdir -p "$RUNNER_TEMP/vcpkg-binary-cache"
+            echo "VCPKG_BINARY_SOURCES=clear;files,$RUNNER_TEMP/vcpkg-binary-cache,readwrite" >> "$GITHUB_ENV"
+          else
+            echo "VCPKG_BINARY_SOURCES=clear" >> "$GITHUB_ENV"
+          fi
+          echo "VCPKG_BINARY_CACHE_HIT=${{ steps.vcpkg-binary-cache.outputs.cache-hit }}"
 
       - name: Checkout and bootstrap pinned vcpkg
         shell: bash
@@ -274,10 +312,15 @@ jobs:
           fi
           echo 'OK: root project and installed package configuration contain no hidden provisioning path'
 
+      - name: Save vcpkg binary archives
+        if: success() && steps.vcpkg-cache-identity.outputs.available == 'true' && steps.vcpkg-binary-cache.outputs.cache-hit != 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/vcpkg-binary-cache
+          key: ${{ steps.vcpkg-binary-cache.outputs.cache-primary-key }}
+
   vcpkg-windows:
     runs-on: windows-latest
-    env:
-      VCPKG_BINARY_SOURCES: clear
     timeout-minutes: 360
     permissions:
       contents: read
@@ -285,6 +328,46 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+
+      - name: Resolve vcpkg cache outer compatibility boundary
+        id: vcpkg-cache-identity
+        shell: pwsh
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:ImageOS) -or
+              [string]::IsNullOrWhiteSpace($env:ImageVersion)) {
+            'available=false' | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            exit 0
+          }
+          $identity = "$($env:ImageOS)-$($env:ImageVersion)" -replace '[^A-Za-z0-9._-]', '-'
+          'available=true' | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "value=$identity" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Restore vcpkg binary archives
+        if: steps.vcpkg-cache-identity.outputs.available == 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+        id: vcpkg-binary-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/vcpkg-binary-cache
+          key: vcpkg-files-v2-${{ runner.os }}-${{ runner.arch }}-x64-windows-${{ hashFiles('vcpkg.json') }}-${{ steps.vcpkg-cache-identity.outputs.value }}
+          restore-keys: |
+            vcpkg-files-v2-${{ runner.os }}-${{ runner.arch }}-x64-windows-${{ hashFiles('vcpkg.json') }}-
+            vcpkg-files-v1-${{ runner.os }}-${{ runner.arch }}-x64-windows-${{ hashFiles('vcpkg.json') }}
+
+      - name: Configure vcpkg filesystem binary cache
+        shell: pwsh
+        run: |
+          $cacheAvailable = '${{ steps.vcpkg-cache-identity.outputs.available }}'
+          if ($cacheAvailable -eq 'true' -and
+              ($env:GITHUB_EVENT_NAME -eq 'pull_request' -or
+               ($env:GITHUB_EVENT_NAME -eq 'push' -and $env:GITHUB_REF -eq 'refs/heads/main'))) {
+            $cache = Join-Path $env:RUNNER_TEMP 'vcpkg-binary-cache'
+            New-Item -ItemType Directory -Path $cache -Force | Out-Null
+            $cache = $cache.Replace('\', '/')
+            "VCPKG_BINARY_SOURCES=clear;files,$cache,readwrite" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          } else {
+            'VCPKG_BINARY_SOURCES=clear' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          }
+          Write-Host 'VCPKG_BINARY_CACHE_HIT=${{ steps.vcpkg-binary-cache.outputs.cache-hit }}'
 
       - name: Checkout and bootstrap pinned vcpkg
         shell: pwsh
@@ -332,3 +415,10 @@ jobs:
             throw 'Project CMake contains a package-manager provisioning path'
           }
           Write-Host 'OK: root project and installed package configuration contain no hidden provisioning path'
+
+      - name: Save vcpkg binary archives
+        if: success() && steps.vcpkg-cache-identity.outputs.available == 'true' && steps.vcpkg-binary-cache.outputs.cache-hit != 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/vcpkg-binary-cache
+          key: ${{ steps.vcpkg-binary-cache.outputs.cache-primary-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,3 +209,126 @@ jobs:
           $command = "call `"$vsPath\VC\Auxiliary\Build\vcvars64.bat`" && cmake -DSITOS_SOURCE_DIR=`"$workspace`" -DWORK_DIR=`"$workspace/build/package-validation`" -DCMAKE_GENERATOR=Ninja -P `"$workspace/tests/package/validate_installed_package.cmake`""
           cmd /c $command
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+  vcpkg-linux:
+    runs-on: ubuntu-24.04
+    env:
+      VCPKG_BINARY_SOURCES: clear
+    timeout-minutes: 180
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Install Linux provisioning prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build libssl-dev
+
+      - name: Checkout and bootstrap pinned vcpkg
+        shell: bash
+        run: |
+          set -euo pipefail
+          baseline="$(python3 -c 'import json; print(json.load(open("vcpkg.json"))["builtin-baseline"])')"
+          printf '%s\n' "$baseline" | grep -Eq '^[0-9a-f]{40}$'
+          git clone --filter=blob:none https://github.com/microsoft/vcpkg "$RUNNER_TEMP/vcpkg"
+          git -C "$RUNNER_TEMP/vcpkg" checkout --detach "$baseline"
+          test "$(git -C "$RUNNER_TEMP/vcpkg" rev-parse HEAD)" = "$baseline"
+          "$RUNNER_TEMP/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
+
+      - name: Validate pinned RocksDB provisioning and isolated no-feature build
+        shell: bash
+        run: |
+          set -euo pipefail
+          /usr/bin/time -f 'VCPKG_PROVISIONING_WALL_SECONDS=%e' cmake \
+            -DSITOS_SOURCE_DIR="$GITHUB_WORKSPACE" \
+            -DVCPKG_ROOT="$RUNNER_TEMP/vcpkg" \
+            -DWORK_DIR="$GITHUB_WORKSPACE/build/vcpkg-linux" \
+            -DTRIPLET=x64-linux -DCMAKE_GENERATOR=Ninja \
+            -P tests/vcpkg/validate_vcpkg_provisioning.cmake
+
+      - name: Guard package discovery against hidden provisioning
+        shell: bash
+        run: |
+          set -euo pipefail
+          config=cmake/sitosConfig.cmake.in
+          test -f CMakeLists.txt
+          test -f "$config"
+          if grep -nE '(vcpkg|apt-get|brew|bootstrap|git clone|FetchContent)' "$config"; then
+            echo 'ERROR: installed package configuration contains a provisioning path' >&2
+            exit 1
+          fi
+          # tests/vcpkg intentionally owns explicit package-manager provisioning validation and is
+          # outside the root project and installed package-configuration boundary checked here.
+          project_matches=$(
+            grep -nE '(vcpkg|apt-get|brew|bootstrap|git clone)' CMakeLists.txt || true
+            grep -rnE '(vcpkg|apt-get|brew|bootstrap|git clone)' \
+              --include='*.cmake' --include='*.cmake.in' cmake || true
+          )
+          if [[ -n "$project_matches" ]]; then
+            echo 'ERROR: project CMake contains a package-manager provisioning path:' >&2
+            echo "$project_matches" >&2
+            exit 1
+          fi
+          echo 'OK: root project and installed package configuration contain no hidden provisioning path'
+
+  vcpkg-windows:
+    runs-on: windows-latest
+    env:
+      VCPKG_BINARY_SOURCES: clear
+    timeout-minutes: 360
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Checkout and bootstrap pinned vcpkg
+        shell: pwsh
+        run: |
+          $manifest = Get-Content vcpkg.json -Raw | ConvertFrom-Json
+          $baseline = $manifest.'builtin-baseline'
+          if ($baseline -notmatch '^[0-9a-f]{40}$') { throw 'invalid builtin-baseline' }
+          git clone --filter=blob:none https://github.com/microsoft/vcpkg "$env:RUNNER_TEMP\vcpkg"
+          git -C "$env:RUNNER_TEMP\vcpkg" checkout --detach $baseline
+          if ((git -C "$env:RUNNER_TEMP\vcpkg" rev-parse HEAD) -ne $baseline) { throw 'pin mismatch' }
+          & "$env:RUNNER_TEMP\vcpkg\bootstrap-vcpkg.bat" -disableMetrics
+
+      - name: Validate pinned RocksDB provisioning and isolated no-feature build (MSVC + Ninja)
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          $workspace = $env:GITHUB_WORKSPACE.Replace('\', '/')
+          $vcpkg = "$env:RUNNER_TEMP/vcpkg"
+          $command = "call `"$vsPath\VC\Auxiliary\Build\vcvars64.bat`" && cmake -DSITOS_SOURCE_DIR=`"$workspace`" -DVCPKG_ROOT=`"$vcpkg`" -DWORK_DIR=`"$workspace/build/vcpkg-windows`" -DTRIPLET=x64-windows -DCMAKE_GENERATOR=Ninja -P `"$workspace/tests/vcpkg/validate_vcpkg_provisioning.cmake`""
+          $timer = [System.Diagnostics.Stopwatch]::StartNew()
+          cmd /c $command
+          $exitCode = $LASTEXITCODE
+          $timer.Stop()
+          Write-Host ("VCPKG_PROVISIONING_WALL_SECONDS={0:N3}" -f $timer.Elapsed.TotalSeconds)
+          if ($exitCode -ne 0) { exit $exitCode }
+
+      - name: Guard package discovery against hidden provisioning
+        shell: pwsh
+        run: |
+          $config = 'cmake/sitosConfig.cmake.in'
+          if (-not (Test-Path -LiteralPath $config -PathType Leaf)) {
+            throw "Installed package configuration is missing: $config"
+          }
+          if (Select-String -LiteralPath $config -Pattern 'vcpkg|apt-get|brew|bootstrap|git clone|FetchContent') {
+            throw 'Installed package configuration contains a provisioning path'
+          }
+          # tests/vcpkg intentionally owns explicit package-manager provisioning validation and is
+          # outside the root project and installed package-configuration boundary checked here.
+          $projectFiles = @((Resolve-Path -LiteralPath CMakeLists.txt).Path)
+          $projectFiles += @(Get-ChildItem -LiteralPath cmake -Recurse -File |
+            Where-Object { $_.Name -match '\.cmake(\.in)?$' } |
+            ForEach-Object { $_.FullName })
+          if (Select-String -LiteralPath $projectFiles -Pattern 'vcpkg|apt-get|brew|bootstrap|git clone') {
+            throw 'Project CMake contains a package-manager provisioning path'
+          }
+          Write-Host 'OK: root project and installed package configuration contain no hidden provisioning path'

--- a/.gitignore
+++ b/.gitignore
@@ -87,5 +87,7 @@ dmypy.json
 .ruff_cache/
 
 # === Project-specific ===
+/vcpkg_installed/
+
 # Private handoff document is kept out of the public repository.
 HANDOFF.md

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -73,6 +73,40 @@ scope, and no secret or external credential is used. Cache hits affect performan
 provisioning, configure, build, and runtime failures remain fatal. The initial cold-provisioning
 budgets are 180 minutes on Linux and 360 minutes on Windows.
 
+The first successful canonical GitHub-hosted PR run was run `30236511593`,
+attempt 1: Linux job
+[89885220722](https://github.com/tetsuh/sitos/actions/runs/30236511593/job/89885220722) emitted
+`VCPKG_PROVISIONING_WALL_SECONDS=970.42`, and Windows job
+[89885220723](https://github.com/tetsuh/sitos/actions/runs/30236511593/job/89885220723) emitted
+`VCPKG_PROVISIONING_WALL_SECONDS=2,491.543` (2,491.543 seconds). These are provisioning-command
+wall times, not full job durations: the Linux job ran approximately 1,595 seconds and the Windows
+job approximately 2,531 seconds.
+
+The same PR merge-ref was rerun as run `30236511593`, attempt 3. Linux job
+[89961622937](https://github.com/tetsuh/sitos/actions/runs/30236511593/job/89961622937) emitted
+`VCPKG_PROVISIONING_WALL_SECONDS=1010.06`, and Windows job
+[89961622965](https://github.com/tetsuh/sitos/actions/runs/30236511593/job/89961622965) emitted
+`VCPKG_PROVISIONING_WALL_SECONDS=2,802.580` (2,802.580 seconds). The rerun full job durations were
+approximately 1,043 and 2,840 seconds respectively. Both runs explicitly report that the pinned
+vcpkg executable's `x-gha` binary caching backend "has been removed"; no cache restore, hit, miss, or
+save evidence is present. These historical runs explain the replacement but do not validate it.
+
+PR #127 uses the SHA-pinned GitHub cache action with vcpkg's `files` backend. Run `30277962785`,
+attempt 1, recorded cache misses, complete successful validation, and archive saves: Linux took
+951.12 seconds and Windows took 2,819.379 seconds. Attempt 2 on the same head restored the exact
+keys, retained all validation, and skipped save: Linux restored approximately 210 MB and took 24.96
+seconds, while Windows restored approximately 594 MB and took 73.277 seconds. The provisioning
+steps were about 38.1 and 38.5 times faster respectively. These measurements used the first
+filesystem-key schema, which lacked the runner-image boundary.
+
+Run `30315682979`, attempt 1, restored those v1 archives through migration restore keys and saved
+runner-image-aware v2 primary keys after all validation passed. Linux provisioning took 33.24 seconds
+for image `ubuntu24-20260720.247.2`; Windows took 61.910 seconds for image
+`win25-vs2026-20260714.173.1`. Attempt 2 restored the exact v2 keys, reported
+`VCPKG_BINARY_CACHE_HIT=true`, retained all validation, skipped save, and completed provisioning in
+23.24 seconds on Linux and 60.623 seconds on Windows. Cache entries are immutable and may be evicted,
+so later cold builds remain expected.
+
 On Windows, the canonical `RocksDB::rocksdb` target is the `/MD`-compatible static archive. The
 probe stages and verifies the baseline's canonical `z.dll` in a clean runtime directory. The
 validator requires `dumpbin` from the `vcvars64.bat` environment. It does not rename or duplicate

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -45,6 +45,39 @@ sitos/
 * Presets: define `dev-windows`, `dev-linux`, `release`, and `python-wheel` in
   `CMakePresets.json`
 
+### 2.1 Optional vcpkg provisioning foundation
+
+Optional native dependencies are provisioned explicitly through the root `vcpkg.json` manifest.
+The manifest has no ordinary dependencies and keeps RocksDB behind the non-default `rocksdb`
+feature. CI checks out the official `microsoft/vcpkg` repository detached at the manifest's
+`builtin-baseline`, verifies `HEAD` against that value, and bootstraps with telemetry disabled.
+The baseline is the sole executable and registry pin source; updates require a dedicated
+dependency-update PR that changes the baseline and expected probe version together.
+
+The canonical validation triplets are the built-in `x64-linux` and `x64-windows` triplets. Configure
+opt-in consumers with `VCPKG_MANIFEST_FEATURES=rocksdb` and a fresh explicit
+`VCPKG_INSTALLED_DIR`; ordinary builds, installed package validators, and standard wheels do not
+use the vcpkg toolchain and retain `SITOS_WITH_ROCKSDB=OFF`. Project CMake and installed package
+configuration never invoke vcpkg or another package manager and never perform hidden provisioning.
+Existing scoped Zenoh and Google Benchmark `FetchContent` paths are unchanged.
+
+Dedicated vcpkg CI jobs persist a per-platform filesystem binary archive with the GitHub-owned
+`actions/cache` action pinned to an exact commit and configure vcpkg with
+`clear;files,<directory>,readwrite`. Primary keys separate the cache format, OS, architecture,
+canonical triplet, root manifest hash, and GitHub-hosted runner image identity; vcpkg package ABI
+remains the inner correctness boundary. A compatible-prefix restore may seed a new runner-image key,
+but only an exact primary-key hit skips save. Restore occurs before provisioning, while save occurs
+only after provisioning, configure, build, runtime, no-feature, and static-guard validation succeeds.
+Pull-request writes remain isolated to their merge refs, trusted `main` pushes use their normal cache
+scope, and no secret or external credential is used. Cache hits affect performance only;
+provisioning, configure, build, and runtime failures remain fatal. The initial cold-provisioning
+budgets are 180 minutes on Linux and 360 minutes on Windows.
+
+On Windows, the canonical `RocksDB::rocksdb` target is the `/MD`-compatible static archive. The
+probe stages and verifies the baseline's canonical `z.dll` in a clean runtime directory. The
+validator requires `dumpbin` from the `vcvars64.bat` environment. It does not rename or duplicate
+`z.dll` as `zlib1.dll`, depend on `rocksdb-shared.dll`, or use build-tree/vcpkg PATH entries.
+
 ## 3. Install (C++ consumer)
 
 The C++ library and public headers can be installed with the generated CMake export:

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -227,7 +227,7 @@ provisioning are unsupported; `apt` is limited to Linux CI bootstrap prerequisit
 canonical static `RocksDB::rocksdb` target imports the baseline's zlib 1.3.2 runtime as `z.dll`;
 validation stages that file under its actual name, requires `dumpbin` from the `vcvars64.bat`
 environment, and rejects `zlib1.dll` compatibility copies and `rocksdb-shared.dll` dependencies.
-Historical backend failures and canonical cold/cached measurements are recorded in Proposed
-ADR-0031 rather than duplicated in this policy document.
+Historical backend failures and canonical cold/cached measurements are recorded in ADR-0031
+rather than duplicated in this policy document.
 
 (END OF DOCUMENT)

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -199,4 +199,35 @@ The following must not change after zenoh updates:
 As with zenoh, monitor RocksDB and Python packaging with locked versions + latest CI.
 However, RocksDB is optional and must not impair availability of the standard wheel.
 
+### 7.1 Optional vcpkg foundation
+
+The root `vcpkg.json` is the sole source of the vcpkg executable and built-in registry pin. Its
+non-default `rocksdb` feature is validated through the official detached checkout at
+`40f3c709db80acf154ac4b17a1f83c564ebd022e`, resolving RocksDB 11.1.2 port-version 0 with the
+port's default zlib feature. Canonical CI uses only built-in `x64-linux` and `x64-windows`
+triplets and explicit isolated install roots.
+
+Provisioning is opt-in and explicit: project CMake and installed package configuration do not
+clone, bootstrap, install, update, or otherwise invoke a package manager, and package discovery
+has no hidden network behavior. Existing scoped Zenoh and Google Benchmark `FetchContent` paths
+remain unchanged. Standard builds, package validators, and wheels remain RocksDB-OFF and do not
+use vcpkg.
+
+Dedicated vcpkg jobs persist a per-platform package-ABI archive directory through a SHA-pinned
+GitHub-owned `actions/cache` action and configure vcpkg with
+`clear;files,<directory>,readwrite`. Primary keys separate cache format, OS, architecture, canonical
+triplet, root manifest hash, and GitHub-hosted runner image identity. A compatible-prefix restore
+may seed a new image key, but only an exact primary-key hit skips save. Pull-request writes remain
+isolated to their merge-ref scope; trusted pushes to `main` use their normal cache scope. Save occurs
+only after the complete validator succeeds, and no secret, long-lived credential, NuGet feed, Mono
+runtime, or external cache service is used. Cache behavior is performance-only and cannot make
+provisioning or runtime validation optional. A baseline or port version change requires an explicit
+dependency-update PR and cold/cached validation on both canonical triplets. Homebrew and macOS
+provisioning are unsupported; `apt` is limited to Linux CI bootstrap prerequisites. On Windows, the
+canonical static `RocksDB::rocksdb` target imports the baseline's zlib 1.3.2 runtime as `z.dll`;
+validation stages that file under its actual name, requires `dumpbin` from the `vcvars64.bat`
+environment, and rejects `zlib1.dll` compatibility copies and `rocksdb-shared.dll` dependencies.
+Historical backend failures and canonical cold/cached measurements are recorded in Proposed
+ADR-0031 rather than duplicated in this policy document.
+
 (END OF DOCUMENT)

--- a/docs/adr/0031-cross-platform-vcpkg-foundation.md
+++ b/docs/adr/0031-cross-platform-vcpkg-foundation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed — pending owner acceptance immediately before merge
+Accepted — 2026-07-28
 
 ## Context
 
@@ -138,5 +138,4 @@ Attempt 2 reran the exact same head and runner images:
   restored the exact v2 key, reported `cache-hit=true`, retained all validation, completed
   provisioning in 60.623 seconds, and skipped save.
 
-Cache behavior remains performance evidence only. ADR-0031 remains Proposed pending explicit owner
-acceptance.
+Cache behavior remains performance evidence only. ADR-0031 was accepted on 2026-07-28.

--- a/docs/adr/0031-cross-platform-vcpkg-foundation.md
+++ b/docs/adr/0031-cross-platform-vcpkg-foundation.md
@@ -62,3 +62,81 @@ save. The cache is an optional performance optimization, not a correctness depen
 * ADR-0021: Resolve installed Zenoh dependencies without fetching or bundling
 * `docs/06_build_test_packaging.md`
 * `docs/09_dependency_policy.md`
+
+### Validation evidence
+
+#### Superseded `x-gha` attempt
+
+The first successful canonical GitHub-hosted PR run was run `30236511593`, attempt 1:
+
+* Linux job [89885220722](https://github.com/tetsuh/sitos/actions/runs/30236511593/job/89885220722)
+  emitted `VCPKG_PROVISIONING_WALL_SECONDS=970.42`.
+* Windows job [89885220723](https://github.com/tetsuh/sitos/actions/runs/30236511593/job/89885220723)
+  emitted `VCPKG_PROVISIONING_WALL_SECONDS=2,491.543` (2,491.543 seconds).
+
+These are provisioning-command wall times, not full job durations. The corresponding full job
+spans were 04:14:00–04:30:35 UTC (Linux, approximately 1,595 seconds) and
+04:14:01–04:56:12 UTC (Windows, approximately 2,531 seconds).
+
+The same PR merge-ref was rerun as run `30236511593`, attempt 3, with both focused jobs:
+
+* Linux job [89961622937](https://github.com/tetsuh/sitos/actions/runs/30236511593/job/89961622937)
+  emitted `VCPKG_PROVISIONING_WALL_SECONDS=1010.06`.
+* Windows job [89961622965](https://github.com/tetsuh/sitos/actions/runs/30236511593/job/89961622965)
+  emitted `VCPKG_PROVISIONING_WALL_SECONDS=2,802.580` (2,802.580 seconds).
+
+The rerun full job spans were 11:16:38–11:34:01 UTC (Linux, approximately 1,043 seconds) and
+11:16:39–12:03:59 UTC (Windows, approximately 2,840 seconds). Both attempts explicitly logged
+that the pinned vcpkg executable's `x-gha` binary caching backend "has been removed"; neither log
+contains cache restore, hit, miss, or save evidence. Therefore the rerun is a repeat provisioning
+measurement, not a warm-cache measurement, and same-PR `x-gha` reuse is not proven. This evidence
+is retained as the reason the backend was replaced, not as evidence for the replacement cache.
+
+#### Filesystem binary-cache evidence
+
+PR #127 uses SHA-pinned `actions/cache` restore/save steps around a dedicated vcpkg `files` binary
+archive. Run `30277962785`, attempt 1, recorded misses followed by successful post-validation saves:
+
+* Linux job [90016731979](https://github.com/tetsuh/sitos/actions/runs/30277962785/job/90016731979)
+  emitted `VCPKG_PROVISIONING_WALL_SECONDS=951.12` and saved the Linux archive.
+* Windows job
+  [90016731735](https://github.com/tetsuh/sitos/actions/runs/30277962785/job/90016731735)
+  emitted `VCPKG_PROVISIONING_WALL_SECONDS=2,819.379` and saved the Windows archive.
+
+The same run and head were rerun as attempt 2. Both jobs restored their exact keys, retained all
+provisioning and runtime validation, and skipped save because the primary key matched:
+
+* Linux job [90029988641](https://github.com/tetsuh/sitos/actions/runs/30277962785/job/90029988641)
+  restored approximately 210 MB and emitted `VCPKG_PROVISIONING_WALL_SECONDS=24.96`, about 38.1
+  times faster than the replacement-backend cold run.
+* Windows job
+  [90029988603](https://github.com/tetsuh/sitos/actions/runs/30277962785/job/90029988603)
+  restored approximately 594 MB and emitted `VCPKG_PROVISIONING_WALL_SECONDS=73.277`, about 38.5
+  times faster than the replacement-backend cold run.
+
+These measurements used the first filesystem-key schema, which lacked the runner-image boundary.
+Run `30315682979`, attempt 1, migrated to the runner-image-aware v2 key without discarding compatible
+archives:
+
+* Linux job [90140581635](https://github.com/tetsuh/sitos/actions/runs/30315682979/job/90140581635)
+  restored the v1 archive through the migration restore key, reported `cache-hit=false`, completed
+  provisioning in 33.24 seconds, and saved
+  `vcpkg-files-v2-Linux-X64-x64-linux-...-ubuntu24-20260720.247.2`.
+* Windows job
+  [90140581599](https://github.com/tetsuh/sitos/actions/runs/30315682979/job/90140581599)
+  restored the v1 archive through the migration restore key, reported `cache-hit=false`, completed
+  provisioning in 61.910 seconds, and saved
+  `vcpkg-files-v2-Windows-X64-x64-windows-...-win25-vs2026-20260714.173.1`.
+
+Attempt 2 reran the exact same head and runner images:
+
+* Linux job [90141182464](https://github.com/tetsuh/sitos/actions/runs/30315682979/job/90141182464)
+  restored the exact v2 key, reported `cache-hit=true`, retained all validation, completed
+  provisioning in 23.24 seconds, and skipped save.
+* Windows job
+  [90141182570](https://github.com/tetsuh/sitos/actions/runs/30315682979/job/90141182570)
+  restored the exact v2 key, reported `cache-hit=true`, retained all validation, completed
+  provisioning in 60.623 seconds, and skipped save.
+
+Cache behavior remains performance evidence only. ADR-0031 remains Proposed pending explicit owner
+acceptance.

--- a/docs/adr/0031-cross-platform-vcpkg-foundation.md
+++ b/docs/adr/0031-cross-platform-vcpkg-foundation.md
@@ -1,0 +1,64 @@
+# ADR-0031: Establish a cross-platform vcpkg foundation
+
+## Status
+
+Proposed — pending owner acceptance immediately before merge
+
+## Context
+
+sitos needs a reproducible provider for optional native dependencies on Linux and Windows without
+changing the default RocksDB-OFF build or adding package-manager behavior to project CMake. The
+reviewed vcpkg commit resolves RocksDB 11.1.2, port-version 0, with zlib as its only default
+feature. CI must remain correct when its optional binary cache is unavailable.
+
+## Decision
+
+We will use an explicit root `vcpkg.json` with no ordinary dependencies and a non-default `rocksdb`
+feature, and use its `builtin-baseline` as the sole executable and registry pin. Dedicated CI jobs
+will check out official vcpkg at that baseline and use built-in `x64-linux` and `x64-windows`
+triplets. A SHA-pinned GitHub-owned `actions/cache` action persists a dedicated filesystem binary
+archive supplied to vcpkg through `clear;files,<directory>,readwrite`. Primary keys include cache
+format, OS, architecture, triplet, manifest hash, and GitHub-hosted runner image identity. A
+compatible-prefix restore may seed a new runner-image key, but only an exact primary-key hit skips
+save. The cache is an optional performance optimization, not a correctness dependency.
+
+## Consequences
+
+* Good: Optional native provisioning is auditable and reproducible across the supported CI platforms.
+* Good: Explicit isolated install roots and a consumer probe catch target, link, and runtime errors.
+* Good: Pull-request cache writes are constrained to the pull request merge-ref scope, and no
+  external cache credential, Mono runtime, NuGet client, or GitHub Packages feed is required.
+* Good: vcpkg remains responsible for package-ABI validation inside the cached archive directory.
+* Bad: GitHub cache entries are immutable and subject to repository quotas and eviction; the
+  runner-image key component or cache-format version changes when the outer compatibility boundary
+  changes.
+* Bad: Cold provisioning compiles RocksDB and can take substantial time; the initial budgets are 180
+  minutes for Linux and 360 minutes for Windows.
+* Bad: Homebrew/macOS provisioning is unsupported, and `apt` is limited to Linux CI prerequisites.
+* Neutral: Cache misses, eviction, or unavailable credentials do not alter correctness.
+* Windows runtime: the canonical static `RocksDB::rocksdb` target imports the pinned zlib 1.3.2
+  runtime as `z.dll`; validation stages that actual file, requires `dumpbin` from the `vcvars64.bat`
+  environment, and rejects `zlib1.dll` compatibility copies and `rocksdb-shared.dll` dependencies.
+
+## Options Considered
+
+* **Runner-provided vcpkg** — rejected because a mutable checkout is not reproducible.
+* **A custom triplet or static Windows triplet** — rejected because this foundation validates the
+  canonical built-in triplets and their actual runtime behavior.
+* **Automatic provisioning from project or installed CMake** — rejected because package discovery
+  must remain network-free and under the caller's explicit provisioning boundary.
+* **Removed vcpkg `x-gha` backend** — rejected because the pinned vcpkg executable reports that the
+  backend has been removed.
+* **GitHub Packages through vcpkg's NuGet backend** — rejected because it adds Mono and `nuget.exe`
+  on Linux, feed authentication, and package permissions that are unnecessary for this repository.
+* **Caching the installed dependency tree** — rejected because caching vcpkg's package-ABI archives
+  retains vcpkg's own reuse and validation boundary.
+* **External or long-lived cache credentials** — rejected because GitHub's merge-ref-scoped cache
+  action needs no repository secret or external credential.
+
+## References
+
+* Issue #122
+* ADR-0021: Resolve installed Zenoh dependencies without fetching or bundling
+* `docs/06_build_test_packaging.md`
+* `docs/09_dependency_policy.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,3 +34,4 @@ See [docs/10_adr_process.md](../10_adr_process.md) for the process.
 | [0027](0027-keep-http-control-planes-in-host-applications.md) | Keep HTTP control planes in host applications |
 | [0028](0028-unify-acknowledged-operation-results.md) | Unify acknowledged operation results |
 | [0030](0030-param-store-subscription-lifetime-and-delivery.md) | Define ParamStore subscription lifetime and delivery semantics |
+| [0031](0031-cross-platform-vcpkg-foundation.md) | Establish a cross-platform vcpkg foundation (Proposed) |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,4 +34,4 @@ See [docs/10_adr_process.md](../10_adr_process.md) for the process.
 | [0027](0027-keep-http-control-planes-in-host-applications.md) | Keep HTTP control planes in host applications |
 | [0028](0028-unify-acknowledged-operation-results.md) | Unify acknowledged operation results |
 | [0030](0030-param-store-subscription-lifetime-and-delivery.md) | Define ParamStore subscription lifetime and delivery semantics |
-| [0031](0031-cross-platform-vcpkg-foundation.md) | Establish a cross-platform vcpkg foundation (Proposed) |
+| [0031](0031-cross-platform-vcpkg-foundation.md) | Establish a cross-platform vcpkg foundation |

--- a/tests/vcpkg/check_default_no_rocksdb.cmake
+++ b/tests/vcpkg/check_default_no_rocksdb.cmake
@@ -1,0 +1,36 @@
+if(NOT DEFINED VCPKG_INSTALLED_DIR)
+  message(FATAL_ERROR "VCPKG_INSTALLED_DIR must name the isolated no-feature install root")
+endif()
+
+# A manifest with no dependencies may leave no install root or status database. Both
+# states are positive absence evidence, not errors.
+if(NOT EXISTS "${VCPKG_INSTALLED_DIR}")
+  message(STATUS "VcpkgDefaultPathDoesNotProvisionRocksDB: install root is absent (pass)")
+  return()
+endif()
+
+file(GLOB_RECURSE _status_files LIST_DIRECTORIES false
+  "${VCPKG_INSTALLED_DIR}/vcpkg/status"
+  "${VCPKG_INSTALLED_DIR}/*/vcpkg/status")
+foreach(_status_file IN LISTS _status_files)
+  file(READ "${_status_file}" _status)
+  if(_status MATCHES "(^|\\n)Package:[ \\t]*rocksdb([ \\t]*\\n|$)")
+    message(FATAL_ERROR "RocksDB status entry found in ${_status_file}")
+  endif()
+endforeach()
+
+file(GLOB_RECURSE _rocksdb_headers LIST_DIRECTORIES false
+  "${VCPKG_INSTALLED_DIR}/*/include/rocksdb/*.h"
+  "${VCPKG_INSTALLED_DIR}/*/include/rocksdb/*.hpp")
+file(GLOB_RECURSE _rocksdb_libraries LIST_DIRECTORIES false
+  "${VCPKG_INSTALLED_DIR}/*/lib/*rocksdb*"
+  "${VCPKG_INSTALLED_DIR}/*/debug/lib/*rocksdb*")
+file(GLOB_RECURSE _rocksdb_dlls LIST_DIRECTORIES false
+  "${VCPKG_INSTALLED_DIR}/*/bin/*rocksdb*.dll"
+  "${VCPKG_INSTALLED_DIR}/*/debug/bin/*rocksdb*.dll")
+if(_rocksdb_headers OR _rocksdb_libraries OR _rocksdb_dlls)
+  message(FATAL_ERROR
+    "RocksDB artifacts found in no-feature install root: "
+    "headers=${_rocksdb_headers}; libraries=${_rocksdb_libraries}; dlls=${_rocksdb_dlls}")
+endif()
+message(STATUS "VcpkgDefaultPathDoesNotProvisionRocksDB: no status entry or artifacts (pass)")

--- a/tests/vcpkg/consumer/CMakeLists.txt
+++ b/tests/vcpkg/consumer/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.20)
+project(sitos_vcpkg_rocksdb_probe LANGUAGES CXX)
+
+include(CTest)
+enable_testing()
+
+find_package(RocksDB 11.1.2 EXACT CONFIG REQUIRED)
+if(NOT RocksDB_VERSION VERSION_EQUAL 11.1.2)
+  message(FATAL_ERROR "Resolved RocksDB ${RocksDB_VERSION}, expected exactly 11.1.2")
+endif()
+if(NOT TARGET RocksDB::rocksdb)
+  message(FATAL_ERROR "RocksDB::rocksdb is required by the vcpkg consumer contract")
+endif()
+
+add_executable(rocksdb_consumer main.cpp)
+target_link_libraries(rocksdb_consumer PRIVATE RocksDB::rocksdb)
+target_compile_features(rocksdb_consumer PRIVATE cxx_std_20)
+
+if(DEFINED PROBE_RUNTIME_DIR AND NOT PROBE_RUNTIME_DIR STREQUAL "")
+  file(MAKE_DIRECTORY "${PROBE_RUNTIME_DIR}")
+  set_target_properties(rocksdb_consumer PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${PROBE_RUNTIME_DIR}")
+  add_test(NAME VcpkgRocksDBConsumerLinksAndRuns
+    COMMAND "$<TARGET_FILE:rocksdb_consumer>" "${PROBE_RUNTIME_DIR}/rocksdb-db")
+  set_tests_properties(VcpkgRocksDBConsumerLinksAndRuns PROPERTIES
+    TIMEOUT 60 WORKING_DIRECTORY "${PROBE_RUNTIME_DIR}")
+else()
+  add_test(NAME VcpkgRocksDBConsumerLinksAndRuns
+    COMMAND "$<TARGET_FILE:rocksdb_consumer>" "${CMAKE_CURRENT_BINARY_DIR}/rocksdb-db")
+  set_tests_properties(VcpkgRocksDBConsumerLinksAndRuns PROPERTIES TIMEOUT 60)
+endif()
+
+# The exact version and imported-target contract are asserted during configure above. Register the
+# contract name so the configure gate remains visible in the focused CTest output.
+add_test(NAME VcpkgRocksDBFeatureConfigures COMMAND "${CMAKE_COMMAND}" -E true)

--- a/tests/vcpkg/consumer/main.cpp
+++ b/tests/vcpkg/consumer/main.cpp
@@ -1,0 +1,74 @@
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <rocksdb/db.h>
+#include <rocksdb/options.h>
+#include <rocksdb/status.h>
+#include <rocksdb/version.h>
+
+namespace {
+
+bool CheckStatus(const rocksdb::Status& status, const char* operation) {
+  if (status.ok()) {
+    return true;
+  }
+  std::cerr << operation << " failed: " << status.ToString() << '\n';
+  return false;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  if (ROCKSDB_MAJOR != 11 || ROCKSDB_MINOR != 1 || ROCKSDB_PATCH != 2) {
+    std::cerr << "Unexpected compile-time RocksDB version\n";
+    return EXIT_FAILURE;
+  }
+  if (rocksdb::GetRocksVersionAsString() != "11.1.2") {
+    std::cerr << "Unexpected runtime RocksDB version: "
+              << rocksdb::GetRocksVersionAsString() << '\n';
+    return EXIT_FAILURE;
+  }
+  if (argc != 2) {
+    std::cerr << "Usage: rocksdb_consumer <database-directory>\n";
+    return EXIT_FAILURE;
+  }
+
+  rocksdb::Options options;
+  options.create_if_missing = true;
+  std::unique_ptr<rocksdb::DB> database;
+  if (!CheckStatus(rocksdb::DB::Open(options, argv[1], &database), "DB::Open")) {
+    return EXIT_FAILURE;
+  }
+
+  const auto cleanup = [&database, &argv]() {
+    database.reset();
+    std::error_code cleanup_error;
+    std::filesystem::remove_all(argv[1], cleanup_error);
+    return cleanup_error;
+  };
+  const auto finish = [&cleanup](int result) {
+    const std::error_code cleanup_error = cleanup();
+    if (cleanup_error) {
+      std::cerr << "Failed to clean up probe database: " << cleanup_error.message() << '\n';
+      return EXIT_FAILURE;
+    }
+    return result;
+  };
+
+  const rocksdb::WriteOptions write_options;
+  const rocksdb::ReadOptions read_options;
+  if (!CheckStatus(database->Put(write_options, "sitos-key", "sitos-value"), "Put")) {
+    return finish(EXIT_FAILURE);
+  }
+
+  std::string value;
+  const rocksdb::Status get_status = database->Get(read_options, "sitos-key", &value);
+  if (!CheckStatus(get_status, "Get") || value != "sitos-value") {
+    std::cerr << "Get returned an unexpected value\n";
+    return finish(EXIT_FAILURE);
+  }
+  return finish(EXIT_SUCCESS);
+}

--- a/tests/vcpkg/validate_vcpkg_provisioning.cmake
+++ b/tests/vcpkg/validate_vcpkg_provisioning.cmake
@@ -1,0 +1,131 @@
+cmake_minimum_required(VERSION 3.20)
+
+foreach(_required_arg IN ITEMS SITOS_SOURCE_DIR VCPKG_ROOT WORK_DIR TRIPLET)
+  if(NOT DEFINED ${_required_arg} OR "${${_required_arg}}" STREQUAL "")
+    message(FATAL_ERROR "${_required_arg} must be provided")
+  endif()
+endforeach()
+if(NOT DEFINED CMAKE_GENERATOR OR "${CMAKE_GENERATOR}" STREQUAL "")
+  set(CMAKE_GENERATOR Ninja)
+endif()
+set(_generator_args -G "${CMAKE_GENERATOR}")
+if(DEFINED CMAKE_MAKE_PROGRAM AND NOT "${CMAKE_MAKE_PROGRAM}" STREQUAL "")
+  list(APPEND _generator_args "-DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}")
+endif()
+
+function(run_checked)
+  execute_process(COMMAND ${ARGV} RESULT_VARIABLE _result)
+  if(NOT _result EQUAL 0)
+    message(FATAL_ERROR "Command failed with exit code ${_result}: ${ARGV}")
+  endif()
+endfunction()
+
+set(_manifest "${SITOS_SOURCE_DIR}/vcpkg.json")
+if(NOT EXISTS "${_manifest}")
+  message(FATAL_ERROR
+    "VcpkgRocksDBFeatureConfigures RED: root vcpkg.json is absent; pinned feature provisioning is unavailable")
+endif()
+file(READ "${_manifest}" _manifest_text)
+string(JSON _baseline ERROR_VARIABLE _baseline_error GET "${_manifest_text}" "builtin-baseline")
+string(LENGTH "${_baseline}" _baseline_length)
+if(_baseline_error OR NOT _baseline_length EQUAL 40 OR NOT _baseline MATCHES "^[0-9a-fA-F]+$")
+  message(FATAL_ERROR "vcpkg.json builtin-baseline must be a 40-hex commit")
+endif()
+
+execute_process(
+  COMMAND git -C "${VCPKG_ROOT}" rev-parse HEAD
+  RESULT_VARIABLE _git_result
+  OUTPUT_VARIABLE _vcpkg_head
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_VARIABLE _git_error)
+if(NOT _git_result EQUAL 0 OR NOT _vcpkg_head STREQUAL _baseline)
+  message(FATAL_ERROR
+    "vcpkg checkout does not match vcpkg.json builtin-baseline: expected ${_baseline}, got ${_vcpkg_head}; ${_git_error}")
+endif()
+
+if(IS_ABSOLUTE "${WORK_DIR}")
+  set(_work_dir "${WORK_DIR}")
+else()
+  set(_work_dir "${CMAKE_CURRENT_BINARY_DIR}/${WORK_DIR}")
+endif()
+file(REMOVE_RECURSE "${_work_dir}")
+file(MAKE_DIRECTORY "${_work_dir}")
+set(_feature_build "${_work_dir}/feature-build")
+set(_feature_install "${_work_dir}/feature-installed")
+set(_feature_stage "${_work_dir}/feature-stage")
+set(_default_build "${_work_dir}/default-build")
+set(_default_install "${_work_dir}/default-installed")
+if(_feature_install STREQUAL _default_install)
+  message(FATAL_ERROR "Feature and no-feature install roots must differ")
+endif()
+file(MAKE_DIRECTORY "${_feature_stage}")
+
+set(_toolchain "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
+run_checked(
+  "${CMAKE_COMMAND}" -S "${SITOS_SOURCE_DIR}/tests/vcpkg/consumer" -B "${_feature_build}"
+  ${_generator_args} -DCMAKE_BUILD_TYPE=Release
+  "-DCMAKE_TOOLCHAIN_FILE=${_toolchain}"
+  "-DVCPKG_MANIFEST_DIR=${SITOS_SOURCE_DIR}"
+  -DVCPKG_MANIFEST_FEATURES=rocksdb
+  "-DVCPKG_TARGET_TRIPLET=${TRIPLET}"
+  "-DVCPKG_INSTALLED_DIR=${_feature_install}"
+  "-DPROBE_RUNTIME_DIR=${_feature_stage}")
+run_checked("${CMAKE_COMMAND}" --build "${_feature_build}")
+
+if(WIN32)
+  # The pinned baseline's zlib 1.3.2 port exports the canonical z.dll name.
+  # Never rename it or add a compatibility copy under the pre-1.3.2 name.
+  set(_zlib_dll "${_feature_install}/${TRIPLET}/bin/z.dll")
+  if(NOT EXISTS "${_zlib_dll}")
+    message(FATAL_ERROR "Expected canonical z.dll was not provisioned for x64-windows")
+  endif()
+  run_checked("${CMAKE_COMMAND}" -E copy_if_different "${_zlib_dll}" "${_feature_stage}/z.dll")
+  if(NOT EXISTS "${_feature_stage}/z.dll")
+    message(FATAL_ERROR "Failed to stage canonical z.dll")
+  endif()
+  if(EXISTS "${_feature_stage}/zlib1.dll")
+    message(FATAL_ERROR "Unexpected zlib1.dll compatibility artifact was staged")
+  endif()
+
+  execute_process(
+    COMMAND dumpbin /DEPENDENTS "${_feature_stage}/rocksdb_consumer.exe"
+    RESULT_VARIABLE _dumpbin_result
+    OUTPUT_VARIABLE _dumpbin_output
+    ERROR_VARIABLE _dumpbin_error)
+  if(NOT _dumpbin_result EQUAL 0)
+    message(FATAL_ERROR "Unable to inspect Windows probe dependencies: ${_dumpbin_error}")
+  endif()
+  string(TOLOWER "${_dumpbin_output}" _dumpbin_lower)
+  if(NOT _dumpbin_lower MATCHES "(^|[^a-z0-9_])z\\.dll([^a-z0-9_]|$)")
+    message(FATAL_ERROR "Windows probe dependency inspection did not report canonical z.dll")
+  endif()
+  if(NOT _dumpbin_lower MATCHES "vcruntime140(_1)?\\.dll" OR
+     NOT _dumpbin_lower MATCHES "msvcp140(_atomic_wait)?\\.dll")
+    message(FATAL_ERROR "Windows probe does not report the expected dynamic MSVC CRT dependencies")
+  endif()
+  if(_dumpbin_lower MATCHES "rocksdb-shared\\.dll")
+    message(FATAL_ERROR "Canonical RocksDB::rocksdb probe depends on rocksdb-shared.dll")
+  endif()
+endif()
+
+# Execute only from the clean stage directory. In particular, do not add a vcpkg
+# or build-tree directory to PATH to make runtime discovery succeed accidentally.
+set(_clean_path "${_feature_stage}")
+run_checked(
+  "${CMAKE_COMMAND}" -E env "PATH=${_clean_path}"
+  "${CMAKE_CTEST_COMMAND}" --test-dir "${_feature_build}" --output-on-failure
+  -R "VcpkgRocksDBFeatureConfigures|VcpkgRocksDBConsumerLinksAndRuns")
+
+run_checked(
+  "${CMAKE_COMMAND}" -S "${SITOS_SOURCE_DIR}" -B "${_default_build}"
+  ${_generator_args} -DCMAKE_BUILD_TYPE=Release
+  -DSITOS_BUILD_TESTS=OFF -DSITOS_WITH_ROCKSDB=OFF -DSITOS_WITH_ZENOH=OFF
+  "-DCMAKE_TOOLCHAIN_FILE=${_toolchain}"
+  "-DVCPKG_MANIFEST_DIR=${SITOS_SOURCE_DIR}"
+  "-DVCPKG_TARGET_TRIPLET=${TRIPLET}"
+  "-DVCPKG_INSTALLED_DIR=${_default_install}")
+run_checked("${CMAKE_COMMAND}" --build "${_default_build}")
+run_checked(
+  "${CMAKE_COMMAND}" "-DVCPKG_INSTALLED_DIR=${_default_install}"
+  -P "${SITOS_SOURCE_DIR}/tests/vcpkg/check_default_no_rocksdb.cmake")
+message(STATUS "VcpkgDefaultPathDoesNotProvisionRocksDB: isolated no-feature build passed")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "sitos",
+  "version-string": "0.1.0",
+  "builtin-baseline": "40f3c709db80acf154ac4b17a1f83c564ebd022e",
+  "features": {
+    "rocksdb": {
+      "description": "Provision RocksDB for the optional RocksDB consumer probe",
+      "dependencies": [
+        "rocksdb"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Closes #122

## Summary

- Add the root vcpkg manifest with no ordinary dependencies and a non-default `rocksdb` feature.
- Pin the official detached vcpkg executable and registry baseline to `40f3c709db80acf154ac4b17a1f83c564ebd022e`.
- Add the standalone RocksDB 11.1.2 exact CONFIG consumer and isolated feature/no-feature validator.
- Add focused Linux and Windows CI jobs with merge-ref-scoped `actions/cache` persistence of vcpkg filesystem binary archives, telemetry-disabled bootstrap, and 180/360 minute cold-build budgets.
- Keep ordinary builds, installed package validation, and wheels outside the vcpkg provisioning path.
- Record owner acceptance of ADR-0031 on 2026-07-28.

## Requirements mapping

| Requirement | Evidence |
| --- | --- |
| No-default manifest and opt-in feature | `vcpkg.json`; validator passes `-DVCPKG_MANIFEST_FEATURES=rocksdb` only for the positive probe. |
| Single official pin | Both CI jobs parse `builtin-baseline`, detached-check out `microsoft/vcpkg`, verify `HEAD`, and bootstrap with `-disableMetrics`. |
| Exact target/API contract | `find_package(RocksDB 11.1.2 EXACT CONFIG REQUIRED)`, `RocksDB::rocksdb`, compile-time version macros, runtime version, `DB::Open`, Put, Get, and cleanup. |
| Windows canonical runtime | `x64-windows` uses the static `/MD`-compatible target; the validator stages actual `z.dll`, checks `dumpbin /DEPENDENTS` for `z.dll` and dynamic MSVC CRT dependencies, rejects `zlib1.dll` compatibility artifacts and `rocksdb-shared.dll`, and executes with only the clean stage directory on `PATH`. |
| Default/no-feature isolation | Separate fresh install roots, omission of `VCPKG_MANIFEST_FEATURES`, a standalone absence checker, and RocksDB-OFF sitos build. Missing install root/status is positive absence evidence. |
| Cache security | SHA-pinned GitHub-owned `actions/cache` restore/save steps persist only the dedicated vcpkg archive directory. PR and trusted main push use `clear;files,<directory>,readwrite`; save runs only after complete validation; no secrets, `pull_request_target`, Mono, NuGet, GitHub Packages, or external cache credentials. |
| Scope preservation | Existing CI build/package/wheel jobs and CMake/package/wheel configuration are unchanged; no RocksDBEngine, installed RocksDB reconstruction, wheel, custom triplet, overlay, or provider compatibility artifact is added. |

## TDD evidence

### Genuine RED (preserved from the implementation handoff)

Before adding `vcpkg.json`, this command was run:

```sh
cmake -DSITOS_SOURCE_DIR="$PWD" -DVCPKG_ROOT="$PWD/.missing-vcpkg" -DWORK_DIR="$PWD/build/red-vcpkg" -DTRIPLET=x64-linux -DCMAKE_GENERATOR=Ninja -P tests/vcpkg/validate_vcpkg_provisioning.cmake
```

It failed with exit code 1:

```text
CMake Error at tests/vcpkg/validate_vcpkg_provisioning.cmake:21 (message):
  VcpkgRocksDBFeatureConfigures RED: root vcpkg.json is absent; pinned
  feature provisioning is unavailable
```

This is genuine missing-contract RED evidence, not a cache miss.

### Review-driven replacement-cache configuration RED

Before grouped commit `1d336ac`, the option-3 acceptance check was run against pre-rewrite head `379f836`:

```sh
python - <<'PY'
from pathlib import Path
workflow = Path('.github/workflows/ci.yml').read_text(encoding='utf-8')
assert 'x-gha' not in workflow, 'legacy x-gha backend is still configured'
assert 'actions/cache/restore@' in workflow, 'actions/cache restore step is absent'
assert 'actions/cache/save@' in workflow, 'actions/cache save step is absent'
assert 'clear;files,' in workflow, 'vcpkg files binary source is absent'
PY
```

It failed before the replacement edit:

```text
AssertionError: legacy x-gha backend is still configured
```

After the edit, the same contract check passes together with YAML parsing, PowerShell parser validation, and `git diff --check`. This is review-driven configuration RED evidence, not a cache-performance assertion.

### Review-driven Opus contract RED

Before the fixes now grouped into `1d336ac` and `2759e53`, an exact-head static contract check reported:

```text
FAIL: Finding 1: section 2.1 splits the section-2 bullet list
FAIL: Finding 2: Windows vcpkg steps contain over-escaped path separators
FAIL: Finding 3: the named configure contract has no explicit version assertion/comment
FAIL: Finding 4: vcpkg cache key omits the hosted-runner image boundary
FAIL: Finding 5: the static guard does not cover project CMake
```

The same check now passes together with YAML parsing, all five extracted Windows PowerShell block
parses, Linux and Windows hidden-provisioning guard execution, and `git diff --check`. Findings 6
and 7 were documentation consistency corrections and did not require behavioral RED.

### Review-driven Opus follow-up RED

Before the pre-rewrite fix now grouped into `1d336ac`, the follow-up contract check reported:

```text
FAIL: A: cache identity does not expose graceful availability state on both platforms
FAIL: A: restore/configure/save are not gated on image identity availability
FAIL: B: intentional test provisioning exclusion is undocumented
FAIL: B: success messages overstate the static guard scan scope
FAIL: C: Linux guard does not require the root CMakeLists.txt
```

The same check now passes. Missing-image and sanitized-image paths pass on Linux and Windows; YAML
and all five extracted Windows PowerShell blocks parse; and `git diff --check` passes. This is
review-driven defensive coverage and does not alter the earlier behavioral TDD provenance.

### Local GREEN

The complete Windows validator passed after entering the latest MSVC x64 environment:

```text
100% tests passed, 0 tests failed out of 2
-- VcpkgDefaultPathDoesNotProvisionRocksDB: no status entry or artifacts (pass)
-- VcpkgDefaultPathDoesNotProvisionRocksDB: isolated no-feature build passed
```

The clean staged executable dependency inspection reported:

```text
z.dll
MSVCP140.dll
MSVCP140_ATOMIC_WAIT.dll
VCRUNTIME140.dll
VCRUNTIME140_1.dll
```

The real staged DB::Open/Put/Get probe passed. The ordinary no-vcpkg `dev-windows` preset also configured, built, and passed all 356 tests (`Total Test time = 50.09 sec`). A first local attempt with an older MSVC compiler failed only because the cached RocksDB archive was built by the newer compiler; rerunning with the `vswhere`-selected latest compiler passed. No workaround was added.

Other local checks passed:

- `git diff --check`
- `python -m json.tool vcpkg.json`
- PyYAML parse of `.github/workflows/ci.yml`
- absence validator with a missing install root

## Hosted CI cache evidence

### Superseded `x-gha` attempt

The first successful canonical GitHub-hosted PR run is [run 30236511593](https://github.com/tetsuh/sitos/actions/runs/30236511593), attempt 1. Its focused jobs emitted the following provisioning-command wall times:

- Linux [job 89885220722](https://github.com/tetsuh/sitos/actions/runs/30236511593/job/89885220722): `VCPKG_PROVISIONING_WALL_SECONDS=970.42`.
- Windows [job 89885220723](https://github.com/tetsuh/sitos/actions/runs/30236511593/job/89885220723): `VCPKG_PROVISIONING_WALL_SECONDS=2,491.543` (2,491.543 seconds).

These are not full job durations. The full job spans were 04:14:00-04:30:35 UTC (Linux, approximately 1,595 seconds) and 04:14:01-04:56:12 UTC (Windows, approximately 2,531 seconds).

The same PR merge-ref was rerun as [run 30236511593](https://github.com/tetsuh/sitos/actions/runs/30236511593), attempt 3, with both focused jobs:

- Linux [job 89961622937](https://github.com/tetsuh/sitos/actions/runs/30236511593/job/89961622937): `VCPKG_PROVISIONING_WALL_SECONDS=1010.06`.
- Windows [job 89961622965](https://github.com/tetsuh/sitos/actions/runs/30236511593/job/89961622965): `VCPKG_PROVISIONING_WALL_SECONDS=2,802.580` (2,802.580 seconds).

The rerun full job spans were 11:16:38-11:34:01 UTC (Linux, approximately 1,043 seconds) and 11:16:39-12:03:59 UTC (Windows, approximately 2,840 seconds). Both attempts explicitly logged that the pinned vcpkg executable's `x-gha` binary caching backend "has been removed". Neither log contains cache restore, hit, miss, or save evidence. Therefore the rerun is a repeat provisioning measurement, not a warm-cache measurement, and same-PR x-gha reuse is not proven. The slower rerun timings must not be interpreted as cache behavior.

Cache behavior remains performance evidence only; all provisioning, configure, build, and runtime failures remain fatal. The attempt-3 run completed successfully on the same SHA, but it validated only that the pinned backend was unavailable.

### Replacement `actions/cache` plus `files` backend

Grouped commit `1d336ac` replaces `x-gha` with SHA-pinned `actions/cache/restore` and `actions/cache/save` around dedicated per-platform vcpkg filesystem binary archives. The save step runs only after the complete validator succeeds.

Run [30277962785](https://github.com/tetsuh/sitos/actions/runs/30277962785), attempt 1, recorded cache misses followed by complete successful validation and archive saves:

- Linux [job 90016731979](https://github.com/tetsuh/sitos/actions/runs/30277962785/job/90016731979): `VCPKG_PROVISIONING_WALL_SECONDS=951.12`.
- Windows [job 90016731735](https://github.com/tetsuh/sitos/actions/runs/30277962785/job/90016731735): `VCPKG_PROVISIONING_WALL_SECONDS=2,819.379`.

Attempt 2 reran the same head and restored both exact keys while retaining the complete validator; the save steps were skipped because the primary keys matched:

- Linux [job 90029988641](https://github.com/tetsuh/sitos/actions/runs/30277962785/job/90029988641): approximately 210 MB restored, `VCPKG_BINARY_CACHE_HIT=true`, `VCPKG_PROVISIONING_WALL_SECONDS=24.96` (about 38.1 times faster).
- Windows [job 90029988603](https://github.com/tetsuh/sitos/actions/runs/30277962785/job/90029988603): approximately 594 MB restored, `VCPKG_BINARY_CACHE_HIT=true`, `VCPKG_PROVISIONING_WALL_SECONDS=73.277` (about 38.5 times faster).

These measurements used the first filesystem-key schema, which omitted the hosted-runner image
boundary. Grouped commit `1d336ac` adds a runner-image-aware v2 primary key plus compatible archive
seeding, and `152be6b` records the resulting evidence.

Run [30315682979](https://github.com/tetsuh/sitos/actions/runs/30315682979), attempt 1, restored the
v1 archives through migration restore keys, reported `VCPKG_BINARY_CACHE_HIT=false`, retained all
validation, and saved image-aware v2 primary keys:

- Linux [job 90140581635](https://github.com/tetsuh/sitos/actions/runs/30315682979/job/90140581635): image `ubuntu24-20260720.247.2`, `VCPKG_PROVISIONING_WALL_SECONDS=33.24`.
- Windows [job 90140581599](https://github.com/tetsuh/sitos/actions/runs/30315682979/job/90140581599): image `win25-vs2026-20260714.173.1`, `VCPKG_PROVISIONING_WALL_SECONDS=61.910`.

Attempt 2 reran the exact same head and runner images. Both jobs restored their exact v2 keys,
reported `VCPKG_BINARY_CACHE_HIT=true`, retained all validation, and skipped save:

- Linux [job 90141182464](https://github.com/tetsuh/sitos/actions/runs/30315682979/job/90141182464): `VCPKG_PROVISIONING_WALL_SECONDS=23.24`.
- Windows [job 90141182570](https://github.com/tetsuh/sitos/actions/runs/30315682979/job/90141182570): `VCPKG_PROVISIONING_WALL_SECONDS=60.623`.

## ADR and residual risks

ADR-0031 was accepted by the owner on 2026-07-28 and is indexed. The canonical historical, v1 replacement-cache, and runner-image-aware v2 measurements are recorded above. The v2 migration-save and exact-hit evidence gate is complete. Cache immutability, quota pressure, and eviction may cause later cold builds by design. This PR does not alter wire/API surfaces or register a Contract Registry item.

Commits:

- `1a2d58a feat(vcpkg): add pinned RocksDB provisioning contract (#122)`
- `9704aba feat(ci): validate pinned vcpkg provisioning cross-platform (#122)`
- `1d336ac feat(ci): cache vcpkg archives by runner image (#122)`
- `8b43012 docs(adr): define cross-platform vcpkg foundation (#122)`
- `2759e53 docs(build): document optional vcpkg provisioning policy (#122)`
- `152be6b docs(ci): record hosted vcpkg cache evidence (#122)`
- `6919af3 docs(adr): accept cross-platform vcpkg foundation (#122)`
- `4052ba0 docs(policy): synchronize ADR-0031 acceptance reference (#122)`










