### PR TITLE
[ADR] feat(engine): add RocksDBEngine (#8)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ add_library(sitos STATIC
   src/key.cpp
   src/storage_engine.cpp
   src/in_memory_engine.cpp
+  src/rocksdb_engine.cpp
   src/logging.cpp
   src/storage_node.cpp
   src/session_view.cpp
@@ -137,7 +138,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
 endif()
 
 if(SITOS_WITH_ROCKSDB)
-  target_sources(sitos PRIVATE src/rocksdb_engine.cpp)
   target_link_libraries(sitos PUBLIC RocksDB::rocksdb)
   target_compile_definitions(sitos PRIVATE SITOS_WITH_ROCKSDB=1)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,17 @@ if(SITOS_WITH_ZENOH)
   include(cmake/zenohc.cmake)
 endif()
 
+if(SITOS_WITH_ROCKSDB)
+  find_package(RocksDB 11.1.2 EXACT CONFIG REQUIRED)
+  if(NOT RocksDB_VERSION VERSION_EQUAL 11.1.2)
+    message(FATAL_ERROR "Resolved RocksDB ${RocksDB_VERSION}, expected exactly 11.1.2")
+  endif()
+  if(NOT TARGET RocksDB::rocksdb)
+    message(FATAL_ERROR "RocksDB::rocksdb is required")
+  endif()
+  set(SITOS_ROCKSDB_VERSION "${RocksDB_VERSION}")
+endif()
+
 if(SITOS_BUILD_PYTHON)
   find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
   find_package(nanobind CONFIG REQUIRED)
@@ -123,6 +134,12 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
    AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)
   set_property(SOURCE src/param_value.cpp APPEND PROPERTY
     COMPILE_OPTIONS -Wno-free-nonheap-object)
+endif()
+
+if(SITOS_WITH_ROCKSDB)
+  target_sources(sitos PRIVATE src/rocksdb_engine.cpp)
+  target_link_libraries(sitos PUBLIC RocksDB::rocksdb)
+  target_compile_definitions(sitos PRIVATE SITOS_WITH_ROCKSDB=1)
 endif()
 
 if(SITOS_WITH_ZENOH)

--- a/cmake/sitosConfig.cmake.in
+++ b/cmake/sitosConfig.cmake.in
@@ -1,6 +1,12 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
 set(_sitos_with_zenoh "@SITOS_WITH_ZENOH@")
+set(_sitos_with_rocksdb "@SITOS_WITH_ROCKSDB@")
+if(_sitos_with_rocksdb)
+  find_dependency(RocksDB "@SITOS_ROCKSDB_VERSION@" EXACT CONFIG)
+endif()
+
 if(_sitos_with_zenoh AND NOT TARGET zenohc::zenohc)
   set(_sitos_module_path_defined FALSE)
   if(DEFINED CMAKE_MODULE_PATH)

--- a/docs/04_api_cpp.md
+++ b/docs/04_api_cpp.md
@@ -198,13 +198,19 @@ Bundled engines:
 /// Zero dependencies. TakeSnapshot performs a full copy [X02]
 class InMemoryEngine final : public StorageEngine { ... };
 
-/// Provided only when built with SITOS_WITH_ROCKSDB.
-/// TakeSnapshot is O(1) via rocksdb::DB::GetSnapshot [N02]
-class RocksDBEngine final : public StorageEngine {
+/// The PImpl-only public API is installed in both build modes. A functional implementation requires
+/// SITOS_WITH_ROCKSDB=ON; the OFF build returns Status::Error with operation_not_supported.
+/// TakeSnapshot consumes ADR-0004's O(1), copy-free native snapshot invariant [N02].
+class RocksDBEngine : public StorageEngine {
 public:
     static Result<std::unique_ptr<RocksDBEngine>> Open(const std::string& path);
 };
 ```
+
+The RocksDB-ON installed package reconstructs the exact RocksDB version used at build time. The
+installed consumer validates configure and compile/link only; runtime deployment remains with the
+application or package manager. Exact version equality is necessary but not sufficient for ABI
+compatibility. See ADR-0033.
 
 ```cpp
 class StorageNode {

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -40,7 +40,7 @@ sitos/
   - **zenoh-c**: First choice is to use official prebuilt releases via
     `find_package(zenohc)`. CI pins versions with FetchContent.
     Also provide a Corrosion (Rust) path for environments that need source builds
-  - **RocksDB** (when `SITOS_WITH_ROCKSDB=ON`): `find_package(RocksDB)`.
+  - **RocksDB** (when `SITOS_WITH_ROCKSDB=ON`): `find_package(RocksDB 11.1.2 EXACT CONFIG REQUIRED)`.
   - **gtest / benchmark**: FetchContent
 * Presets: define `dev-windows`, `dev-linux`, `release`, and `python-wheel` in
   `CMakePresets.json`
@@ -113,6 +113,13 @@ validator requires `dumpbin` from the `vcvars64.bat` environment. It does not re
 `z.dll` as `zlib1.dll`, depend on `rocksdb-shared.dll`, or use build-tree/vcpkg PATH entries.
 
 ## 3. Install (C++ consumer)
+
+When `SITOS_WITH_ROCKSDB=ON`, the installed package records the exact RocksDB version used to build
+sitos and reconstructs `RocksDB::rocksdb` with `find_dependency(RocksDB <version> EXACT CONFIG)`.
+RocksDB-ON installed consumers are configured and built/linked but not executed; runtime deployment
+belongs to the application or package manager. Exact version equality is necessary but not sufficient
+for ABI compatibility, so external consumers must provide a compatible compiler, CRT, standard
+library ABI, build configuration, and compile options. See ADR-0033.
 
 The C++ library and public headers can be installed with the generated CMake export:
 
@@ -225,6 +232,8 @@ major behaviors.
 | `BatchV1GoldenFixture` | F09/C01 | Exact match with the batch fixture in [03] §5.1 |
 | `InvalidKeysAreRejected` | X03 | Reject reserved characters, empty chunks, and invalid sid |
 | `SnapshotIsIsolatedFromBasePut` | F05/N02 | A base put after CreateSession does not affect snap reads |
+| `SnapshotIsIsolatedFromBaseDelete` | F05/N02 | A base delete after snapshot creation does not affect snap reads |
+| `ListEmitsDeterministicKeyOrder` | X01 | StorageEngine List emits matching keys in ascending order |
 | `SnapshotFallbackCopiesForInMemory` | N03 | InMemory snapshot works with the same semantics |
 | `AttachDoesNotMissConcurrentPut` | F06 | Does not miss a concurrent put during Attach |
 | `BatchIsReceivedBySessionSubscriber` | F09 / ADR-0018 | `:batch` is received by a `session/<sid>/**` subscription |

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -228,6 +228,11 @@ canonical static `RocksDB::rocksdb` target imports the baseline's zlib 1.3.2 run
 validation stages that file under its actual name, requires `dumpbin` from the `vcvars64.bat`
 environment, and rejects `zlib1.dll` compatibility copies and `rocksdb-shared.dll` dependencies.
 Historical backend failures and canonical cold/cached measurements are recorded in ADR-0031
-rather than duplicated in this policy document.
+rather than duplicated in this policy document. RocksDBEngine package reconstruction and snapshot
+lifetime are defined by ADR-0033. Installed RocksDB-ON consumers are configure/build/link-only and do
+not execute or stage runtime dependencies; runtime is covered by the RocksDB engine tests and the
+vcpkg clean-stage probe. Exact version equality is necessary but not sufficient for ABI compatibility,
+so external consumers own compiler, CRT, standard-library ABI, build configuration, and compile-option
+compatibility.
 
 (END OF DOCUMENT)

--- a/docs/adr/0033-rocksdb-engine-snapshot-and-package-boundary.md
+++ b/docs/adr/0033-rocksdb-engine-snapshot-and-package-boundary.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed — 2026-07-28
+Proposed — pending owner acceptance immediately before merge
 
 ## Context
 
@@ -21,7 +21,8 @@ packages, keep the OFF build linkable by making `RocksDBEngine::Open` return `St
 configuration time, and make installed-package dependency reconstruction exact, provider-neutral,
 relocatable, network-free, and non-bundling; an installed RocksDB-OFF package will neither discover
 nor require RocksDB. We will preserve ADR-0004's O(1), copy-free snapshot invariant by retaining
-shared database ownership until snapshot release; each `List` operation will fully materialize a
+shared database ownership until snapshot release and ordering native snapshot release before final
+database destruction and filesystem cleanup; each `List` operation will fully materialize a
 consistent read set before invoking user sinks, and no sink will run while an engine lock, native
 database lock, or iterator is held. We will run the reusable contract suite against the production
 library and build test-only native Open, CRUD, snapshot, and lifecycle seams into a separate

--- a/docs/adr/0033-rocksdb-engine-snapshot-and-package-boundary.md
+++ b/docs/adr/0033-rocksdb-engine-snapshot-and-package-boundary.md
@@ -14,21 +14,32 @@ hidden package-manager or runtime deployment behavior.
 
 ## Decision
 
-We will implement RocksDBEngine behind a PImpl-only public header, require the exact build-time
-RocksDB version when reconstructing RocksDB-ON installed packages, and keep RocksDB-OFF packages free
-of the dependency. We will consume ADR-0004's O(1), copy-free snapshot invariant while making shared
-DB ownership, snapshot release, final DB destruction, and filesystem cleanup ordering explicit. Read
-operations fully materialize each consistent List read set before invoking user sinks, and all sinks
-are invoked after native iterator and lock state has been released; sink invocation is never performed
-under an engine or native database lock.
+We will implement RocksDBEngine behind a PImpl-only public header that is installed in both
+RocksDB-ON and RocksDB-OFF packages. The OFF build remains linkable: RocksDBEngine::Open returns
+Status::Error with std::errc::operation_not_supported. The project configure gate requires
+RocksDB 11.1.2 EXACT and the RocksDB::rocksdb target. Installed package discovery is provider-neutral,
+relocatable, network-free, and non-bundling; an installed ON package reconstructs the exact build-time
+RocksDB dependency, while an installed OFF package discovers no RocksDB dependency.
+
+We will consume ADR-0004's O(1), copy-free snapshot invariant while making shared DB ownership,
+snapshot release, final DB destruction, and filesystem cleanup ordering explicit. Read operations
+fully materialize each consistent List read set before invoking user sinks, and all sinks are invoked
+after native iterator and lock state has been released; sink invocation is never performed under an
+engine or native database lock. Test-only native Open, CRUD, snapshot, and lifecycle seams are built
+only into test targets and are not part of the production library or installed archive.
 
 ## Consequences
 
 * Good: RocksDB snapshots can outlive the engine while retaining a live DB owner safely.
 * Good: `ReleaseSnapshot()` occurs before final DB destruction and directory removal, including on
   Windows where an open LOCK file prevents cleanup.
-* Good: Public headers and RocksDB-OFF packages remain independent of native RocksDB headers and
-  libraries.
+* Good: The PImpl public header is always installable, and RocksDB-OFF packages remain independent
+  of native RocksDB headers and libraries while providing a linkable unsupported Open stub.
+* Good: The ON configure and installed-package boundaries require RocksDB 11.1.2 EXACT through
+  RocksDB::rocksdb, with provider-neutral, relocatable, network-free, non-bundling discovery and
+  exact build-time dependency reconstruction.
+* Good: Test-only native Open, CRUD, snapshot, and lifecycle seams are excluded from production
+  library archives and installed packages.
 * Good: Installed RocksDB-ON consumers validate exact configure and compile/link dependency
   reconstruction without bundling or executing runtime deployment.
 * Good: Fully materialized List read sets provide consistent reads and deterministic, unlocked sink

--- a/docs/adr/0033-rocksdb-engine-snapshot-and-package-boundary.md
+++ b/docs/adr/0033-rocksdb-engine-snapshot-and-package-boundary.md
@@ -17,16 +17,19 @@ hidden package-manager or runtime deployment behavior.
 We will implement RocksDBEngine behind a PImpl-only public header that is installed in both
 RocksDB-ON and RocksDB-OFF packages. The OFF build remains linkable: RocksDBEngine::Open returns
 Status::Error with std::errc::operation_not_supported. The project configure gate requires
-RocksDB 11.1.2 EXACT and the RocksDB::rocksdb target. Installed package discovery is provider-neutral,
-relocatable, network-free, and non-bundling; an installed ON package reconstructs the exact build-time
-RocksDB dependency, while an installed OFF package discovers no RocksDB dependency.
+RocksDB 11.1.2 EXACT and the RocksDB::rocksdb target. Installed package discovery is
+provider-neutral, relocatable, network-free, and non-bundling; an installed ON package reconstructs
+the exact build-time RocksDB dependency, while an installed OFF package discovers no RocksDB
+dependency.
 
 We will consume ADR-0004's O(1), copy-free snapshot invariant while making shared DB ownership,
 snapshot release, final DB destruction, and filesystem cleanup ordering explicit. Read operations
-fully materialize each consistent List read set before invoking user sinks, and all sinks are invoked
+fully materialize each consistent List read set before invoking user sinks. All sinks are invoked
 after native iterator and lock state has been released; sink invocation is never performed under an
-engine or native database lock. Test-only native Open, CRUD, snapshot, and lifecycle seams are built
-only into test targets and are not part of the production library or installed archive.
+engine or native database lock. The reusable contract suite links the production library directly.
+Test-only native Open, CRUD, snapshot, and lifecycle seams run in an isolated executable that does
+not link the production archive, delegate successful operations to the shared native helpers, and
+are not part of the production library or installed archive.
 
 ## Consequences
 
@@ -38,8 +41,8 @@ only into test targets and are not part of the production library or installed a
 * Good: The ON configure and installed-package boundaries require RocksDB 11.1.2 EXACT through
   RocksDB::rocksdb, with provider-neutral, relocatable, network-free, non-bundling discovery and
   exact build-time dependency reconstruction.
-* Good: Test-only native Open, CRUD, snapshot, and lifecycle seams are excluded from production
-  library archives and installed packages.
+* Good: Contract tests execute the production library, while isolated test seams share native
+  helpers without introducing duplicate RocksDBEngine definitions or production archive symbols.
 * Good: Installed RocksDB-ON consumers validate exact configure and compile/link dependency
   reconstruction without bundling or executing runtime deployment.
 * Good: Fully materialized List read sets provide consistent reads and deterministic, unlocked sink

--- a/docs/adr/0033-rocksdb-engine-snapshot-and-package-boundary.md
+++ b/docs/adr/0033-rocksdb-engine-snapshot-and-package-boundary.md
@@ -2,73 +2,75 @@
 
 ## Status
 
-Proposed
+Proposed — 2026-07-28
 
 ## Context
 
-Issue #8 adds the optional persistent RocksDB StorageEngine and extends the installed CMake package
-with an exact external RocksDB dependency. ADR-0004 is the sole authority for O(1), copy-free native
-snapshot semantics, but it leaves ownership and filesystem cleanup ordering open. The implementation
-must remain available in RocksDB-OFF builds, preserve the existing StorageEngine contract, and avoid
-hidden package-manager or runtime deployment behavior.
+Issue #8 adds an optional persistent RocksDB implementation of `StorageEngine` and gives the
+installed CMake package an external dependency on an exact RocksDB version. ADR-0004 governs O(1),
+copy-free native snapshot semantics but does not define ownership or filesystem-cleanup ordering.
+The implementation must preserve the existing `StorageEngine` contract, remain available in
+RocksDB-OFF builds, avoid implicit package-manager activity, and keep runtime deployment outside
+installed-package validation.
 
 ## Decision
 
-We will implement RocksDBEngine behind a PImpl-only public header that is installed in both
-RocksDB-ON and RocksDB-OFF packages. The OFF build remains linkable: RocksDBEngine::Open returns
-Status::Error with std::errc::operation_not_supported. The project configure gate requires
-RocksDB 11.1.2 EXACT and the RocksDB::rocksdb target. Installed package discovery is
-provider-neutral, relocatable, network-free, and non-bundling; an installed ON package reconstructs
-the exact build-time RocksDB dependency, while an installed OFF package discovers no RocksDB
-dependency.
-
-We will consume ADR-0004's O(1), copy-free snapshot invariant while making shared DB ownership,
-snapshot release, final DB destruction, and filesystem cleanup ordering explicit. Read operations
-fully materialize each consistent List read set before invoking user sinks. All sinks are invoked
-after native iterator and lock state has been released; sink invocation is never performed under an
-engine or native database lock. The reusable contract suite links the production library directly.
-Test-only native Open, CRUD, snapshot, and lifecycle seams run in an isolated executable that does
-not link the production archive, delegate successful operations to the shared native helpers, and
-are not part of the production library or installed archive.
+We will install a PImpl-only `RocksDBEngine` public header in both RocksDB-ON and RocksDB-OFF
+packages, keep the OFF build linkable by making `RocksDBEngine::Open` return `Status::Error` with
+`std::errc::operation_not_supported`, require RocksDB 11.1.2 EXACT and `RocksDB::rocksdb` at
+configuration time, and make installed-package dependency reconstruction exact, provider-neutral,
+relocatable, network-free, and non-bundling; an installed RocksDB-OFF package will neither discover
+nor require RocksDB. We will preserve ADR-0004's O(1), copy-free snapshot invariant by retaining
+shared database ownership until snapshot release; each `List` operation will fully materialize a
+consistent read set before invoking user sinks, and no sink will run while an engine lock, native
+database lock, or iterator is held. We will run the reusable contract suite against the production
+library and build test-only native Open, CRUD, snapshot, and lifecycle seams into a separate
+executable that does not link the production archive; successful CRUD and snapshot seam operations
+will delegate to shared native helpers, and no seam symbols will enter the production library or
+installed archive.
 
 ## Consequences
 
-* Good: RocksDB snapshots can outlive the engine while retaining a live DB owner safely.
-* Good: `ReleaseSnapshot()` occurs before final DB destruction and directory removal, including on
-  Windows where an open LOCK file prevents cleanup.
+* Good: RocksDB snapshots can outlive the engine because they retain shared ownership of the live
+  database state.
+* Good: `ReleaseSnapshot()` occurs before final database destruction and directory removal,
+  including on Windows, where an open `LOCK` file prevents cleanup.
 * Good: The PImpl public header is always installable, and RocksDB-OFF packages remain independent
-  of native RocksDB headers and libraries while providing a linkable unsupported Open stub.
-* Good: The ON configure and installed-package boundaries require RocksDB 11.1.2 EXACT through
-  RocksDB::rocksdb, with provider-neutral, relocatable, network-free, non-bundling discovery and
-  exact build-time dependency reconstruction.
-* Good: Contract tests execute the production library, while isolated test seams share native
-  helpers without introducing duplicate RocksDBEngine definitions or production archive symbols.
-* Good: Installed RocksDB-ON consumers validate exact configure and compile/link dependency
-  reconstruction without bundling or executing runtime deployment.
-* Good: Fully materialized List read sets provide consistent reads and deterministic, unlocked sink
-  callbacks that may safely re-enter the engine.
+  of native RocksDB headers and libraries while providing a linkable `Open` stub that reports an
+  unsupported operation.
+* Good: RocksDB-ON configuration and installed-package reconstruction require RocksDB 11.1.2 EXACT
+  through `RocksDB::rocksdb`, with provider-neutral, relocatable, network-free, and non-bundling
+  discovery.
+* Good: Contract tests execute the production library, while isolated test seams reuse native
+  helpers without introducing duplicate `RocksDBEngine` definitions or production archive symbols.
+* Good: Installed RocksDB-ON consumers validate exact dependency reconstruction during
+  configuration and compile/link validation without bundling dependencies or executing the
+  installed consumer.
+* Good: Fully materialized `List` read sets provide consistent reads and deterministic, unlocked
+  sink callbacks that may safely re-enter the engine.
 * Bad: Exact version equality is necessary but not sufficient for ABI compatibility. External
   consumers remain responsible for compiler, CRT, standard-library ABI, build configuration, and
   relevant compile options.
-* Neutral: Runtime RocksDB deployment is validated by the executed engine tests and the existing
-  vcpkg clean-stage probe, while installed consumers are build/link-only.
+* Neutral: Executed engine tests and the existing vcpkg clean-stage probe validate RocksDB runtime
+  behavior, while installed consumers remain build/link-only.
 
 ## Options Considered
 
-* **Copy snapshots into a separate map** — rejected for RocksDB because ADR-0004 requires O(1),
-  copy-free native snapshots.
-* **Destroy the DB with the engine regardless of snapshots** — rejected because native snapshot
-  handles require the DB to remain alive until `ReleaseSnapshot()`.
-* **Remove the database directory from the engine destructor** — rejected because user-owned paths
-  and Windows LOCK-file lifetime make cleanup an explicit owner responsibility.
+* **Copy snapshots into a separate map** — rejected because ADR-0004 requires O(1), copy-free native
+  snapshots for RocksDB.
+* **Destroy the database with the engine regardless of live snapshots** — rejected because native
+  snapshot handles require the database to remain alive until `ReleaseSnapshot()`.
+* **Remove the database directory in the engine destructor** — rejected because paths are
+  user-owned, and the Windows `LOCK`-file lifetime makes cleanup an explicit owner responsibility.
 * **Allow any compatible RocksDB version in installed packages** — rejected until cross-version
-  compiler/link/run evidence exists; the build-time exact version is the current boundary.
+  compile, link, and runtime evidence exists; the exact build-time version is the current boundary.
 * **Execute installed RocksDB consumers** — rejected because runtime deployment belongs to the
-  application or package manager under ADR-0021; the #122 clean-stage probe owns runtime evidence.
+  application or package manager under ADR-0021; the Issue #122 clean-stage probe provides runtime
+  evidence.
 
 ## References
 
-* Issue #8 / PR implementing Issue #8
+* Issue #8 / PR #128
 * ADR-0004: Expose engine-native snapshots through the zenoh key space
 * ADR-0021: Resolve installed Zenoh dependencies without fetching or bundling
 * ADR-0031: Establish a cross-platform vcpkg foundation

--- a/docs/adr/0033-rocksdb-engine-snapshot-and-package-boundary.md
+++ b/docs/adr/0033-rocksdb-engine-snapshot-and-package-boundary.md
@@ -1,0 +1,55 @@
+# ADR-0033: Define the RocksDB engine, snapshot, and installed-package boundary
+
+## Status
+
+Proposed
+
+## Context
+
+Issue #8 adds the optional persistent RocksDB StorageEngine and extends the installed CMake package
+with an exact external RocksDB dependency. ADR-0004 is the sole authority for O(1), copy-free native
+snapshot semantics, but it leaves ownership and filesystem cleanup ordering open. The implementation
+must remain available in RocksDB-OFF builds, preserve the existing StorageEngine contract, and avoid
+hidden package-manager or runtime deployment behavior.
+
+## Decision
+
+We will implement RocksDBEngine behind a PImpl-only public header, require the exact build-time
+RocksDB version when reconstructing RocksDB-ON installed packages, and keep RocksDB-OFF packages free
+of the dependency. We will consume ADR-0004's O(1), copy-free snapshot invariant while making shared
+DB ownership, snapshot release, final DB destruction, and filesystem cleanup ordering explicit.
+
+## Consequences
+
+* Good: RocksDB snapshots can outlive the engine while retaining a live DB owner safely.
+* Good: `ReleaseSnapshot()` occurs before final DB destruction and directory removal, including on
+  Windows where an open LOCK file prevents cleanup.
+* Good: Public headers and RocksDB-OFF packages remain independent of native RocksDB headers and
+  libraries.
+* Good: Installed RocksDB-ON consumers validate exact configure and compile/link dependency
+  reconstruction without bundling or executing runtime deployment.
+* Bad: Exact version equality is necessary but not sufficient for ABI compatibility. External
+  consumers remain responsible for compiler, CRT, standard-library ABI, build configuration, and
+  relevant compile options.
+* Neutral: Runtime RocksDB deployment is validated by the executed engine tests and the existing
+  vcpkg clean-stage probe, while installed consumers are build/link-only.
+
+## Options Considered
+
+* **Copy snapshots into a separate map** — rejected for RocksDB because ADR-0004 requires O(1),
+  copy-free native snapshots.
+* **Destroy the DB with the engine regardless of snapshots** — rejected because native snapshot
+  handles require the DB to remain alive until `ReleaseSnapshot()`.
+* **Remove the database directory from the engine destructor** — rejected because user-owned paths
+  and Windows LOCK-file lifetime make cleanup an explicit owner responsibility.
+* **Allow any compatible RocksDB version in installed packages** — rejected until cross-version
+  compiler/link/run evidence exists; the build-time exact version is the current boundary.
+* **Execute installed RocksDB consumers** — rejected because runtime deployment belongs to the
+  application or package manager under ADR-0021; the #122 clean-stage probe owns runtime evidence.
+
+## References
+
+* Issue #8 / PR implementing Issue #8
+* ADR-0004: Expose engine-native snapshots through the zenoh key space
+* ADR-0021: Resolve installed Zenoh dependencies without fetching or bundling
+* ADR-0031: Establish a cross-platform vcpkg foundation

--- a/docs/adr/0033-rocksdb-engine-snapshot-and-package-boundary.md
+++ b/docs/adr/0033-rocksdb-engine-snapshot-and-package-boundary.md
@@ -17,7 +17,10 @@ hidden package-manager or runtime deployment behavior.
 We will implement RocksDBEngine behind a PImpl-only public header, require the exact build-time
 RocksDB version when reconstructing RocksDB-ON installed packages, and keep RocksDB-OFF packages free
 of the dependency. We will consume ADR-0004's O(1), copy-free snapshot invariant while making shared
-DB ownership, snapshot release, final DB destruction, and filesystem cleanup ordering explicit.
+DB ownership, snapshot release, final DB destruction, and filesystem cleanup ordering explicit. Read
+operations fully materialize each consistent List read set before invoking user sinks, and all sinks
+are invoked after native iterator and lock state has been released; sink invocation is never performed
+under an engine or native database lock.
 
 ## Consequences
 
@@ -28,6 +31,8 @@ DB ownership, snapshot release, final DB destruction, and filesystem cleanup ord
   libraries.
 * Good: Installed RocksDB-ON consumers validate exact configure and compile/link dependency
   reconstruction without bundling or executing runtime deployment.
+* Good: Fully materialized List read sets provide consistent reads and deterministic, unlocked sink
+  callbacks that may safely re-enter the engine.
 * Bad: Exact version equality is necessary but not sufficient for ABI compatibility. External
   consumers remain responsible for compiler, CRT, standard-library ABI, build configuration, and
   relevant compile options.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,3 +35,4 @@ See [docs/10_adr_process.md](../10_adr_process.md) for the process.
 | [0028](0028-unify-acknowledged-operation-results.md) | Unify acknowledged operation results |
 | [0030](0030-param-store-subscription-lifetime-and-delivery.md) | Define ParamStore subscription lifetime and delivery semantics |
 | [0031](0031-cross-platform-vcpkg-foundation.md) | Establish a cross-platform vcpkg foundation |
+| [0033](0033-rocksdb-engine-snapshot-and-package-boundary.md) | Define the RocksDB engine, snapshot, and installed-package boundary |

--- a/include/sitos/rocksdb_engine.hpp
+++ b/include/sitos/rocksdb_engine.hpp
@@ -4,7 +4,6 @@
 #ifndef SITOS_ROCKSDB_ENGINE_HPP
 #define SITOS_ROCKSDB_ENGINE_HPP
 
-#include <cstddef>
 #include <memory>
 #include <string>
 
@@ -36,11 +35,6 @@ class RocksDBEngine : public StorageEngine {
  private:
   struct Impl;
   explicit RocksDBEngine(std::unique_ptr<Impl> impl);
-  void SetFailureMaskForTest(unsigned int mask);
-  void GetSnapshotStatsForTest(std::size_t& snapshot_calls,
-                               std::size_t& enumeration_calls) const;
-
-  friend class RocksDBEngineTestAccess;
   std::unique_ptr<Impl> impl_;
 };
 

--- a/include/sitos/rocksdb_engine.hpp
+++ b/include/sitos/rocksdb_engine.hpp
@@ -1,0 +1,49 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SITOS_ROCKSDB_ENGINE_HPP
+#define SITOS_ROCKSDB_ENGINE_HPP
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+#include "sitos/result.hpp"
+#include "sitos/storage_engine.hpp"
+
+namespace sitos {
+
+/// Persistent StorageEngine backed by RocksDB when SITOS_WITH_ROCKSDB is enabled.
+/// The public header intentionally contains no RocksDB types.
+class RocksDBEngine : public StorageEngine {
+ public:
+  /// Opens or creates a database at path.
+  static Result<std::unique_ptr<RocksDBEngine>> Open(const std::string& path);
+
+  ~RocksDBEngine() override;
+
+  RocksDBEngine(const RocksDBEngine&) = delete;
+  RocksDBEngine& operator=(const RocksDBEngine&) = delete;
+  RocksDBEngine(RocksDBEngine&&) = delete;
+  RocksDBEngine& operator=(RocksDBEngine&&) = delete;
+
+  bool Put(std::string_view key, Bytes value) override;
+  bool Delete(std::string_view key) override;
+  bool Get(std::string_view key, const EntrySink& sink) const override;
+  bool List(std::string_view prefix, const EntrySink& sink) const override;
+  std::shared_ptr<const StorageReader> TakeSnapshot() const override;
+
+ private:
+  struct Impl;
+  explicit RocksDBEngine(std::unique_ptr<Impl> impl);
+  void SetFailureMaskForTest(unsigned int mask);
+  void GetSnapshotStatsForTest(std::size_t& snapshot_calls,
+                               std::size_t& enumeration_calls) const;
+
+  friend class RocksDBEngineTestAccess;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace sitos
+
+#endif  // SITOS_ROCKSDB_ENGINE_HPP

--- a/include/sitos/sitos.hpp
+++ b/include/sitos/sitos.hpp
@@ -16,6 +16,7 @@
 #include "sitos/param_subscription.hpp"
 #include "sitos/param_value.hpp"
 #include "sitos/result.hpp"
+#include "sitos/rocksdb_engine.hpp"
 #include "sitos/session.hpp"
 #include "sitos/session_view.hpp"
 #include "sitos/status.hpp"

--- a/src/rocksdb_engine.cpp
+++ b/src/rocksdb_engine.cpp
@@ -143,7 +143,9 @@ Result<std::unique_ptr<RocksDBEngine>> RocksDBEngine::Open(const std::string& pa
                                                        "RocksDB open failed: " + status.ToString(),
                                                        MakeRocksDBError(status));
   }
-  auto database = std::make_shared<DatabaseState>(std::shared_ptr<rocksdb::DB>(raw_db));
+  std::unique_ptr<rocksdb::DB> owned_db(raw_db);
+  auto database = std::make_shared<DatabaseState>(
+      std::shared_ptr<rocksdb::DB>(std::move(owned_db)));
   return Result<std::unique_ptr<RocksDBEngine>>::Ok(
       std::unique_ptr<RocksDBEngine>(
           new RocksDBEngine(std::make_unique<Impl>(std::move(database)))));

--- a/src/rocksdb_engine.cpp
+++ b/src/rocksdb_engine.cpp
@@ -25,7 +25,7 @@
 #include <rocksdb/status.h>
 #endif
 
-#if defined(SITOS_WITH_ROCKSDB)
+#if defined(SITOS_WITH_ROCKSDB) && defined(SITOS_ROCKSDB_TEST_SEAM)
 #include "rocksdb_engine_test_access.hpp"
 #endif
 
@@ -57,6 +57,7 @@ std::error_code MakeRocksDBError(const rocksdb::Status& status) {
   return {static_cast<int>(code) + 1, RocksDBCategory()};
 }
 
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
 struct OperationAdapter {
   using Put = std::function<rocksdb::Status(rocksdb::DB&, const rocksdb::WriteOptions&,
                                              const rocksdb::Slice&, const rocksdb::Slice&)>;
@@ -67,12 +68,30 @@ struct OperationAdapter {
   using List = std::function<rocksdb::Status(
       rocksdb::DB&, const rocksdb::ReadOptions&, std::string_view,
       std::vector<std::pair<std::string, std::vector<std::byte>>>&)>;
+  using GetSnapshot = std::function<const rocksdb::Snapshot*(rocksdb::DB&)>;
+  using ReleaseSnapshot = std::function<void(rocksdb::DB&, const rocksdb::Snapshot*)>;
 
   Put put;
   Delete delete_key;
   Get get;
   List list;
+  GetSnapshot get_snapshot;
+  ReleaseSnapshot release_snapshot;
 };
+
+using OpenOperation = std::function<rocksdb::Status(
+    const rocksdb::Options&, const std::string&, std::unique_ptr<rocksdb::DB>*)>;
+
+std::mutex open_operation_mutex;
+OpenOperation open_operation = [](const rocksdb::Options& options, const std::string& path,
+                                  std::unique_ptr<rocksdb::DB>* database) {
+  return rocksdb::DB::Open(options, path, database);
+};
+
+OpenOperation OpenOperationForTest() {
+  std::lock_guard lock(open_operation_mutex);
+  return open_operation;
+}
 
 OperationAdapter MakeOperationAdapter(unsigned int failures = 0) {
   OperationAdapter adapter;
@@ -117,26 +136,40 @@ OperationAdapter MakeOperationAdapter(unsigned int failures = 0) {
     }
     return iterator->status();
   };
+  adapter.get_snapshot = [](rocksdb::DB& db) { return db.GetSnapshot(); };
+  adapter.release_snapshot = [](rocksdb::DB& db, const rocksdb::Snapshot* snapshot) {
+    db.ReleaseSnapshot(snapshot);
+  };
   return adapter;
 }
 
+#endif
+
 struct DatabaseState {
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
   DatabaseState(std::shared_ptr<rocksdb::DB> database,
                 std::shared_ptr<rocksdb_test::EventLog> event_log)
       : db(std::move(database)), events(std::move(event_log)), operations(MakeOperationAdapter()) {}
+#else
+  explicit DatabaseState(std::shared_ptr<rocksdb::DB> database) : db(std::move(database)) {}
+#endif
 
   std::shared_ptr<rocksdb::DB> db;
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
   std::shared_ptr<rocksdb_test::EventLog> events;
   std::mutex operations_mutex;
   OperationAdapter operations;
   std::atomic<std::size_t> snapshot_calls{0};
   std::atomic<std::size_t> enumeration_calls{0};
+#endif
 };
 
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
 OperationAdapter Operations(const std::shared_ptr<DatabaseState>& state) {
   std::lock_guard lock(state->operations_mutex);
   return state->operations;
 }
+#endif
 
 class RocksDBSnapshot final : public StorageReader {
  public:
@@ -145,8 +178,14 @@ class RocksDBSnapshot final : public StorageReader {
 
   ~RocksDBSnapshot() override {
     if (snapshot_ != nullptr) {
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
+      Operations(state_).release_snapshot(*state_->db, snapshot_);
+#else
       state_->db->ReleaseSnapshot(snapshot_);
+#endif
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
       state_->events->Add("release_snapshot");
+#endif
     }
   }
 
@@ -159,11 +198,19 @@ class RocksDBSnapshot final : public StorageReader {
     std::string value;
     rocksdb::ReadOptions options;
     options.snapshot = snapshot_;
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
     if (const rocksdb::Status status = Operations(state_).get(
             *state_->db, options, rocksdb::Slice(key.data(), key.size()), &value);
         status.IsNotFound() || !status.ok()) {
       return false;
     }
+#else
+    if (const rocksdb::Status status =
+            state_->db->Get(options, rocksdb::Slice(key.data(), key.size()), &value);
+        status.IsNotFound() || !status.ok()) {
+      return false;
+    }
+#endif
     sink(key, std::span<const std::byte>(reinterpret_cast<const std::byte*>(value.data()),
                                           value.size()));
     return true;
@@ -173,9 +220,28 @@ class RocksDBSnapshot final : public StorageReader {
     std::vector<std::pair<std::string, std::vector<std::byte>>> entries;
     rocksdb::ReadOptions options;
     options.snapshot = snapshot_;
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
     state_->enumeration_calls.fetch_add(1);
     const rocksdb::Status status = Operations(state_).list(*state_->db, options, prefix, entries);
     if (!status.ok()) return false;
+#else
+    {
+      std::unique_ptr<rocksdb::Iterator> iterator(state_->db->NewIterator(options));
+      iterator->Seek(rocksdb::Slice(prefix.data(), prefix.size()));
+      while (iterator->Valid()) {
+        const rocksdb::Slice entry_key = iterator->key();
+        if (!std::string_view(entry_key.data(), entry_key.size()).starts_with(prefix)) break;
+        const rocksdb::Slice value = iterator->value();
+        entries.emplace_back(
+            std::string(entry_key.data(), entry_key.size()),
+            std::vector<std::byte>(
+                reinterpret_cast<const std::byte*>(value.data()),
+                reinterpret_cast<const std::byte*>(value.data()) + value.size()));
+        iterator->Next();
+      }
+      if (!iterator->status().ok()) return false;
+    }
+#endif
     return std::ranges::all_of(entries, [&sink](const auto& entry) {
       const auto& [entry_key, value] = entry;
       return sink(entry_key, value);
@@ -187,6 +253,7 @@ class RocksDBSnapshot final : public StorageReader {
   const rocksdb::Snapshot* snapshot_;
 };
 
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
 std::mutex registry_mutex;
 std::unordered_map<const RocksDBEngine*, std::weak_ptr<DatabaseState>> registry;
 
@@ -206,6 +273,7 @@ std::shared_ptr<DatabaseState> StateFor(const RocksDBEngine* engine) {
   return it == registry.end() ? nullptr : it->second.lock();
 }
 #endif
+#endif
 
 }  // namespace
 
@@ -217,13 +285,13 @@ struct RocksDBEngine::Impl {
 };
 
 RocksDBEngine::RocksDBEngine(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {
-#if defined(SITOS_WITH_ROCKSDB)
+#if defined(SITOS_WITH_ROCKSDB) && defined(SITOS_ROCKSDB_TEST_SEAM)
   Register(this, impl_->state);
 #endif
 }
 
 RocksDBEngine::~RocksDBEngine() {
-#if defined(SITOS_WITH_ROCKSDB)
+#if defined(SITOS_WITH_ROCKSDB) && defined(SITOS_ROCKSDB_TEST_SEAM)
   Unregister(this);
 #endif
 }
@@ -238,13 +306,19 @@ Result<std::unique_ptr<RocksDBEngine>> RocksDBEngine::Open(const std::string& pa
   rocksdb::Options options;
   options.create_if_missing = true;
   std::unique_ptr<rocksdb::DB> owned_db;
-  if (const rocksdb::Status status = rocksdb::DB::Open(options, path, &owned_db);
-      !status.ok()) {
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
+  const rocksdb::Status status = OpenOperationForTest()(options, path, &owned_db);
+#else
+  const rocksdb::Status status = rocksdb::DB::Open(options, path, &owned_db);
+#endif
+  if (!status.ok()) {
     return Result<std::unique_ptr<RocksDBEngine>>::Err(
         Status::Error, std::format("RocksDB open failed: {}", status.ToString()),
         MakeRocksDBError(status));
   }
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
   auto event_log = std::make_shared<rocksdb_test::EventLog>();
+  event_log->Add("open");
   std::weak_ptr<rocksdb_test::EventLog> weak_events = event_log;
   std::shared_ptr<rocksdb::DB> shared_db(
       owned_db.release(), [weak_events](rocksdb::DB* database) {
@@ -252,6 +326,10 @@ Result<std::unique_ptr<RocksDBEngine>> RocksDBEngine::Open(const std::string& pa
         if (const auto events = weak_events.lock()) events->Add("db_close");
       });
   auto database = std::make_shared<DatabaseState>(std::move(shared_db), std::move(event_log));
+#else
+  auto database = std::make_shared<DatabaseState>(
+      std::shared_ptr<rocksdb::DB>(owned_db.release()));
+#endif
   return Result<std::unique_ptr<RocksDBEngine>>::Ok(
       std::unique_ptr<RocksDBEngine>(
           new RocksDBEngine(std::make_unique<Impl>(std::move(database)))));
@@ -265,9 +343,15 @@ Result<std::unique_ptr<RocksDBEngine>> RocksDBEngine::Open(const std::string& pa
 
 bool RocksDBEngine::Put(std::string_view key, Bytes value) {
 #if defined(SITOS_WITH_ROCKSDB)
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
   const rocksdb::Status status = Operations(impl_->state).put(
       *impl_->state->db, rocksdb::WriteOptions{}, rocksdb::Slice(key.data(), key.size()),
       rocksdb::Slice(reinterpret_cast<const char*>(value.data()), value.size()));
+#else
+  const rocksdb::Status status = impl_->state->db->Put(
+      rocksdb::WriteOptions{}, rocksdb::Slice(key.data(), key.size()),
+      rocksdb::Slice(reinterpret_cast<const char*>(value.data()), value.size()));
+#endif
   return status.ok();
 #else
   static_cast<void>(key);
@@ -278,9 +362,15 @@ bool RocksDBEngine::Put(std::string_view key, Bytes value) {
 
 bool RocksDBEngine::Delete(std::string_view key) {
 #if defined(SITOS_WITH_ROCKSDB)
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
   return Operations(impl_->state).delete_key(
              *impl_->state->db, rocksdb::WriteOptions{}, rocksdb::Slice(key.data(), key.size()))
       .ok();
+#else
+  return impl_->state->db
+      ->Delete(rocksdb::WriteOptions{}, rocksdb::Slice(key.data(), key.size()))
+      .ok();
+#endif
 #else
   static_cast<void>(key);
   return false;
@@ -290,12 +380,20 @@ bool RocksDBEngine::Delete(std::string_view key) {
 bool RocksDBEngine::Get(std::string_view key, const EntrySink& sink) const {
 #if defined(SITOS_WITH_ROCKSDB)
   std::string value;
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
   if (const rocksdb::Status status = Operations(impl_->state).get(
           *impl_->state->db, rocksdb::ReadOptions{}, rocksdb::Slice(key.data(), key.size()),
           &value);
       status.IsNotFound() || !status.ok()) {
     return false;
   }
+#else
+  if (const rocksdb::Status status = impl_->state->db->Get(
+          rocksdb::ReadOptions{}, rocksdb::Slice(key.data(), key.size()), &value);
+      status.IsNotFound() || !status.ok()) {
+    return false;
+  }
+#endif
   sink(key, std::span<const std::byte>(reinterpret_cast<const std::byte*>(value.data()),
                                         value.size()));
   return true;
@@ -309,12 +407,32 @@ bool RocksDBEngine::Get(std::string_view key, const EntrySink& sink) const {
 bool RocksDBEngine::List(std::string_view prefix, const EntrySink& sink) const {
 #if defined(SITOS_WITH_ROCKSDB)
   std::vector<std::pair<std::string, std::vector<std::byte>>> entries;
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
   impl_->state->enumeration_calls.fetch_add(1);
   if (const rocksdb::Status status = Operations(impl_->state).list(
           *impl_->state->db, rocksdb::ReadOptions{}, prefix, entries);
       !status.ok()) {
     return false;
   }
+#else
+  {
+    std::unique_ptr<rocksdb::Iterator> iterator(
+        impl_->state->db->NewIterator(rocksdb::ReadOptions{}));
+    iterator->Seek(rocksdb::Slice(prefix.data(), prefix.size()));
+    while (iterator->Valid()) {
+      const rocksdb::Slice entry_key = iterator->key();
+      if (!std::string_view(entry_key.data(), entry_key.size()).starts_with(prefix)) break;
+      const rocksdb::Slice value = iterator->value();
+      entries.emplace_back(
+          std::string(entry_key.data(), entry_key.size()),
+          std::vector<std::byte>(
+              reinterpret_cast<const std::byte*>(value.data()),
+              reinterpret_cast<const std::byte*>(value.data()) + value.size()));
+      iterator->Next();
+    }
+    if (!iterator->status().ok()) return false;
+  }
+#endif
   return std::ranges::all_of(entries, [&sink](const auto& entry) {
     const auto& [entry_key, value] = entry;
     return sink(entry_key, value);
@@ -328,14 +446,22 @@ bool RocksDBEngine::List(std::string_view prefix, const EntrySink& sink) const {
 
 std::shared_ptr<const StorageReader> RocksDBEngine::TakeSnapshot() const {
 #if defined(SITOS_WITH_ROCKSDB)
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
+  const rocksdb::Snapshot* snapshot = Operations(impl_->state).get_snapshot(*impl_->state->db);
   impl_->state->snapshot_calls.fetch_add(1);
-  const rocksdb::Snapshot* snapshot = impl_->state->db->GetSnapshot();
   impl_->state->events->Add("get_snapshot");
+#else
+  const rocksdb::Snapshot* snapshot = impl_->state->db->GetSnapshot();
+#endif
   try {
     return std::make_shared<RocksDBSnapshot>(impl_->state, snapshot);
   } catch (...) {
-    impl_->state->db->ReleaseSnapshot(snapshot);
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
+    Operations(impl_->state).release_snapshot(*impl_->state->db, snapshot);
     impl_->state->events->Add("release_snapshot");
+#else
+    impl_->state->db->ReleaseSnapshot(snapshot);
+#endif
     throw;
   }
 #else
@@ -343,8 +469,20 @@ std::shared_ptr<const StorageReader> RocksDBEngine::TakeSnapshot() const {
 #endif
 }
 
-#if defined(SITOS_WITH_ROCKSDB)
+#if defined(SITOS_WITH_ROCKSDB) && defined(SITOS_ROCKSDB_TEST_SEAM)
 namespace rocksdb_test {
+
+void SetOpenFailureForTest() {
+  std::lock_guard lock(open_operation_mutex);
+  const auto remaining = std::make_shared<std::atomic_bool>(true);
+  open_operation = [remaining](const rocksdb::Options& options, const std::string& path,
+                               std::unique_ptr<rocksdb::DB>* database) {
+    if (remaining->exchange(false)) {
+      return rocksdb::Status::IOError("injected Open failure");
+    }
+    return rocksdb::DB::Open(options, path, database);
+  };
+}
 
 void SetFailures(RocksDBEngine& engine, unsigned int failures) {
   const auto state = StateFor(&engine);

--- a/src/rocksdb_engine.cpp
+++ b/src/rocksdb_engine.cpp
@@ -1,0 +1,248 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/rocksdb_engine.hpp"
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#if defined(SITOS_WITH_ROCKSDB)
+#include <rocksdb/db.h>
+#include <rocksdb/options.h>
+#include <rocksdb/slice.h>
+#include <rocksdb/status.h>
+#endif
+
+namespace sitos {
+namespace {
+
+#if defined(SITOS_WITH_ROCKSDB)
+class RocksDBErrorCategory final : public std::error_category {
+ public:
+  const char* name() const noexcept override { return "sitos.rocksdb"; }
+  std::string message(int value) const override {
+    return "RocksDB failure (code " + std::to_string(value) + ")";
+  }
+};
+
+const std::error_category& RocksDBCategory() noexcept {
+  static const RocksDBErrorCategory category;
+  return category;
+}
+
+std::error_code MakeRocksDBError(const rocksdb::Status& status) {
+  return {static_cast<int>(status.code()) + 1, RocksDBCategory()};
+}
+#endif
+
+constexpr unsigned int kFailPut = 1U << 0;
+constexpr unsigned int kFailDelete = 1U << 1;
+constexpr unsigned int kFailGet = 1U << 2;
+constexpr unsigned int kFailList = 1U << 3;
+
+#if defined(SITOS_WITH_ROCKSDB)
+struct DatabaseState {
+  explicit DatabaseState(std::shared_ptr<rocksdb::DB> database) : db(std::move(database)) {}
+
+  std::shared_ptr<rocksdb::DB> db;
+  std::atomic<unsigned int> failures{0};
+  std::atomic<std::size_t> snapshot_calls{0};
+  std::atomic<std::size_t> enumeration_calls{0};
+};
+
+bool Enumerate(rocksdb::DB& db, const rocksdb::ReadOptions& options,
+               std::string_view prefix, const EntrySink& sink,
+               std::atomic<std::size_t>* enumeration_calls = nullptr) {
+  if (enumeration_calls != nullptr) {
+    enumeration_calls->fetch_add(1, std::memory_order_relaxed);
+  }
+  std::vector<std::pair<std::string, std::vector<std::byte>>> entries;
+  std::unique_ptr<rocksdb::Iterator> iterator(db.NewIterator(options));
+  for (iterator->Seek(rocksdb::Slice(prefix.data(), prefix.size())); iterator->Valid();
+       iterator->Next()) {
+    const rocksdb::Slice key = iterator->key();
+    if (!std::string_view(key.data(), key.size()).starts_with(prefix)) break;
+    const rocksdb::Slice value = iterator->value();
+    entries.emplace_back(std::string(key.data(), key.size()),
+                         std::vector<std::byte>(
+                             reinterpret_cast<const std::byte*>(value.data()),
+                             reinterpret_cast<const std::byte*>(value.data()) + value.size()));
+  }
+  if (!iterator->status().ok()) return false;
+  for (const auto& [entry_key, value] : entries) {
+    if (!sink(entry_key, value)) return false;
+  }
+  return true;
+}
+
+class RocksDBSnapshot final : public StorageReader {
+ public:
+  RocksDBSnapshot(std::shared_ptr<DatabaseState> state, const rocksdb::Snapshot* snapshot)
+      : state_(std::move(state)), snapshot_(snapshot) {}
+
+  ~RocksDBSnapshot() override {
+    if (snapshot_ != nullptr) state_->db->ReleaseSnapshot(snapshot_);
+  }
+
+  bool Get(std::string_view key, const EntrySink& sink) const override {
+    if ((state_->failures.load(std::memory_order_relaxed) & kFailGet) != 0) return false;
+    rocksdb::ReadOptions options;
+    options.snapshot = snapshot_;
+    std::string value;
+    const rocksdb::Status status =
+        state_->db->Get(options, rocksdb::Slice(key.data(), key.size()), &value);
+    if (status.IsNotFound() || !status.ok()) return false;
+    sink(key, std::span<const std::byte>(reinterpret_cast<const std::byte*>(value.data()),
+                                          value.size()));
+    return true;
+  }
+
+  bool List(std::string_view prefix, const EntrySink& sink) const override {
+    if ((state_->failures.load(std::memory_order_relaxed) & kFailList) != 0) return false;
+    rocksdb::ReadOptions options;
+    options.snapshot = snapshot_;
+    return Enumerate(*state_->db, options, prefix, sink, &state_->enumeration_calls);
+  }
+
+ private:
+  std::shared_ptr<DatabaseState> state_;
+  const rocksdb::Snapshot* snapshot_;
+};
+#endif
+
+}  // namespace
+
+struct RocksDBEngine::Impl {
+#if defined(SITOS_WITH_ROCKSDB)
+  explicit Impl(std::shared_ptr<DatabaseState> database) : state(std::move(database)) {}
+  std::shared_ptr<DatabaseState> state;
+#endif
+};
+
+RocksDBEngine::RocksDBEngine(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {}
+RocksDBEngine::~RocksDBEngine() = default;
+
+Result<std::unique_ptr<RocksDBEngine>> RocksDBEngine::Open(const std::string& path) {
+#if defined(SITOS_WITH_ROCKSDB)
+  if (path.empty()) {
+    return Result<std::unique_ptr<RocksDBEngine>>::Err(
+        Status::InvalidArgument, "RocksDB path must not be empty",
+        std::make_error_code(std::errc::invalid_argument));
+  }
+  rocksdb::Options options;
+  options.create_if_missing = true;
+  rocksdb::DB* raw_db = nullptr;
+  const rocksdb::Status status = rocksdb::DB::Open(options, path, &raw_db);
+  if (!status.ok()) {
+    return Result<std::unique_ptr<RocksDBEngine>>::Err(Status::Error,
+                                                       "RocksDB open failed: " + status.ToString(),
+                                                       MakeRocksDBError(status));
+  }
+  auto database = std::make_shared<DatabaseState>(std::shared_ptr<rocksdb::DB>(raw_db));
+  return Result<std::unique_ptr<RocksDBEngine>>::Ok(
+      std::unique_ptr<RocksDBEngine>(
+          new RocksDBEngine(std::make_unique<Impl>(std::move(database)))));
+#else
+  static_cast<void>(path);
+  return Result<std::unique_ptr<RocksDBEngine>>::Err(
+      Status::Error, "RocksDB support is disabled",
+      std::make_error_code(std::errc::operation_not_supported));
+#endif
+}
+
+bool RocksDBEngine::Put(std::string_view key, Bytes value) {
+#if defined(SITOS_WITH_ROCKSDB)
+  if ((impl_->state->failures.load(std::memory_order_relaxed) & kFailPut) != 0) return false;
+  const rocksdb::Status status = impl_->state->db->Put(
+      rocksdb::WriteOptions{}, rocksdb::Slice(key.data(), key.size()),
+      rocksdb::Slice(reinterpret_cast<const char*>(value.data()), value.size()));
+  return status.ok();
+#else
+  static_cast<void>(key);
+  static_cast<void>(value);
+  return false;
+#endif
+}
+
+bool RocksDBEngine::Delete(std::string_view key) {
+#if defined(SITOS_WITH_ROCKSDB)
+  if ((impl_->state->failures.load(std::memory_order_relaxed) & kFailDelete) != 0) return false;
+  return impl_->state->db
+      ->Delete(rocksdb::WriteOptions{}, rocksdb::Slice(key.data(), key.size()))
+      .ok();
+#else
+  static_cast<void>(key);
+  return false;
+#endif
+}
+
+bool RocksDBEngine::Get(std::string_view key, const EntrySink& sink) const {
+#if defined(SITOS_WITH_ROCKSDB)
+  if ((impl_->state->failures.load(std::memory_order_relaxed) & kFailGet) != 0) return false;
+  std::string value;
+  const rocksdb::Status status = impl_->state->db->Get(
+      rocksdb::ReadOptions{}, rocksdb::Slice(key.data(), key.size()), &value);
+  if (status.IsNotFound() || !status.ok()) return false;
+  sink(key, std::span<const std::byte>(reinterpret_cast<const std::byte*>(value.data()),
+                                        value.size()));
+  return true;
+#else
+  static_cast<void>(key);
+  static_cast<void>(sink);
+  return false;
+#endif
+}
+
+bool RocksDBEngine::List(std::string_view prefix, const EntrySink& sink) const {
+#if defined(SITOS_WITH_ROCKSDB)
+  if ((impl_->state->failures.load(std::memory_order_relaxed) & kFailList) != 0) return false;
+  rocksdb::ReadOptions options;
+  return Enumerate(*impl_->state->db, options, prefix, sink,
+                   &impl_->state->enumeration_calls);
+#else
+  static_cast<void>(prefix);
+  static_cast<void>(sink);
+  return false;
+#endif
+}
+
+std::shared_ptr<const StorageReader> RocksDBEngine::TakeSnapshot() const {
+#if defined(SITOS_WITH_ROCKSDB)
+  impl_->state->snapshot_calls.fetch_add(1, std::memory_order_relaxed);
+  const rocksdb::Snapshot* snapshot = impl_->state->db->GetSnapshot();
+  try {
+    return std::make_shared<RocksDBSnapshot>(impl_->state, snapshot);
+  } catch (...) {
+    impl_->state->db->ReleaseSnapshot(snapshot);
+    throw;
+  }
+#else
+  return nullptr;
+#endif
+}
+
+void RocksDBEngine::GetSnapshotStatsForTest(std::size_t& snapshot_calls,
+                                             std::size_t& enumeration_calls) const {
+#if defined(SITOS_WITH_ROCKSDB)
+  snapshot_calls = impl_->state->snapshot_calls.load(std::memory_order_relaxed);
+  enumeration_calls = impl_->state->enumeration_calls.load(std::memory_order_relaxed);
+#else
+  snapshot_calls = 0;
+  enumeration_calls = 0;
+#endif
+}
+
+void RocksDBEngine::SetFailureMaskForTest(unsigned int mask) {
+#if defined(SITOS_WITH_ROCKSDB)
+  impl_->state->failures.store(mask, std::memory_order_relaxed);
+#else
+  static_cast<void>(mask);
+#endif
+}
+
+}  // namespace sitos

--- a/src/rocksdb_engine.cpp
+++ b/src/rocksdb_engine.cpp
@@ -10,6 +10,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <new>
 #include <string>
 #include <string_view>
 #include <system_error>
@@ -52,9 +53,8 @@ const std::error_category& RocksDBCategory() noexcept {
 }
 
 std::error_code MakeRocksDBError(const rocksdb::Status& status) {
-  using StatusCodeType = std::underlying_type_t<rocksdb::Status::Code>;
-  const auto code = static_cast<StatusCodeType>(status.code());
-  return {static_cast<int>(code) + 1, RocksDBCategory()};
+  const auto code = static_cast<int>(status.code());
+  return {code + 1, RocksDBCategory()};
 }
 
 #if defined(SITOS_ROCKSDB_TEST_SEAM)
@@ -82,15 +82,23 @@ struct OperationAdapter {
 using OpenOperation = std::function<rocksdb::Status(
     const rocksdb::Options&, const std::string&, std::unique_ptr<rocksdb::DB>*)>;
 
-std::mutex open_operation_mutex;
-OpenOperation open_operation = [](const rocksdb::Options& options, const std::string& path,
-                                  std::unique_ptr<rocksdb::DB>* database) {
-  return rocksdb::DB::Open(options, path, database);
+struct OpenOperationState {
+  std::mutex mutex;
+  OpenOperation operation = [](const rocksdb::Options& options, const std::string& path,
+                               std::unique_ptr<rocksdb::DB>* database) {
+    return rocksdb::DB::Open(options, path, database);
+  };
 };
 
+OpenOperationState& GetOpenOperationState() {
+  static OpenOperationState state;
+  return state;
+}
+
 OpenOperation OpenOperationForTest() {
-  std::lock_guard lock(open_operation_mutex);
-  return open_operation;
+  auto& state = GetOpenOperationState();
+  std::lock_guard lock(state.mutex);
+  return state.operation;
 }
 
 OperationAdapter MakeOperationAdapter(unsigned int failures = 0) {
@@ -145,11 +153,20 @@ OperationAdapter MakeOperationAdapter(unsigned int failures = 0) {
 
 #endif
 
+rocksdb::Status OpenDatabase(const rocksdb::Options& options, const std::string& path,
+                             std::unique_ptr<rocksdb::DB>* database) {
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
+  return OpenOperationForTest()(options, path, database);
+#else
+  return rocksdb::DB::Open(options, path, database);
+#endif
+}
+
 struct DatabaseState {
 #if defined(SITOS_ROCKSDB_TEST_SEAM)
   DatabaseState(std::shared_ptr<rocksdb::DB> database,
                 std::shared_ptr<rocksdb_test::EventLog> event_log)
-      : db(std::move(database)), events(std::move(event_log)), operations(MakeOperationAdapter()) {}
+      : db(std::move(database)), events(std::move(event_log)) {}
 #else
   explicit DatabaseState(std::shared_ptr<rocksdb::DB> database) : db(std::move(database)) {}
 #endif
@@ -158,7 +175,7 @@ struct DatabaseState {
 #if defined(SITOS_ROCKSDB_TEST_SEAM)
   std::shared_ptr<rocksdb_test::EventLog> events;
   std::mutex operations_mutex;
-  OperationAdapter operations;
+  OperationAdapter operations = MakeOperationAdapter();
   std::atomic<std::size_t> snapshot_calls{0};
   std::atomic<std::size_t> enumeration_calls{0};
 #endif
@@ -171,22 +188,40 @@ OperationAdapter Operations(const std::shared_ptr<DatabaseState>& state) {
 }
 #endif
 
+void ReleaseSnapshotNoexcept(const std::shared_ptr<DatabaseState>& state,
+                             const rocksdb::Snapshot* snapshot) noexcept {
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
+  bool recovered = false;
+  try {
+    std::lock_guard lock(state->operations_mutex);
+    state->operations.release_snapshot(*state->db, snapshot);
+  } catch (...) {
+    recovered = true;
+    try {
+      state->db->ReleaseSnapshot(snapshot);
+    } catch (...) {
+      state->events->Add("release_snapshot_failed");
+      return;
+    }
+  }
+  if (recovered) state->events->Add("release_snapshot_recovered");
+  state->events->Add("release_snapshot");
+#else
+  try {
+    state->db->ReleaseSnapshot(snapshot);
+  } catch (...) {
+    // RocksDB does not normally throw; destructors cannot propagate an unexpected exception.
+  }
+#endif
+}
+
 class RocksDBSnapshot final : public StorageReader {
  public:
   RocksDBSnapshot(std::shared_ptr<DatabaseState> state, const rocksdb::Snapshot* snapshot)
       : state_(std::move(state)), snapshot_(snapshot) {}
 
   ~RocksDBSnapshot() override {
-    if (snapshot_ != nullptr) {
-#if defined(SITOS_ROCKSDB_TEST_SEAM)
-      Operations(state_).release_snapshot(*state_->db, snapshot_);
-#else
-      state_->db->ReleaseSnapshot(snapshot_);
-#endif
-#if defined(SITOS_ROCKSDB_TEST_SEAM)
-      state_->events->Add("release_snapshot");
-#endif
-    }
+    if (snapshot_ != nullptr) ReleaseSnapshotNoexcept(state_, snapshot_);
   }
 
   RocksDBSnapshot(const RocksDBSnapshot&) = delete;
@@ -222,8 +257,11 @@ class RocksDBSnapshot final : public StorageReader {
     options.snapshot = snapshot_;
 #if defined(SITOS_ROCKSDB_TEST_SEAM)
     state_->enumeration_calls.fetch_add(1);
-    const rocksdb::Status status = Operations(state_).list(*state_->db, options, prefix, entries);
-    if (!status.ok()) return false;
+    if (const rocksdb::Status status =
+            Operations(state_).list(*state_->db, options, prefix, entries);
+        !status.ok()) {
+      return false;
+    }
 #else
     {
       std::unique_ptr<rocksdb::Iterator> iterator(state_->db->NewIterator(options));
@@ -254,23 +292,33 @@ class RocksDBSnapshot final : public StorageReader {
 };
 
 #if defined(SITOS_ROCKSDB_TEST_SEAM)
-std::mutex registry_mutex;
-std::unordered_map<const RocksDBEngine*, std::weak_ptr<DatabaseState>> registry;
+struct EngineRegistry {
+  std::mutex mutex;
+  std::unordered_map<const RocksDBEngine*, std::weak_ptr<DatabaseState>> engines;
+};
+
+EngineRegistry& GetEngineRegistry() {
+  static EngineRegistry registry;
+  return registry;
+}
 
 void Register(const RocksDBEngine* engine, const std::shared_ptr<DatabaseState>& state) {
-  std::lock_guard lock(registry_mutex);
-  registry[engine] = state;
+  auto& registry = GetEngineRegistry();
+  std::lock_guard lock(registry.mutex);
+  registry.engines[engine] = state;
 }
 
 void Unregister(const RocksDBEngine* engine) {
-  std::lock_guard lock(registry_mutex);
-  registry.erase(engine);
+  auto& registry = GetEngineRegistry();
+  std::lock_guard lock(registry.mutex);
+  registry.engines.erase(engine);
 }
 
 std::shared_ptr<DatabaseState> StateFor(const RocksDBEngine* engine) {
-  std::lock_guard lock(registry_mutex);
-  const auto it = registry.find(engine);
-  return it == registry.end() ? nullptr : it->second.lock();
+  auto& registry = GetEngineRegistry();
+  std::lock_guard lock(registry.mutex);
+  const auto it = registry.engines.find(engine);
+  return it == registry.engines.end() ? nullptr : it->second.lock();
 }
 #endif
 #endif
@@ -306,12 +354,7 @@ Result<std::unique_ptr<RocksDBEngine>> RocksDBEngine::Open(const std::string& pa
   rocksdb::Options options;
   options.create_if_missing = true;
   std::unique_ptr<rocksdb::DB> owned_db;
-#if defined(SITOS_ROCKSDB_TEST_SEAM)
-  const rocksdb::Status status = OpenOperationForTest()(options, path, &owned_db);
-#else
-  const rocksdb::Status status = rocksdb::DB::Open(options, path, &owned_db);
-#endif
-  if (!status.ok()) {
+  if (const rocksdb::Status status = OpenDatabase(options, path, &owned_db); !status.ok()) {
     return Result<std::unique_ptr<RocksDBEngine>>::Err(
         Status::Error, std::format("RocksDB open failed: {}", status.ToString()),
         MakeRocksDBError(status));
@@ -322,7 +365,7 @@ Result<std::unique_ptr<RocksDBEngine>> RocksDBEngine::Open(const std::string& pa
   std::weak_ptr<rocksdb_test::EventLog> weak_events = event_log;
   std::shared_ptr<rocksdb::DB> shared_db(
       owned_db.release(), [weak_events](rocksdb::DB* database) {
-        delete database;
+        std::default_delete<rocksdb::DB>{}(database);
         if (const auto events = weak_events.lock()) events->Add("db_close");
       });
   auto database = std::make_shared<DatabaseState>(std::move(shared_db), std::move(event_log));
@@ -456,12 +499,7 @@ std::shared_ptr<const StorageReader> RocksDBEngine::TakeSnapshot() const {
   try {
     return std::make_shared<RocksDBSnapshot>(impl_->state, snapshot);
   } catch (...) {
-#if defined(SITOS_ROCKSDB_TEST_SEAM)
-    Operations(impl_->state).release_snapshot(*impl_->state->db, snapshot);
-    impl_->state->events->Add("release_snapshot");
-#else
-    impl_->state->db->ReleaseSnapshot(snapshot);
-#endif
+    ReleaseSnapshotNoexcept(impl_->state, snapshot);
     throw;
   }
 #else
@@ -473,10 +511,11 @@ std::shared_ptr<const StorageReader> RocksDBEngine::TakeSnapshot() const {
 namespace rocksdb_test {
 
 void SetOpenFailureForTest() {
-  std::lock_guard lock(open_operation_mutex);
+  auto& state = GetOpenOperationState();
+  std::lock_guard lock(state.mutex);
   const auto remaining = std::make_shared<std::atomic_bool>(true);
-  open_operation = [remaining](const rocksdb::Options& options, const std::string& path,
-                               std::unique_ptr<rocksdb::DB>* database) {
+  state.operation = [remaining](const rocksdb::Options& options, const std::string& path,
+                                std::unique_ptr<rocksdb::DB>* database) {
     if (remaining->exchange(false)) {
       return rocksdb::Status::IOError("injected Open failure");
     }
@@ -484,7 +523,16 @@ void SetOpenFailureForTest() {
   };
 }
 
-void SetFailures(RocksDBEngine& engine, unsigned int failures) {
+void SetSnapshotReleaseFailureForTest(RocksDBEngine& engine) {
+  const auto state = StateFor(&engine);
+  if (state == nullptr) return;
+  std::lock_guard lock(state->operations_mutex);
+  state->operations.release_snapshot = [](rocksdb::DB&, const rocksdb::Snapshot*) {
+    throw std::bad_alloc{};
+  };
+}
+
+void SetFailures(const RocksDBEngine& engine, unsigned int failures) {
   const auto state = StateFor(&engine);
   if (state == nullptr) return;
   std::lock_guard lock(state->operations_mutex);

--- a/src/rocksdb_engine.cpp
+++ b/src/rocksdb_engine.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -22,6 +23,11 @@ namespace sitos {
 namespace {
 
 #if defined(SITOS_WITH_ROCKSDB)
+using RocksDBOpenResult = decltype(rocksdb::DB::Open(
+    std::declval<const rocksdb::Options&>(), std::declval<const std::string&>(),
+    std::declval<std::unique_ptr<rocksdb::DB>*>()));
+static_assert(std::is_same_v<RocksDBOpenResult, rocksdb::Status>);
+
 class RocksDBErrorCategory final : public std::error_category {
  public:
   const char* name() const noexcept override { return "sitos.rocksdb"; }
@@ -136,16 +142,15 @@ Result<std::unique_ptr<RocksDBEngine>> RocksDBEngine::Open(const std::string& pa
   }
   rocksdb::Options options;
   options.create_if_missing = true;
-  rocksdb::DB* raw_db = nullptr;
-  const rocksdb::Status status = rocksdb::DB::Open(options, path, &raw_db);
+  std::unique_ptr<rocksdb::DB> owned_db;
+  const rocksdb::Status status = rocksdb::DB::Open(options, path, &owned_db);
   if (!status.ok()) {
     return Result<std::unique_ptr<RocksDBEngine>>::Err(Status::Error,
                                                        "RocksDB open failed: " + status.ToString(),
                                                        MakeRocksDBError(status));
   }
-  std::unique_ptr<rocksdb::DB> owned_db(raw_db);
-  auto database = std::make_shared<DatabaseState>(
-      std::shared_ptr<rocksdb::DB>(std::move(owned_db)));
+  std::shared_ptr<rocksdb::DB> shared_db(std::move(owned_db));
+  auto database = std::make_shared<DatabaseState>(std::move(shared_db));
   return Result<std::unique_ptr<RocksDBEngine>>::Ok(
       std::unique_ptr<RocksDBEngine>(
           new RocksDBEngine(std::make_unique<Impl>(std::move(database)))));

--- a/src/rocksdb_engine.cpp
+++ b/src/rocksdb_engine.cpp
@@ -3,12 +3,18 @@
 
 #include "sitos/rocksdb_engine.hpp"
 
+#include <algorithm>
 #include <atomic>
+#include <cstddef>
+#include <format>
+#include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <system_error>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -17,6 +23,10 @@
 #include <rocksdb/options.h>
 #include <rocksdb/slice.h>
 #include <rocksdb/status.h>
+#endif
+
+#if defined(SITOS_WITH_ROCKSDB)
+#include "rocksdb_engine_test_access.hpp"
 #endif
 
 namespace sitos {
@@ -32,7 +42,7 @@ class RocksDBErrorCategory final : public std::error_category {
  public:
   const char* name() const noexcept override { return "sitos.rocksdb"; }
   std::string message(int value) const override {
-    return "RocksDB failure (code " + std::to_string(value) + ")";
+    return std::format("RocksDB failure (code {})", value);
   }
 };
 
@@ -42,48 +52,90 @@ const std::error_category& RocksDBCategory() noexcept {
 }
 
 std::error_code MakeRocksDBError(const rocksdb::Status& status) {
-  return {static_cast<int>(status.code()) + 1, RocksDBCategory()};
+  using StatusCodeType = std::underlying_type_t<rocksdb::Status::Code>;
+  const auto code = static_cast<StatusCodeType>(status.code());
+  return {static_cast<int>(code) + 1, RocksDBCategory()};
 }
-#endif
 
-constexpr unsigned int kFailPut = 1U << 0;
-constexpr unsigned int kFailDelete = 1U << 1;
-constexpr unsigned int kFailGet = 1U << 2;
-constexpr unsigned int kFailList = 1U << 3;
+struct OperationAdapter {
+  using Put = std::function<rocksdb::Status(rocksdb::DB&, const rocksdb::WriteOptions&,
+                                             const rocksdb::Slice&, const rocksdb::Slice&)>;
+  using Delete = std::function<rocksdb::Status(rocksdb::DB&, const rocksdb::WriteOptions&,
+                                                const rocksdb::Slice&)>;
+  using Get = std::function<rocksdb::Status(rocksdb::DB&, const rocksdb::ReadOptions&,
+                                             const rocksdb::Slice&, std::string*)>;
+  using List = std::function<rocksdb::Status(
+      rocksdb::DB&, const rocksdb::ReadOptions&, std::string_view,
+      std::vector<std::pair<std::string, std::vector<std::byte>>>&)>;
 
-#if defined(SITOS_WITH_ROCKSDB)
+  Put put;
+  Delete delete_key;
+  Get get;
+  List list;
+};
+
+OperationAdapter MakeOperationAdapter(unsigned int failures = 0) {
+  OperationAdapter adapter;
+  adapter.put = [failures](rocksdb::DB& db, const rocksdb::WriteOptions& options,
+                           const rocksdb::Slice& key, const rocksdb::Slice& value) {
+    if ((failures & rocksdb_test::kPut) != 0) {
+      return rocksdb::Status::IOError("injected Put failure");
+    }
+    return db.Put(options, key, value);
+  };
+  adapter.delete_key = [failures](rocksdb::DB& db, const rocksdb::WriteOptions& options,
+                                  const rocksdb::Slice& key) {
+    if ((failures & rocksdb_test::kDelete) != 0) {
+      return rocksdb::Status::IOError("injected Delete failure");
+    }
+    return db.Delete(options, key);
+  };
+  adapter.get = [failures](rocksdb::DB& db, const rocksdb::ReadOptions& options,
+                           const rocksdb::Slice& key, std::string* value) {
+    if ((failures & rocksdb_test::kGet) != 0) {
+      return rocksdb::Status::IOError("injected Get failure");
+    }
+    return db.Get(options, key, value);
+  };
+  adapter.list = [failures](rocksdb::DB& db, const rocksdb::ReadOptions& options,
+                            std::string_view prefix,
+                            std::vector<std::pair<std::string, std::vector<std::byte>>>& entries) {
+    if ((failures & rocksdb_test::kList) != 0) {
+      return rocksdb::Status::IOError("injected List failure");
+    }
+    std::unique_ptr<rocksdb::Iterator> iterator(db.NewIterator(options));
+    iterator->Seek(rocksdb::Slice(prefix.data(), prefix.size()));
+    while (iterator->Valid()) {
+      const rocksdb::Slice key = iterator->key();
+      if (!std::string_view(key.data(), key.size()).starts_with(prefix)) break;
+      const rocksdb::Slice value = iterator->value();
+      entries.emplace_back(
+          std::string(key.data(), key.size()),
+          std::vector<std::byte>(reinterpret_cast<const std::byte*>(value.data()),
+                                reinterpret_cast<const std::byte*>(value.data()) + value.size()));
+      iterator->Next();
+    }
+    return iterator->status();
+  };
+  return adapter;
+}
+
 struct DatabaseState {
-  explicit DatabaseState(std::shared_ptr<rocksdb::DB> database) : db(std::move(database)) {}
+  DatabaseState(std::shared_ptr<rocksdb::DB> database,
+                std::shared_ptr<rocksdb_test::EventLog> event_log)
+      : db(std::move(database)), events(std::move(event_log)), operations(MakeOperationAdapter()) {}
 
   std::shared_ptr<rocksdb::DB> db;
-  std::atomic<unsigned int> failures{0};
+  std::shared_ptr<rocksdb_test::EventLog> events;
+  std::mutex operations_mutex;
+  OperationAdapter operations;
   std::atomic<std::size_t> snapshot_calls{0};
   std::atomic<std::size_t> enumeration_calls{0};
 };
 
-bool Enumerate(rocksdb::DB& db, const rocksdb::ReadOptions& options,
-               std::string_view prefix, const EntrySink& sink,
-               std::atomic<std::size_t>* enumeration_calls = nullptr) {
-  if (enumeration_calls != nullptr) {
-    enumeration_calls->fetch_add(1, std::memory_order_relaxed);
-  }
-  std::vector<std::pair<std::string, std::vector<std::byte>>> entries;
-  std::unique_ptr<rocksdb::Iterator> iterator(db.NewIterator(options));
-  for (iterator->Seek(rocksdb::Slice(prefix.data(), prefix.size())); iterator->Valid();
-       iterator->Next()) {
-    const rocksdb::Slice key = iterator->key();
-    if (!std::string_view(key.data(), key.size()).starts_with(prefix)) break;
-    const rocksdb::Slice value = iterator->value();
-    entries.emplace_back(std::string(key.data(), key.size()),
-                         std::vector<std::byte>(
-                             reinterpret_cast<const std::byte*>(value.data()),
-                             reinterpret_cast<const std::byte*>(value.data()) + value.size()));
-  }
-  if (!iterator->status().ok()) return false;
-  for (const auto& [entry_key, value] : entries) {
-    if (!sink(entry_key, value)) return false;
-  }
-  return true;
+OperationAdapter Operations(const std::shared_ptr<DatabaseState>& state) {
+  std::lock_guard lock(state->operations_mutex);
+  return state->operations;
 }
 
 class RocksDBSnapshot final : public StorageReader {
@@ -92,33 +144,67 @@ class RocksDBSnapshot final : public StorageReader {
       : state_(std::move(state)), snapshot_(snapshot) {}
 
   ~RocksDBSnapshot() override {
-    if (snapshot_ != nullptr) state_->db->ReleaseSnapshot(snapshot_);
+    if (snapshot_ != nullptr) {
+      state_->db->ReleaseSnapshot(snapshot_);
+      state_->events->Add("release_snapshot");
+    }
   }
 
+  RocksDBSnapshot(const RocksDBSnapshot&) = delete;
+  RocksDBSnapshot& operator=(const RocksDBSnapshot&) = delete;
+  RocksDBSnapshot(RocksDBSnapshot&&) = delete;
+  RocksDBSnapshot& operator=(RocksDBSnapshot&&) = delete;
+
   bool Get(std::string_view key, const EntrySink& sink) const override {
-    if ((state_->failures.load(std::memory_order_relaxed) & kFailGet) != 0) return false;
+    std::string value;
     rocksdb::ReadOptions options;
     options.snapshot = snapshot_;
-    std::string value;
-    const rocksdb::Status status =
-        state_->db->Get(options, rocksdb::Slice(key.data(), key.size()), &value);
-    if (status.IsNotFound() || !status.ok()) return false;
+    if (const rocksdb::Status status = Operations(state_).get(
+            *state_->db, options, rocksdb::Slice(key.data(), key.size()), &value);
+        status.IsNotFound() || !status.ok()) {
+      return false;
+    }
     sink(key, std::span<const std::byte>(reinterpret_cast<const std::byte*>(value.data()),
                                           value.size()));
     return true;
   }
 
   bool List(std::string_view prefix, const EntrySink& sink) const override {
-    if ((state_->failures.load(std::memory_order_relaxed) & kFailList) != 0) return false;
+    std::vector<std::pair<std::string, std::vector<std::byte>>> entries;
     rocksdb::ReadOptions options;
     options.snapshot = snapshot_;
-    return Enumerate(*state_->db, options, prefix, sink, &state_->enumeration_calls);
+    state_->enumeration_calls.fetch_add(1);
+    const rocksdb::Status status = Operations(state_).list(*state_->db, options, prefix, entries);
+    if (!status.ok()) return false;
+    return std::ranges::all_of(entries, [&sink](const auto& entry) {
+      const auto& [entry_key, value] = entry;
+      return sink(entry_key, value);
+    });
   }
 
  private:
   std::shared_ptr<DatabaseState> state_;
   const rocksdb::Snapshot* snapshot_;
 };
+
+std::mutex registry_mutex;
+std::unordered_map<const RocksDBEngine*, std::weak_ptr<DatabaseState>> registry;
+
+void Register(const RocksDBEngine* engine, const std::shared_ptr<DatabaseState>& state) {
+  std::lock_guard lock(registry_mutex);
+  registry[engine] = state;
+}
+
+void Unregister(const RocksDBEngine* engine) {
+  std::lock_guard lock(registry_mutex);
+  registry.erase(engine);
+}
+
+std::shared_ptr<DatabaseState> StateFor(const RocksDBEngine* engine) {
+  std::lock_guard lock(registry_mutex);
+  const auto it = registry.find(engine);
+  return it == registry.end() ? nullptr : it->second.lock();
+}
 #endif
 
 }  // namespace
@@ -130,8 +216,17 @@ struct RocksDBEngine::Impl {
 #endif
 };
 
-RocksDBEngine::RocksDBEngine(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {}
-RocksDBEngine::~RocksDBEngine() = default;
+RocksDBEngine::RocksDBEngine(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {
+#if defined(SITOS_WITH_ROCKSDB)
+  Register(this, impl_->state);
+#endif
+}
+
+RocksDBEngine::~RocksDBEngine() {
+#if defined(SITOS_WITH_ROCKSDB)
+  Unregister(this);
+#endif
+}
 
 Result<std::unique_ptr<RocksDBEngine>> RocksDBEngine::Open(const std::string& path) {
 #if defined(SITOS_WITH_ROCKSDB)
@@ -143,14 +238,20 @@ Result<std::unique_ptr<RocksDBEngine>> RocksDBEngine::Open(const std::string& pa
   rocksdb::Options options;
   options.create_if_missing = true;
   std::unique_ptr<rocksdb::DB> owned_db;
-  const rocksdb::Status status = rocksdb::DB::Open(options, path, &owned_db);
-  if (!status.ok()) {
-    return Result<std::unique_ptr<RocksDBEngine>>::Err(Status::Error,
-                                                       "RocksDB open failed: " + status.ToString(),
-                                                       MakeRocksDBError(status));
+  if (const rocksdb::Status status = rocksdb::DB::Open(options, path, &owned_db);
+      !status.ok()) {
+    return Result<std::unique_ptr<RocksDBEngine>>::Err(
+        Status::Error, std::format("RocksDB open failed: {}", status.ToString()),
+        MakeRocksDBError(status));
   }
-  std::shared_ptr<rocksdb::DB> shared_db(std::move(owned_db));
-  auto database = std::make_shared<DatabaseState>(std::move(shared_db));
+  auto event_log = std::make_shared<rocksdb_test::EventLog>();
+  std::weak_ptr<rocksdb_test::EventLog> weak_events = event_log;
+  std::shared_ptr<rocksdb::DB> shared_db(
+      owned_db.release(), [weak_events](rocksdb::DB* database) {
+        delete database;
+        if (const auto events = weak_events.lock()) events->Add("db_close");
+      });
+  auto database = std::make_shared<DatabaseState>(std::move(shared_db), std::move(event_log));
   return Result<std::unique_ptr<RocksDBEngine>>::Ok(
       std::unique_ptr<RocksDBEngine>(
           new RocksDBEngine(std::make_unique<Impl>(std::move(database)))));
@@ -164,9 +265,8 @@ Result<std::unique_ptr<RocksDBEngine>> RocksDBEngine::Open(const std::string& pa
 
 bool RocksDBEngine::Put(std::string_view key, Bytes value) {
 #if defined(SITOS_WITH_ROCKSDB)
-  if ((impl_->state->failures.load(std::memory_order_relaxed) & kFailPut) != 0) return false;
-  const rocksdb::Status status = impl_->state->db->Put(
-      rocksdb::WriteOptions{}, rocksdb::Slice(key.data(), key.size()),
+  const rocksdb::Status status = Operations(impl_->state).put(
+      *impl_->state->db, rocksdb::WriteOptions{}, rocksdb::Slice(key.data(), key.size()),
       rocksdb::Slice(reinterpret_cast<const char*>(value.data()), value.size()));
   return status.ok();
 #else
@@ -178,9 +278,8 @@ bool RocksDBEngine::Put(std::string_view key, Bytes value) {
 
 bool RocksDBEngine::Delete(std::string_view key) {
 #if defined(SITOS_WITH_ROCKSDB)
-  if ((impl_->state->failures.load(std::memory_order_relaxed) & kFailDelete) != 0) return false;
-  return impl_->state->db
-      ->Delete(rocksdb::WriteOptions{}, rocksdb::Slice(key.data(), key.size()))
+  return Operations(impl_->state).delete_key(
+             *impl_->state->db, rocksdb::WriteOptions{}, rocksdb::Slice(key.data(), key.size()))
       .ok();
 #else
   static_cast<void>(key);
@@ -190,11 +289,13 @@ bool RocksDBEngine::Delete(std::string_view key) {
 
 bool RocksDBEngine::Get(std::string_view key, const EntrySink& sink) const {
 #if defined(SITOS_WITH_ROCKSDB)
-  if ((impl_->state->failures.load(std::memory_order_relaxed) & kFailGet) != 0) return false;
   std::string value;
-  const rocksdb::Status status = impl_->state->db->Get(
-      rocksdb::ReadOptions{}, rocksdb::Slice(key.data(), key.size()), &value);
-  if (status.IsNotFound() || !status.ok()) return false;
+  if (const rocksdb::Status status = Operations(impl_->state).get(
+          *impl_->state->db, rocksdb::ReadOptions{}, rocksdb::Slice(key.data(), key.size()),
+          &value);
+      status.IsNotFound() || !status.ok()) {
+    return false;
+  }
   sink(key, std::span<const std::byte>(reinterpret_cast<const std::byte*>(value.data()),
                                         value.size()));
   return true;
@@ -207,10 +308,17 @@ bool RocksDBEngine::Get(std::string_view key, const EntrySink& sink) const {
 
 bool RocksDBEngine::List(std::string_view prefix, const EntrySink& sink) const {
 #if defined(SITOS_WITH_ROCKSDB)
-  if ((impl_->state->failures.load(std::memory_order_relaxed) & kFailList) != 0) return false;
-  rocksdb::ReadOptions options;
-  return Enumerate(*impl_->state->db, options, prefix, sink,
-                   &impl_->state->enumeration_calls);
+  std::vector<std::pair<std::string, std::vector<std::byte>>> entries;
+  impl_->state->enumeration_calls.fetch_add(1);
+  if (const rocksdb::Status status = Operations(impl_->state).list(
+          *impl_->state->db, rocksdb::ReadOptions{}, prefix, entries);
+      !status.ok()) {
+    return false;
+  }
+  return std::ranges::all_of(entries, [&sink](const auto& entry) {
+    const auto& [entry_key, value] = entry;
+    return sink(entry_key, value);
+  });
 #else
   static_cast<void>(prefix);
   static_cast<void>(sink);
@@ -220,12 +328,14 @@ bool RocksDBEngine::List(std::string_view prefix, const EntrySink& sink) const {
 
 std::shared_ptr<const StorageReader> RocksDBEngine::TakeSnapshot() const {
 #if defined(SITOS_WITH_ROCKSDB)
-  impl_->state->snapshot_calls.fetch_add(1, std::memory_order_relaxed);
+  impl_->state->snapshot_calls.fetch_add(1);
   const rocksdb::Snapshot* snapshot = impl_->state->db->GetSnapshot();
+  impl_->state->events->Add("get_snapshot");
   try {
     return std::make_shared<RocksDBSnapshot>(impl_->state, snapshot);
   } catch (...) {
     impl_->state->db->ReleaseSnapshot(snapshot);
+    impl_->state->events->Add("release_snapshot");
     throw;
   }
 #else
@@ -233,23 +343,34 @@ std::shared_ptr<const StorageReader> RocksDBEngine::TakeSnapshot() const {
 #endif
 }
 
-void RocksDBEngine::GetSnapshotStatsForTest(std::size_t& snapshot_calls,
-                                             std::size_t& enumeration_calls) const {
 #if defined(SITOS_WITH_ROCKSDB)
-  snapshot_calls = impl_->state->snapshot_calls.load(std::memory_order_relaxed);
-  enumeration_calls = impl_->state->enumeration_calls.load(std::memory_order_relaxed);
-#else
-  snapshot_calls = 0;
-  enumeration_calls = 0;
-#endif
+namespace rocksdb_test {
+
+void SetFailures(RocksDBEngine& engine, unsigned int failures) {
+  const auto state = StateFor(&engine);
+  if (state == nullptr) return;
+  std::lock_guard lock(state->operations_mutex);
+  state->operations = MakeOperationAdapter(failures);
 }
 
-void RocksDBEngine::SetFailureMaskForTest(unsigned int mask) {
-#if defined(SITOS_WITH_ROCKSDB)
-  impl_->state->failures.store(mask, std::memory_order_relaxed);
-#else
-  static_cast<void>(mask);
-#endif
+void GetSnapshotStats(const RocksDBEngine& engine, std::size_t& snapshot_calls,
+                      std::size_t& enumeration_calls) {
+  const auto state = StateFor(&engine);
+  if (state == nullptr) {
+    snapshot_calls = 0;
+    enumeration_calls = 0;
+    return;
+  }
+  snapshot_calls = state->snapshot_calls.load();
+  enumeration_calls = state->enumeration_calls.load();
 }
+
+std::shared_ptr<rocksdb_test::EventLog> GetEventLog(const RocksDBEngine& engine) {
+  const auto state = StateFor(&engine);
+  return state == nullptr ? nullptr : state->events;
+}
+
+}  // namespace rocksdb_test
+#endif
 
 }  // namespace sitos

--- a/src/rocksdb_engine.cpp
+++ b/src/rocksdb_engine.cpp
@@ -53,8 +53,49 @@ const std::error_category& RocksDBCategory() noexcept {
 }
 
 std::error_code MakeRocksDBError(const rocksdb::Status& status) {
-  const auto code = static_cast<int>(status.code());
+  using StatusCode = std::underlying_type_t<rocksdb::Status::Code>;
+  const auto code = static_cast<int>(static_cast<StatusCode>(status.code()));
   return {code + 1, RocksDBCategory()};
+}
+
+using EntryBuffer = std::vector<std::pair<std::string, std::vector<std::byte>>>;
+
+rocksdb::Status NativePut(rocksdb::DB& db, const rocksdb::WriteOptions& options,
+                          const rocksdb::Slice& key, const rocksdb::Slice& value) {
+  return db.Put(options, key, value);
+}
+
+rocksdb::Status NativeDelete(rocksdb::DB& db, const rocksdb::WriteOptions& options,
+                             const rocksdb::Slice& key) {
+  return db.Delete(options, key);
+}
+
+rocksdb::Status NativeGet(rocksdb::DB& db, const rocksdb::ReadOptions& options,
+                          const rocksdb::Slice& key, std::string* value) {
+  return db.Get(options, key, value);
+}
+
+rocksdb::Status ListEntries(rocksdb::DB& db, const rocksdb::ReadOptions& options,
+                            std::string_view prefix, EntryBuffer& entries) {
+  std::unique_ptr<rocksdb::Iterator> iterator(db.NewIterator(options));
+  iterator->Seek(rocksdb::Slice(prefix.data(), prefix.size()));
+  while (iterator->Valid()) {
+    const rocksdb::Slice key = iterator->key();
+    if (!std::string_view(key.data(), key.size()).starts_with(prefix)) break;
+    const rocksdb::Slice value = iterator->value();
+    entries.emplace_back(
+        std::string(key.data(), key.size()),
+        std::vector<std::byte>(reinterpret_cast<const std::byte*>(value.data()),
+                              reinterpret_cast<const std::byte*>(value.data()) + value.size()));
+    iterator->Next();
+  }
+  return iterator->status();
+}
+
+const rocksdb::Snapshot* NativeGetSnapshot(rocksdb::DB& db) { return db.GetSnapshot(); }
+
+void NativeReleaseSnapshot(rocksdb::DB& db, const rocksdb::Snapshot* snapshot) {
+  db.ReleaseSnapshot(snapshot);
 }
 
 #if defined(SITOS_ROCKSDB_TEST_SEAM)
@@ -66,8 +107,7 @@ struct OperationAdapter {
   using Get = std::function<rocksdb::Status(rocksdb::DB&, const rocksdb::ReadOptions&,
                                              const rocksdb::Slice&, std::string*)>;
   using List = std::function<rocksdb::Status(
-      rocksdb::DB&, const rocksdb::ReadOptions&, std::string_view,
-      std::vector<std::pair<std::string, std::vector<std::byte>>>&)>;
+      rocksdb::DB&, const rocksdb::ReadOptions&, std::string_view, EntryBuffer&)>;
   using GetSnapshot = std::function<const rocksdb::Snapshot*(rocksdb::DB&)>;
   using ReleaseSnapshot = std::function<void(rocksdb::DB&, const rocksdb::Snapshot*)>;
 
@@ -108,46 +148,31 @@ OperationAdapter MakeOperationAdapter(unsigned int failures = 0) {
     if ((failures & rocksdb_test::kPut) != 0) {
       return rocksdb::Status::IOError("injected Put failure");
     }
-    return db.Put(options, key, value);
+    return NativePut(db, options, key, value);
   };
   adapter.delete_key = [failures](rocksdb::DB& db, const rocksdb::WriteOptions& options,
                                   const rocksdb::Slice& key) {
     if ((failures & rocksdb_test::kDelete) != 0) {
       return rocksdb::Status::IOError("injected Delete failure");
     }
-    return db.Delete(options, key);
+    return NativeDelete(db, options, key);
   };
   adapter.get = [failures](rocksdb::DB& db, const rocksdb::ReadOptions& options,
                            const rocksdb::Slice& key, std::string* value) {
     if ((failures & rocksdb_test::kGet) != 0) {
       return rocksdb::Status::IOError("injected Get failure");
     }
-    return db.Get(options, key, value);
+    return NativeGet(db, options, key, value);
   };
   adapter.list = [failures](rocksdb::DB& db, const rocksdb::ReadOptions& options,
-                            std::string_view prefix,
-                            std::vector<std::pair<std::string, std::vector<std::byte>>>& entries) {
+                            std::string_view prefix, EntryBuffer& entries) {
     if ((failures & rocksdb_test::kList) != 0) {
       return rocksdb::Status::IOError("injected List failure");
     }
-    std::unique_ptr<rocksdb::Iterator> iterator(db.NewIterator(options));
-    iterator->Seek(rocksdb::Slice(prefix.data(), prefix.size()));
-    while (iterator->Valid()) {
-      const rocksdb::Slice key = iterator->key();
-      if (!std::string_view(key.data(), key.size()).starts_with(prefix)) break;
-      const rocksdb::Slice value = iterator->value();
-      entries.emplace_back(
-          std::string(key.data(), key.size()),
-          std::vector<std::byte>(reinterpret_cast<const std::byte*>(value.data()),
-                                reinterpret_cast<const std::byte*>(value.data()) + value.size()));
-      iterator->Next();
-    }
-    return iterator->status();
+    return ListEntries(db, options, prefix, entries);
   };
-  adapter.get_snapshot = [](rocksdb::DB& db) { return db.GetSnapshot(); };
-  adapter.release_snapshot = [](rocksdb::DB& db, const rocksdb::Snapshot* snapshot) {
-    db.ReleaseSnapshot(snapshot);
-  };
+  adapter.get_snapshot = NativeGetSnapshot;
+  adapter.release_snapshot = NativeReleaseSnapshot;
   return adapter;
 }
 
@@ -188,6 +213,87 @@ OperationAdapter Operations(const std::shared_ptr<DatabaseState>& state) {
 }
 #endif
 
+rocksdb::Status PutDatabase(const std::shared_ptr<DatabaseState>& state,
+                            const rocksdb::WriteOptions& options,
+                            const rocksdb::Slice& key, const rocksdb::Slice& value) {
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
+  return Operations(state).put(*state->db, options, key, value);
+#else
+  return NativePut(*state->db, options, key, value);
+#endif
+}
+
+rocksdb::Status DeleteDatabase(const std::shared_ptr<DatabaseState>& state,
+                               const rocksdb::WriteOptions& options,
+                               const rocksdb::Slice& key) {
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
+  return Operations(state).delete_key(*state->db, options, key);
+#else
+  return NativeDelete(*state->db, options, key);
+#endif
+}
+
+rocksdb::Status GetDatabase(const std::shared_ptr<DatabaseState>& state,
+                            const rocksdb::ReadOptions& options,
+                            const rocksdb::Slice& key, std::string* value) {
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
+  return Operations(state).get(*state->db, options, key, value);
+#else
+  return NativeGet(*state->db, options, key, value);
+#endif
+}
+
+rocksdb::Status ListDatabase(const std::shared_ptr<DatabaseState>& state,
+                             const rocksdb::ReadOptions& options,
+                             std::string_view prefix, EntryBuffer& entries) {
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
+  state->enumeration_calls.fetch_add(1);
+  return Operations(state).list(*state->db, options, prefix, entries);
+#else
+  return ListEntries(*state->db, options, prefix, entries);
+#endif
+}
+
+const rocksdb::Snapshot* GetDatabaseSnapshot(
+    const std::shared_ptr<DatabaseState>& state) {
+#if defined(SITOS_ROCKSDB_TEST_SEAM)
+  const rocksdb::Snapshot* snapshot = Operations(state).get_snapshot(*state->db);
+  state->snapshot_calls.fetch_add(1);
+  state->events->Add("get_snapshot");
+  return snapshot;
+#else
+  return NativeGetSnapshot(*state->db);
+#endif
+}
+
+bool ReadEntry(const std::shared_ptr<DatabaseState>& state,
+               const rocksdb::ReadOptions& options, std::string_view key,
+               const EntrySink& sink) {
+  std::string value;
+  if (const rocksdb::Status status =
+          GetDatabase(state, options, rocksdb::Slice(key.data(), key.size()), &value);
+      status.IsNotFound() || !status.ok()) {
+    return false;
+  }
+  sink(key, std::span<const std::byte>(reinterpret_cast<const std::byte*>(value.data()),
+                                        value.size()));
+  return true;
+}
+
+bool ReadEntries(const std::shared_ptr<DatabaseState>& state,
+                 const rocksdb::ReadOptions& options, std::string_view prefix,
+                 const EntrySink& sink) {
+  EntryBuffer entries;
+  if (const rocksdb::Status status = ListDatabase(state, options, prefix, entries);
+      !status.ok()) {
+    return false;
+  }
+  return std::ranges::all_of(entries, [&sink](const auto& entry) {
+    const auto& [entry_key, value] = entry;
+    return sink(entry_key, value);
+  });
+}
+
 void ReleaseSnapshotNoexcept(const std::shared_ptr<DatabaseState>& state,
                              const rocksdb::Snapshot* snapshot) noexcept {
 #if defined(SITOS_ROCKSDB_TEST_SEAM)
@@ -198,7 +304,7 @@ void ReleaseSnapshotNoexcept(const std::shared_ptr<DatabaseState>& state,
   } catch (...) {
     recovered = true;
     try {
-      state->db->ReleaseSnapshot(snapshot);
+      NativeReleaseSnapshot(*state->db, snapshot);
     } catch (...) {
       state->events->Add("release_snapshot_failed");
       return;
@@ -208,7 +314,7 @@ void ReleaseSnapshotNoexcept(const std::shared_ptr<DatabaseState>& state,
   state->events->Add("release_snapshot");
 #else
   try {
-    state->db->ReleaseSnapshot(snapshot);
+    NativeReleaseSnapshot(*state->db, snapshot);
   } catch (...) {
     // RocksDB does not normally throw; destructors cannot propagate an unexpected exception.
   }
@@ -230,60 +336,15 @@ class RocksDBSnapshot final : public StorageReader {
   RocksDBSnapshot& operator=(RocksDBSnapshot&&) = delete;
 
   bool Get(std::string_view key, const EntrySink& sink) const override {
-    std::string value;
     rocksdb::ReadOptions options;
     options.snapshot = snapshot_;
-#if defined(SITOS_ROCKSDB_TEST_SEAM)
-    if (const rocksdb::Status status = Operations(state_).get(
-            *state_->db, options, rocksdb::Slice(key.data(), key.size()), &value);
-        status.IsNotFound() || !status.ok()) {
-      return false;
-    }
-#else
-    if (const rocksdb::Status status =
-            state_->db->Get(options, rocksdb::Slice(key.data(), key.size()), &value);
-        status.IsNotFound() || !status.ok()) {
-      return false;
-    }
-#endif
-    sink(key, std::span<const std::byte>(reinterpret_cast<const std::byte*>(value.data()),
-                                          value.size()));
-    return true;
+    return ReadEntry(state_, options, key, sink);
   }
 
   bool List(std::string_view prefix, const EntrySink& sink) const override {
-    std::vector<std::pair<std::string, std::vector<std::byte>>> entries;
     rocksdb::ReadOptions options;
     options.snapshot = snapshot_;
-#if defined(SITOS_ROCKSDB_TEST_SEAM)
-    state_->enumeration_calls.fetch_add(1);
-    if (const rocksdb::Status status =
-            Operations(state_).list(*state_->db, options, prefix, entries);
-        !status.ok()) {
-      return false;
-    }
-#else
-    {
-      std::unique_ptr<rocksdb::Iterator> iterator(state_->db->NewIterator(options));
-      iterator->Seek(rocksdb::Slice(prefix.data(), prefix.size()));
-      while (iterator->Valid()) {
-        const rocksdb::Slice entry_key = iterator->key();
-        if (!std::string_view(entry_key.data(), entry_key.size()).starts_with(prefix)) break;
-        const rocksdb::Slice value = iterator->value();
-        entries.emplace_back(
-            std::string(entry_key.data(), entry_key.size()),
-            std::vector<std::byte>(
-                reinterpret_cast<const std::byte*>(value.data()),
-                reinterpret_cast<const std::byte*>(value.data()) + value.size()));
-        iterator->Next();
-      }
-      if (!iterator->status().ok()) return false;
-    }
-#endif
-    return std::ranges::all_of(entries, [&sink](const auto& entry) {
-      const auto& [entry_key, value] = entry;
-      return sink(entry_key, value);
-    });
+    return ReadEntries(state_, options, prefix, sink);
   }
 
  private:
@@ -386,16 +447,10 @@ Result<std::unique_ptr<RocksDBEngine>> RocksDBEngine::Open(const std::string& pa
 
 bool RocksDBEngine::Put(std::string_view key, Bytes value) {
 #if defined(SITOS_WITH_ROCKSDB)
-#if defined(SITOS_ROCKSDB_TEST_SEAM)
-  const rocksdb::Status status = Operations(impl_->state).put(
-      *impl_->state->db, rocksdb::WriteOptions{}, rocksdb::Slice(key.data(), key.size()),
-      rocksdb::Slice(reinterpret_cast<const char*>(value.data()), value.size()));
-#else
-  const rocksdb::Status status = impl_->state->db->Put(
-      rocksdb::WriteOptions{}, rocksdb::Slice(key.data(), key.size()),
-      rocksdb::Slice(reinterpret_cast<const char*>(value.data()), value.size()));
-#endif
-  return status.ok();
+  return PutDatabase(impl_->state, rocksdb::WriteOptions{},
+                     rocksdb::Slice(key.data(), key.size()),
+                     rocksdb::Slice(reinterpret_cast<const char*>(value.data()), value.size()))
+      .ok();
 #else
   static_cast<void>(key);
   static_cast<void>(value);
@@ -405,15 +460,9 @@ bool RocksDBEngine::Put(std::string_view key, Bytes value) {
 
 bool RocksDBEngine::Delete(std::string_view key) {
 #if defined(SITOS_WITH_ROCKSDB)
-#if defined(SITOS_ROCKSDB_TEST_SEAM)
-  return Operations(impl_->state).delete_key(
-             *impl_->state->db, rocksdb::WriteOptions{}, rocksdb::Slice(key.data(), key.size()))
+  return DeleteDatabase(impl_->state, rocksdb::WriteOptions{},
+                        rocksdb::Slice(key.data(), key.size()))
       .ok();
-#else
-  return impl_->state->db
-      ->Delete(rocksdb::WriteOptions{}, rocksdb::Slice(key.data(), key.size()))
-      .ok();
-#endif
 #else
   static_cast<void>(key);
   return false;
@@ -422,24 +471,7 @@ bool RocksDBEngine::Delete(std::string_view key) {
 
 bool RocksDBEngine::Get(std::string_view key, const EntrySink& sink) const {
 #if defined(SITOS_WITH_ROCKSDB)
-  std::string value;
-#if defined(SITOS_ROCKSDB_TEST_SEAM)
-  if (const rocksdb::Status status = Operations(impl_->state).get(
-          *impl_->state->db, rocksdb::ReadOptions{}, rocksdb::Slice(key.data(), key.size()),
-          &value);
-      status.IsNotFound() || !status.ok()) {
-    return false;
-  }
-#else
-  if (const rocksdb::Status status = impl_->state->db->Get(
-          rocksdb::ReadOptions{}, rocksdb::Slice(key.data(), key.size()), &value);
-      status.IsNotFound() || !status.ok()) {
-    return false;
-  }
-#endif
-  sink(key, std::span<const std::byte>(reinterpret_cast<const std::byte*>(value.data()),
-                                        value.size()));
-  return true;
+  return ReadEntry(impl_->state, rocksdb::ReadOptions{}, key, sink);
 #else
   static_cast<void>(key);
   static_cast<void>(sink);
@@ -449,37 +481,7 @@ bool RocksDBEngine::Get(std::string_view key, const EntrySink& sink) const {
 
 bool RocksDBEngine::List(std::string_view prefix, const EntrySink& sink) const {
 #if defined(SITOS_WITH_ROCKSDB)
-  std::vector<std::pair<std::string, std::vector<std::byte>>> entries;
-#if defined(SITOS_ROCKSDB_TEST_SEAM)
-  impl_->state->enumeration_calls.fetch_add(1);
-  if (const rocksdb::Status status = Operations(impl_->state).list(
-          *impl_->state->db, rocksdb::ReadOptions{}, prefix, entries);
-      !status.ok()) {
-    return false;
-  }
-#else
-  {
-    std::unique_ptr<rocksdb::Iterator> iterator(
-        impl_->state->db->NewIterator(rocksdb::ReadOptions{}));
-    iterator->Seek(rocksdb::Slice(prefix.data(), prefix.size()));
-    while (iterator->Valid()) {
-      const rocksdb::Slice entry_key = iterator->key();
-      if (!std::string_view(entry_key.data(), entry_key.size()).starts_with(prefix)) break;
-      const rocksdb::Slice value = iterator->value();
-      entries.emplace_back(
-          std::string(entry_key.data(), entry_key.size()),
-          std::vector<std::byte>(
-              reinterpret_cast<const std::byte*>(value.data()),
-              reinterpret_cast<const std::byte*>(value.data()) + value.size()));
-      iterator->Next();
-    }
-    if (!iterator->status().ok()) return false;
-  }
-#endif
-  return std::ranges::all_of(entries, [&sink](const auto& entry) {
-    const auto& [entry_key, value] = entry;
-    return sink(entry_key, value);
-  });
+  return ReadEntries(impl_->state, rocksdb::ReadOptions{}, prefix, sink);
 #else
   static_cast<void>(prefix);
   static_cast<void>(sink);
@@ -489,13 +491,7 @@ bool RocksDBEngine::List(std::string_view prefix, const EntrySink& sink) const {
 
 std::shared_ptr<const StorageReader> RocksDBEngine::TakeSnapshot() const {
 #if defined(SITOS_WITH_ROCKSDB)
-#if defined(SITOS_ROCKSDB_TEST_SEAM)
-  const rocksdb::Snapshot* snapshot = Operations(impl_->state).get_snapshot(*impl_->state->db);
-  impl_->state->snapshot_calls.fetch_add(1);
-  impl_->state->events->Add("get_snapshot");
-#else
-  const rocksdb::Snapshot* snapshot = impl_->state->db->GetSnapshot();
-#endif
+  const rocksdb::Snapshot* snapshot = GetDatabaseSnapshot(impl_->state);
   try {
     return std::make_shared<RocksDBSnapshot>(impl_->state, snapshot);
   } catch (...) {
@@ -523,11 +519,12 @@ void SetOpenFailureForTest() {
   };
 }
 
-void SetSnapshotReleaseFailureForTest(RocksDBEngine& engine) {
+void SetSnapshotReleaseFailureForTest(const RocksDBEngine& engine) {
   const auto state = StateFor(&engine);
   if (state == nullptr) return;
   std::lock_guard lock(state->operations_mutex);
   state->operations.release_snapshot = [](rocksdb::DB&, const rocksdb::Snapshot*) {
+    // Injected failures must throw before native release so the noexcept fallback releases once.
     throw std::bad_alloc{};
   };
 }

--- a/src/rocksdb_engine_test_access.hpp
+++ b/src/rocksdb_engine_test_access.hpp
@@ -44,7 +44,7 @@ inline constexpr unsigned int kGet = 1U << 2;
 inline constexpr unsigned int kList = 1U << 3;
 
 void SetOpenFailureForTest();
-void SetSnapshotReleaseFailureForTest(RocksDBEngine& engine);
+void SetSnapshotReleaseFailureForTest(const RocksDBEngine& engine);
 void SetFailures(const RocksDBEngine& engine, unsigned int failures);
 void GetSnapshotStats(const RocksDBEngine& engine, std::size_t& snapshot_calls,
                       std::size_t& enumeration_calls);

--- a/src/rocksdb_engine_test_access.hpp
+++ b/src/rocksdb_engine_test_access.hpp
@@ -35,6 +35,7 @@ inline constexpr unsigned int kDelete = 1U << 1;
 inline constexpr unsigned int kGet = 1U << 2;
 inline constexpr unsigned int kList = 1U << 3;
 
+void SetOpenFailureForTest();
 void SetFailures(RocksDBEngine& engine, unsigned int failures);
 void GetSnapshotStats(const RocksDBEngine& engine, std::size_t& snapshot_calls,
                       std::size_t& enumeration_calls);

--- a/src/rocksdb_engine_test_access.hpp
+++ b/src/rocksdb_engine_test_access.hpp
@@ -16,18 +16,26 @@
 
 namespace sitos::rocksdb_test {
 
-struct EventLog {
+class EventLog final {
+ public:
   void Add(std::string_view event) noexcept {
     try {
       std::string copy(event);
-      std::lock_guard lock(mutex);
-      events.push_back(std::move(copy));
+      std::lock_guard lock(mutex_);
+      events_.push_back(std::move(copy));
     } catch (...) {
+      // Test instrumentation must never interrupt product cleanup.
     }
   }
 
-  mutable std::mutex mutex;
-  std::vector<std::string> events;
+  std::vector<std::string> Snapshot() const {
+    std::lock_guard lock(mutex_);
+    return events_;
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  std::vector<std::string> events_;
 };
 
 inline constexpr unsigned int kPut = 1U << 0;
@@ -36,7 +44,8 @@ inline constexpr unsigned int kGet = 1U << 2;
 inline constexpr unsigned int kList = 1U << 3;
 
 void SetOpenFailureForTest();
-void SetFailures(RocksDBEngine& engine, unsigned int failures);
+void SetSnapshotReleaseFailureForTest(RocksDBEngine& engine);
+void SetFailures(const RocksDBEngine& engine, unsigned int failures);
 void GetSnapshotStats(const RocksDBEngine& engine, std::size_t& snapshot_calls,
                       std::size_t& enumeration_calls);
 std::shared_ptr<EventLog> GetEventLog(const RocksDBEngine& engine);

--- a/src/rocksdb_engine_test_access.hpp
+++ b/src/rocksdb_engine_test_access.hpp
@@ -4,30 +4,42 @@
 #ifndef SITOS_ROCKSDB_ENGINE_TEST_ACCESS_HPP
 #define SITOS_ROCKSDB_ENGINE_TEST_ACCESS_HPP
 
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
 #include "sitos/rocksdb_engine.hpp"
 
-namespace sitos {
+namespace sitos::rocksdb_test {
 
-/// Source-test-only controls for deterministic native failure contract tests.
-class RocksDBEngineTestAccess {
- public:
-  enum Failure : unsigned int {
-    kPut = 1U << 0,
-    kDelete = 1U << 1,
-    kGet = 1U << 2,
-    kList = 1U << 3,
-  };
-
-  static void SetFailures(RocksDBEngine& engine, unsigned int failures) {
-    engine.SetFailureMaskForTest(failures);
+struct EventLog {
+  void Add(std::string_view event) noexcept {
+    try {
+      std::string copy(event);
+      std::lock_guard lock(mutex);
+      events.push_back(std::move(copy));
+    } catch (...) {
+    }
   }
 
-  static void GetSnapshotStats(const RocksDBEngine& engine, std::size_t& snapshot_calls,
-                               std::size_t& enumeration_calls) {
-    engine.GetSnapshotStatsForTest(snapshot_calls, enumeration_calls);
-  }
+  mutable std::mutex mutex;
+  std::vector<std::string> events;
 };
 
-}  // namespace sitos
+inline constexpr unsigned int kPut = 1U << 0;
+inline constexpr unsigned int kDelete = 1U << 1;
+inline constexpr unsigned int kGet = 1U << 2;
+inline constexpr unsigned int kList = 1U << 3;
+
+void SetFailures(RocksDBEngine& engine, unsigned int failures);
+void GetSnapshotStats(const RocksDBEngine& engine, std::size_t& snapshot_calls,
+                      std::size_t& enumeration_calls);
+std::shared_ptr<EventLog> GetEventLog(const RocksDBEngine& engine);
+
+}  // namespace sitos::rocksdb_test
 
 #endif  // SITOS_ROCKSDB_ENGINE_TEST_ACCESS_HPP

--- a/src/rocksdb_engine_test_access.hpp
+++ b/src/rocksdb_engine_test_access.hpp
@@ -1,0 +1,33 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SITOS_ROCKSDB_ENGINE_TEST_ACCESS_HPP
+#define SITOS_ROCKSDB_ENGINE_TEST_ACCESS_HPP
+
+#include "sitos/rocksdb_engine.hpp"
+
+namespace sitos {
+
+/// Source-test-only controls for deterministic native failure contract tests.
+class RocksDBEngineTestAccess {
+ public:
+  enum Failure : unsigned int {
+    kPut = 1U << 0,
+    kDelete = 1U << 1,
+    kGet = 1U << 2,
+    kList = 1U << 3,
+  };
+
+  static void SetFailures(RocksDBEngine& engine, unsigned int failures) {
+    engine.SetFailureMaskForTest(failures);
+  }
+
+  static void GetSnapshotStats(const RocksDBEngine& engine, std::size_t& snapshot_calls,
+                               std::size_t& enumeration_calls) {
+    engine.GetSnapshotStatsForTest(snapshot_calls, enumeration_calls);
+  }
+};
+
+}  // namespace sitos
+
+#endif  // SITOS_ROCKSDB_ENGINE_TEST_ACCESS_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -155,8 +155,18 @@ sitos_enable_warnings(sitos_storage_engine_contract_test)
 gtest_discover_tests(sitos_storage_engine_contract_test DISCOVERY_MODE PRE_TEST)
 
 if(SITOS_WITH_ROCKSDB)
+  add_library(sitos_rocksdb_test_engine OBJECT ../src/rocksdb_engine.cpp)
+  target_compile_definitions(sitos_rocksdb_test_engine PRIVATE
+    SITOS_WITH_ROCKSDB=1 SITOS_ROCKSDB_TEST_SEAM=1)
+  target_include_directories(sitos_rocksdb_test_engine PRIVATE
+    ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/src)
+  target_link_libraries(sitos_rocksdb_test_engine PRIVATE RocksDB::rocksdb)
+  sitos_enable_warnings(sitos_rocksdb_test_engine)
+
   add_executable(sitos_rocksdb_engine_test
     unit/rocksdb_engine_test.cpp)
+  target_sources(sitos_rocksdb_engine_test PRIVATE
+    $<TARGET_OBJECTS:sitos_rocksdb_test_engine>)
   target_link_libraries(sitos_rocksdb_engine_test
     PRIVATE GTest::gtest_main sitos::sitos)
   target_include_directories(sitos_rocksdb_engine_test PRIVATE ${CMAKE_SOURCE_DIR}/src)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -155,6 +155,18 @@ sitos_enable_warnings(sitos_storage_engine_contract_test)
 gtest_discover_tests(sitos_storage_engine_contract_test DISCOVERY_MODE PRE_TEST)
 
 if(SITOS_WITH_ROCKSDB)
+  # The contract suite links the production archive so it exercises the exact
+  # RocksDB implementation that is installed for consumers.
+  add_executable(sitos_rocksdb_engine_test
+    unit/rocksdb_engine_test.cpp)
+  target_link_libraries(sitos_rocksdb_engine_test
+    PRIVATE GTest::gtest_main sitos::sitos)
+  sitos_enable_warnings(sitos_rocksdb_engine_test)
+  gtest_discover_tests(sitos_rocksdb_engine_test DISCOVERY_MODE PRE_TEST)
+
+  # Native failure and lifecycle instrumentation stay in a separate binary.
+  # It supplies the seam translation unit directly and never links sitos::sitos,
+  # avoiding duplicate RocksDBEngine definitions in one executable.
   add_library(sitos_rocksdb_test_engine OBJECT ../src/rocksdb_engine.cpp)
   target_compile_definitions(sitos_rocksdb_test_engine PRIVATE
     SITOS_WITH_ROCKSDB=1 SITOS_ROCKSDB_TEST_SEAM=1)
@@ -163,15 +175,18 @@ if(SITOS_WITH_ROCKSDB)
   target_link_libraries(sitos_rocksdb_test_engine PRIVATE RocksDB::rocksdb)
   sitos_enable_warnings(sitos_rocksdb_test_engine)
 
-  add_executable(sitos_rocksdb_engine_test
-    unit/rocksdb_engine_test.cpp)
-  target_sources(sitos_rocksdb_engine_test PRIVATE
+  add_executable(sitos_rocksdb_test_access_test
+    unit/rocksdb_engine_test_access_test.cpp
+    ../src/status.cpp
+    ../src/storage_engine.cpp)
+  target_sources(sitos_rocksdb_test_access_test PRIVATE
     $<TARGET_OBJECTS:sitos_rocksdb_test_engine>)
-  target_link_libraries(sitos_rocksdb_engine_test
-    PRIVATE GTest::gtest_main sitos::sitos)
-  target_include_directories(sitos_rocksdb_engine_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
-  sitos_enable_warnings(sitos_rocksdb_engine_test)
-  gtest_discover_tests(sitos_rocksdb_engine_test DISCOVERY_MODE PRE_TEST)
+  target_link_libraries(sitos_rocksdb_test_access_test
+    PRIVATE GTest::gtest_main RocksDB::rocksdb)
+  target_include_directories(sitos_rocksdb_test_access_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/src)
+  sitos_enable_warnings(sitos_rocksdb_test_access_test)
+  gtest_discover_tests(sitos_rocksdb_test_access_test DISCOVERY_MODE PRE_TEST)
 endif()
 
 add_executable(sitos_in_memory_engine_test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -140,6 +140,13 @@ gtest_add_tests(TARGET sitos_key_test SOURCES unit/key_test.cpp)
 # DISCOVERY_MODE PRE_TEST moves the flaky JSON discovery out of the build
 # step (ninja) and into ctest, so a discovery hiccup no longer breaks the
 # build itself (#93).
+if(NOT SITOS_WITH_ROCKSDB)
+  add_executable(sitos_rocksdb_engine_off_test unit/rocksdb_engine_off_test.cpp)
+  target_link_libraries(sitos_rocksdb_engine_off_test PRIVATE GTest::gtest_main sitos::sitos)
+  sitos_enable_warnings(sitos_rocksdb_engine_off_test)
+  gtest_add_tests(TARGET sitos_rocksdb_engine_off_test SOURCES unit/rocksdb_engine_off_test.cpp)
+endif()
+
 add_executable(sitos_storage_engine_contract_test
   unit/storage_engine_contract_test.cpp)
 target_link_libraries(sitos_storage_engine_contract_test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,6 +41,8 @@ add_sitos_public_header_compile_test(
   sitos_param_subscription_header_compile_test consumer/param_subscription_header_compile.cpp)
 add_sitos_public_header_compile_test(
   sitos_session_view_header_compile_test consumer/session_view_header_compile.cpp)
+add_sitos_public_header_compile_test(
+  sitos_rocksdb_engine_header_compile_test consumer/rocksdb_engine_header_compile.cpp)
 if(SITOS_WITH_ZENOH)
   sitos_copy_zenohc(sitos_param_store_header_compile_test)
   sitos_copy_zenohc(sitos_param_cache_header_compile_test)
@@ -144,6 +146,16 @@ target_link_libraries(sitos_storage_engine_contract_test
   PRIVATE GTest::gtest_main sitos::sitos)
 sitos_enable_warnings(sitos_storage_engine_contract_test)
 gtest_discover_tests(sitos_storage_engine_contract_test DISCOVERY_MODE PRE_TEST)
+
+if(SITOS_WITH_ROCKSDB)
+  add_executable(sitos_rocksdb_engine_test
+    unit/rocksdb_engine_test.cpp)
+  target_link_libraries(sitos_rocksdb_engine_test
+    PRIVATE GTest::gtest_main sitos::sitos)
+  target_include_directories(sitos_rocksdb_engine_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
+  sitos_enable_warnings(sitos_rocksdb_engine_test)
+  gtest_discover_tests(sitos_rocksdb_engine_test DISCOVERY_MODE PRE_TEST)
+endif()
 
 add_executable(sitos_in_memory_engine_test
   unit/in_memory_engine_test.cpp)

--- a/tests/bench/CMakeLists.txt
+++ b/tests/bench/CMakeLists.txt
@@ -1,3 +1,9 @@
 add_executable(sitos_cache_get_bench cache_get_bench.cpp)
 target_link_libraries(sitos_cache_get_bench PRIVATE sitos::sitos benchmark::benchmark)
 sitos_enable_warnings(sitos_cache_get_bench)
+
+if(SITOS_WITH_ROCKSDB)
+  add_executable(sitos_rocksdb_snapshot_bench rocksdb_snapshot_bench.cpp)
+  target_link_libraries(sitos_rocksdb_snapshot_bench PRIVATE sitos::sitos benchmark::benchmark)
+  sitos_enable_warnings(sitos_rocksdb_snapshot_bench)
+endif()

--- a/tests/bench/rocksdb_snapshot_bench.cpp
+++ b/tests/bench/rocksdb_snapshot_bench.cpp
@@ -1,0 +1,44 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <benchmark/benchmark.h>
+
+#include <atomic>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "sitos/rocksdb_engine.hpp"
+
+namespace {
+
+std::filesystem::path MakePath() {
+  static std::atomic<unsigned int> next_id{0};
+  return std::filesystem::temp_directory_path() /
+         ("sitos-rocksdb-bench-" + std::to_string(next_id.fetch_add(1)));
+}
+
+void TakeSnapshot(benchmark::State& state) {
+  const auto path = MakePath();
+  auto result = sitos::RocksDBEngine::Open(path.string());
+  if (!result.IsOk()) state.SkipWithError("RocksDBEngine::Open failed");
+  auto engine = result.IsOk() ? std::move(result).Value() : nullptr;
+  if (engine != nullptr) {
+    const std::vector<std::byte> value{std::byte{0x01}};
+    for (int i = 0; i < state.range(0); ++i) {
+      engine->Put("key/" + std::to_string(i), value);
+    }
+    for (auto _ : state) {
+      static_cast<void>(_);
+      benchmark::DoNotOptimize(engine->TakeSnapshot());
+    }
+  }
+  engine.reset();
+  std::error_code error;
+  std::filesystem::remove_all(path, error);
+}
+
+}  // namespace
+
+BENCHMARK(TakeSnapshot)->Args({1000})->Args({100000});
+BENCHMARK_MAIN();

--- a/tests/consumer/rocksdb_engine_header_compile.cpp
+++ b/tests/consumer/rocksdb_engine_header_compile.cpp
@@ -1,0 +1,11 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <type_traits>
+
+#include "sitos/rocksdb_engine.hpp"
+
+static_assert(std::is_destructible_v<sitos::RocksDBEngine>);
+static_assert(!std::is_copy_constructible_v<sitos::RocksDBEngine>);
+
+int main() { return 0; }

--- a/tests/package/check_no_rocksdb_test_symbols.cmake
+++ b/tests/package/check_no_rocksdb_test_symbols.cmake
@@ -37,7 +37,10 @@ endif()
 if(NOT _result EQUAL 0)
   message(FATAL_ERROR "Unable to inspect installed archive ${_archive}: ${_error}")
 endif()
-if(_symbols MATCHES "rocksdb_test|SetOpenFailureForTest|SetFailures|GetSnapshotStats|GetEventLog")
+string(CONCAT _test_symbol_pattern
+  "rocksdb_test|SetOpenFailureForTest|SetSnapshotReleaseFailureForTest"
+  "|SetFailures|GetSnapshotStats|GetEventLog")
+if(_symbols MATCHES "${_test_symbol_pattern}")
   message(FATAL_ERROR "Installed production archive exposes RocksDB test-control symbols")
 endif()
 message(STATUS "Installed production archive contains no RocksDB test-control symbols")

--- a/tests/package/check_no_rocksdb_test_symbols.cmake
+++ b/tests/package/check_no_rocksdb_test_symbols.cmake
@@ -1,0 +1,43 @@
+if(NOT DEFINED SITOS_PREFIX)
+  message(FATAL_ERROR "SITOS_PREFIX must name an installed sitos prefix")
+endif()
+if(NOT DEFINED SITOS_INSTALL_LIBDIR)
+  set(SITOS_INSTALL_LIBDIR lib)
+endif()
+
+if(WIN32)
+  set(_archive "${SITOS_PREFIX}/${SITOS_INSTALL_LIBDIR}/sitos.lib")
+  find_program(_symbol_tool NAMES dumpbin)
+  if(NOT _symbol_tool)
+    message(FATAL_ERROR "dumpbin is required for installed archive symbol validation")
+  endif()
+  execute_process(
+    COMMAND "${_symbol_tool}" /SYMBOLS "${_archive}"
+    RESULT_VARIABLE _result
+    OUTPUT_VARIABLE _symbols
+    ERROR_VARIABLE _error)
+else()
+  file(GLOB _archives "${SITOS_PREFIX}/${SITOS_INSTALL_LIBDIR}/libsitos.a")
+  list(LENGTH _archives _archive_count)
+  if(NOT _archive_count EQUAL 1)
+    message(FATAL_ERROR "Expected one installed sitos archive, found ${_archive_count}")
+  endif()
+  list(GET _archives 0 _archive)
+  find_program(_symbol_tool NAMES llvm-nm nm)
+  if(NOT _symbol_tool)
+    message(FATAL_ERROR "nm is required for installed archive symbol validation")
+  endif()
+  execute_process(
+    COMMAND "${_symbol_tool}" -g "${_archive}"
+    RESULT_VARIABLE _result
+    OUTPUT_VARIABLE _symbols
+    ERROR_VARIABLE _error)
+endif()
+
+if(NOT _result EQUAL 0)
+  message(FATAL_ERROR "Unable to inspect installed archive ${_archive}: ${_error}")
+endif()
+if(_symbols MATCHES "rocksdb_test|SetOpenFailureForTest|SetFailures|GetSnapshotStats|GetEventLog")
+  message(FATAL_ERROR "Installed production archive exposes RocksDB test-control symbols")
+endif()
+message(STATUS "Installed production archive contains no RocksDB test-control symbols")

--- a/tests/package/consumer/CMakeLists.txt
+++ b/tests/package/consumer/CMakeLists.txt
@@ -5,7 +5,11 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+option(SITOS_PACKAGE_CONSUMER_WITH_ROCKSDB "Validate the RocksDB-enabled package" OFF)
 find_package(sitos 0.1 CONFIG REQUIRED)
 
 add_executable(sitos_package_consumer main.cpp)
+if(SITOS_PACKAGE_CONSUMER_WITH_ROCKSDB)
+  target_compile_definitions(sitos_package_consumer PRIVATE SITOS_PACKAGE_CONSUMER_WITH_ROCKSDB=1)
+endif()
 target_link_libraries(sitos_package_consumer PRIVATE sitos::sitos)

--- a/tests/package/consumer/main.cpp
+++ b/tests/package/consumer/main.cpp
@@ -3,6 +3,7 @@
 
 #include "sitos/list_sink.hpp"
 #include "sitos/param_concepts.hpp"
+#include "sitos/rocksdb_engine.hpp"
 #include "sitos/session_view.hpp"
 #include "sitos/sitos.hpp"
 
@@ -25,5 +26,8 @@ static_assert(!HasSessionViewPut<sitos::SessionView>);
 
 int main() {
   static_cast<void>(sitos::MakeZenohTransport());
+#if defined(SITOS_PACKAGE_CONSUMER_WITH_ROCKSDB)
+  static_cast<void>(&sitos::RocksDBEngine::Open);
+#endif
   return 0;
 }

--- a/tests/package/consumer/main.cpp
+++ b/tests/package/consumer/main.cpp
@@ -24,10 +24,13 @@ concept HasSessionViewPut = requires(T& value) {
 };
 static_assert(!HasSessionViewPut<sitos::SessionView>);
 
-int main() {
+int main(int argc, char** argv) {
   static_cast<void>(sitos::MakeZenohTransport());
 #if defined(SITOS_PACKAGE_CONSUMER_WITH_ROCKSDB)
-  static_cast<void>(&sitos::RocksDBEngine::Open);
+  const std::string path = argc > 0 ? argv[0] : "rocksdb-consumer";
+  auto result = sitos::RocksDBEngine::Open(path);
+  volatile int status = static_cast<int>(result.StatusCode());
+  static_cast<void>(status);
 #endif
   return 0;
 }

--- a/tests/unit/rocksdb_engine_off_test.cpp
+++ b/tests/unit/rocksdb_engine_off_test.cpp
@@ -1,0 +1,15 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <system_error>
+
+#include "sitos/rocksdb_engine.hpp"
+
+TEST(RocksDBEngineOffTest, OpenReturnsOperationNotSupported) {
+  const auto result = sitos::RocksDBEngine::Open("disabled-db");
+  ASSERT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), sitos::Status::Error);
+  EXPECT_EQ(result.Error(), std::make_error_code(std::errc::operation_not_supported));
+}

--- a/tests/unit/rocksdb_engine_test.cpp
+++ b/tests/unit/rocksdb_engine_test.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <memory>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -19,7 +20,6 @@
 #endif
 
 #include "sitos/rocksdb_engine.hpp"
-#include "rocksdb_engine_test_access.hpp"
 
 namespace {
 
@@ -31,24 +31,27 @@ std::filesystem::path MakeTestPath() {
 #else
   const auto process_id = getpid();
 #endif
-  return std::filesystem::temp_directory_path() /
-         ("sitos-rocksdb-test-" + std::to_string(process_id) + "-" + std::to_string(id));
+  const auto path = std::filesystem::temp_directory_path() /
+                    ("sitos-rocksdb-test-" + std::to_string(process_id) + "-" +
+                     std::to_string(id));
+  std::error_code error;
+  std::filesystem::remove_all(path, error);
+  EXPECT_FALSE(error);
+  return path;
 }
 
 class CleanupToken final {
  public:
-  CleanupToken(std::filesystem::path path, std::shared_ptr<sitos::rocksdb_test::EventLog> events)
-      : path_(std::move(path)), events_(std::move(events)) {}
+  explicit CleanupToken(std::filesystem::path path) : path_(std::move(path)) {}
 
   ~CleanupToken() {
     std::error_code error;
     std::filesystem::remove_all(path_, error);
-    events_->Add(error ? "directory_remove_failed" : "directory_remove");
+    EXPECT_FALSE(error);
   }
 
  private:
   std::filesystem::path path_;
-  std::shared_ptr<sitos::rocksdb_test::EventLog> events_;
 };
 
 class SnapshotAdapter final : public sitos::StorageReader {
@@ -110,9 +113,8 @@ std::unique_ptr<sitos::StorageEngine> MakeContractEngine() {
     return nullptr;
   }
   auto engine = std::move(result).Value();
-  auto events = sitos::rocksdb_test::GetEventLog(*engine);
   return std::make_unique<ContractEngine>(
-      std::move(engine), std::make_shared<CleanupToken>(path, std::move(events)));
+      std::move(engine), std::make_shared<CleanupToken>(path));
 }
 
 }  // namespace
@@ -124,25 +126,6 @@ TEST(RocksDBEngineOpenApi, EmptyPathIsInvalidArgument) {
   ASSERT_FALSE(result.IsOk());
   EXPECT_EQ(result.StatusCode(), sitos::Status::InvalidArgument);
   EXPECT_TRUE(result.Error());
-}
-
-TEST(RocksDBEngineOpenApi, InjectedNativeOpenFailureReturnsError) {
-  const auto path = MakeTestPath();
-  sitos::rocksdb_test::SetOpenFailureForTest();
-  const auto result = sitos::RocksDBEngine::Open(path.string());
-  ASSERT_FALSE(result.IsOk());
-  EXPECT_EQ(result.StatusCode(), sitos::Status::Error);
-  EXPECT_TRUE(result.Error());
-  EXPECT_FALSE(std::filesystem::exists(path));
-
-  auto retry = sitos::RocksDBEngine::Open(path.string());
-  ASSERT_TRUE(retry.IsOk());
-  auto engine = std::move(retry).Value();
-  ASSERT_NE(engine, nullptr);
-  engine.reset();
-  std::error_code error;
-  std::filesystem::remove_all(path, error);
-  EXPECT_FALSE(error);
 }
 
 TEST(RocksDBEngineOpenApi, ExistingFilePathReturnsNativeErrorWithoutValueBytes) {
@@ -178,85 +161,6 @@ TEST(RocksDBEngineOpenApi, CreatesAndReopensPersistentDatabase) {
   }
   std::error_code error;
   std::filesystem::remove_all(path, error);
-}
-
-TEST(RocksDBEngineSnapshotLifetime, TakeSnapshotUsesNativePrimitiveWithoutEnumeration) {
-  const auto path = MakeTestPath();
-  auto result = sitos::RocksDBEngine::Open(path.string());
-  ASSERT_TRUE(result.IsOk());
-  auto engine = std::move(result).Value();
-  ASSERT_TRUE(engine->Put("key", std::vector<std::byte>{std::byte{0x01}}));
-  auto snapshot = engine->TakeSnapshot();
-  ASSERT_NE(snapshot, nullptr);
-  std::size_t snapshot_calls = 0;
-  std::size_t enumeration_calls = 0;
-  sitos::rocksdb_test::GetSnapshotStats(*engine, snapshot_calls, enumeration_calls);
-  EXPECT_EQ(snapshot_calls, 1u);
-  EXPECT_EQ(enumeration_calls, 0u);
-  std::error_code error;
-  snapshot.reset();
-  engine.reset();
-  std::filesystem::remove_all(path, error);
-}
-
-TEST(RocksDBEngineSnapshotLifetime, SnapshotOutlivesEngine) {
-  const auto path = MakeTestPath();
-  std::shared_ptr<const sitos::StorageReader> snapshot;
-  std::shared_ptr<sitos::rocksdb_test::EventLog> events;
-  {
-    auto result = sitos::RocksDBEngine::Open(path.string());
-    ASSERT_TRUE(result.IsOk());
-    auto engine = std::move(result).Value();
-    events = sitos::rocksdb_test::GetEventLog(*engine);
-    auto cleanup = std::make_shared<CleanupToken>(path, events);
-    ASSERT_TRUE(engine->Put("stable", std::vector<std::byte>{std::byte{0x01}}));
-    snapshot = std::make_shared<SnapshotAdapter>(engine->TakeSnapshot(), cleanup);
-    ASSERT_NE(snapshot, nullptr);
-    engine.reset();
-    EXPECT_TRUE(snapshot->Get("stable", [](std::string_view, sitos::Bytes value) {
-      return value.size() == 1 && value[0] == std::byte{0x01};
-    }));
-  }
-  auto recorded = events->Snapshot();
-  ASSERT_EQ(recorded.size(), 2u);
-  EXPECT_EQ(recorded[0], "open");
-  EXPECT_EQ(recorded[1], "get_snapshot");
-  snapshot.reset();
-  recorded = events->Snapshot();
-  ASSERT_EQ(recorded.size(), 5u);
-  EXPECT_EQ(recorded[0], "open");
-  EXPECT_EQ(recorded[1], "get_snapshot");
-  EXPECT_EQ(recorded[2], "release_snapshot");
-  EXPECT_EQ(recorded[3], "db_close");
-  EXPECT_EQ(recorded[4], "directory_remove");
-  EXPECT_FALSE(std::filesystem::exists(path));
-}
-
-TEST(RocksDBEngineSnapshotLifetime, InjectedReleaseFailureFallsBackWithoutTerminating) {
-  const auto path = MakeTestPath();
-  std::shared_ptr<const sitos::StorageReader> snapshot;
-  std::shared_ptr<sitos::rocksdb_test::EventLog> events;
-  {
-    auto result = sitos::RocksDBEngine::Open(path.string());
-    ASSERT_TRUE(result.IsOk());
-    auto engine = std::move(result).Value();
-    events = sitos::rocksdb_test::GetEventLog(*engine);
-    auto cleanup = std::make_shared<CleanupToken>(path, events);
-    snapshot = std::make_shared<SnapshotAdapter>(engine->TakeSnapshot(), cleanup);
-    sitos::rocksdb_test::SetSnapshotReleaseFailureForTest(*engine);
-    engine.reset();
-  }
-
-  snapshot.reset();
-  const auto recorded = events->Snapshot();
-  ASSERT_EQ(recorded.size(), 6u);
-  EXPECT_EQ(recorded[0], "open");
-  EXPECT_EQ(recorded[1], "get_snapshot");
-  EXPECT_EQ(recorded[2], "release_snapshot_recovered");
-  EXPECT_EQ(recorded[3], "release_snapshot");
-  EXPECT_EQ(recorded[4], "db_close");
-  EXPECT_EQ(recorded[5], "directory_remove");
-  EXPECT_FALSE(std::filesystem::exists(path));
 }
 
 TEST(RocksDBEngineConcurrency, ConcurrentPutDeleteGetList) {
@@ -342,42 +246,6 @@ TEST(RocksDBEngineConcurrency, ConcurrentPutDeleteGetList) {
   EXPECT_EQ(final_count, static_cast<std::size_t>(kWriters));
 
   snapshot.reset();
-  engine.reset();
-  std::error_code error;
-  std::filesystem::remove_all(path, error);
-  EXPECT_FALSE(error);
-}
-
-TEST(RocksDBEngineNativeFailure, PutDeleteGetListHaveContractedFailures) {
-  const auto path = MakeTestPath();
-  auto result = sitos::RocksDBEngine::Open(path.string());
-  ASSERT_TRUE(result.IsOk());
-  auto engine = std::move(result).Value();
-  ASSERT_TRUE(engine->Put("fault", std::vector<std::byte>{std::byte{0x01}}));
-
-  sitos::rocksdb_test::SetFailures(*engine, sitos::rocksdb_test::kPut);
-  EXPECT_FALSE(engine->Put("fault", std::vector<std::byte>{std::byte{0x02}}));
-  EXPECT_TRUE(engine->Get("fault", [](std::string_view, sitos::Bytes value) {
-    return value.size() == 1 && value[0] == std::byte{0x01};
-  }));
-  sitos::rocksdb_test::SetFailures(*engine, sitos::rocksdb_test::kDelete);
-  EXPECT_FALSE(engine->Delete("fault"));
-
-  bool called = false;
-  sitos::rocksdb_test::SetFailures(*engine, sitos::rocksdb_test::kGet);
-  EXPECT_FALSE(engine->Get("fault", [&](std::string_view, sitos::Bytes) {
-    called = true;
-    return true;
-  }));
-  EXPECT_FALSE(called);
-  sitos::rocksdb_test::SetFailures(*engine, sitos::rocksdb_test::kList);
-  EXPECT_FALSE(engine->List("", [&](std::string_view, sitos::Bytes) {
-    called = true;
-    return true;
-  }));
-  EXPECT_FALSE(called);
-
-  sitos::rocksdb_test::SetFailures(*engine, 0);
   engine.reset();
   std::error_code error;
   std::filesystem::remove_all(path, error);

--- a/tests/unit/rocksdb_engine_test.cpp
+++ b/tests/unit/rocksdb_engine_test.cpp
@@ -4,11 +4,19 @@
 #include "storage_engine_contract.hpp"
 
 #include <atomic>
+#include <barrier>
 #include <filesystem>
 #include <fstream>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
+
+#if defined(_WIN32)
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
 
 #include "sitos/rocksdb_engine.hpp"
 #include "rocksdb_engine_test_access.hpp"
@@ -17,20 +25,59 @@ namespace {
 
 std::filesystem::path MakeTestPath() {
   static std::atomic<unsigned int> next_id{0};
-  const auto id = next_id.fetch_add(1, std::memory_order_relaxed);
+  const auto id = next_id.fetch_add(1);
+#if defined(_WIN32)
+  const auto process_id = _getpid();
+#else
+  const auto process_id = getpid();
+#endif
   return std::filesystem::temp_directory_path() /
-         ("sitos-rocksdb-test-" + std::to_string(id));
+         ("sitos-rocksdb-test-" + std::to_string(process_id) + "-" + std::to_string(id));
 }
+
+class CleanupToken final {
+ public:
+  CleanupToken(std::filesystem::path path, std::shared_ptr<sitos::rocksdb_test::EventLog> events)
+      : path_(std::move(path)), events_(std::move(events)) {}
+
+  ~CleanupToken() {
+    std::error_code error;
+    std::filesystem::remove_all(path_, error);
+    events_->Add(error ? "directory_remove_failed" : "directory_remove");
+  }
+
+ private:
+  std::filesystem::path path_;
+  std::shared_ptr<sitos::rocksdb_test::EventLog> events_;
+};
+
+class SnapshotAdapter final : public sitos::StorageReader {
+ public:
+  SnapshotAdapter(std::shared_ptr<const sitos::StorageReader> snapshot,
+                  std::shared_ptr<CleanupToken> cleanup)
+      : cleanup_(std::move(cleanup)), snapshot_(std::move(snapshot)) {}
+
+  bool Get(std::string_view key, const sitos::EntrySink& sink) const override {
+    return snapshot_->Get(key, sink);
+  }
+  bool List(std::string_view prefix, const sitos::EntrySink& sink) const override {
+    return snapshot_->List(prefix, sink);
+  }
+
+ private:
+  std::shared_ptr<CleanupToken> cleanup_;
+  std::shared_ptr<const sitos::StorageReader> snapshot_;
+};
 
 class ContractEngine final : public sitos::StorageEngine {
  public:
-  ContractEngine(std::unique_ptr<sitos::RocksDBEngine> engine, std::filesystem::path path)
-      : engine_(std::move(engine)), path_(std::move(path)) {}
+  ContractEngine(std::unique_ptr<sitos::RocksDBEngine> engine,
+                 std::shared_ptr<CleanupToken> cleanup)
+      : cleanup_(std::move(cleanup)), engine_(std::move(engine)) {}
 
   ~ContractEngine() override {
     engine_.reset();
-    std::error_code error;
-    std::filesystem::remove_all(path_, error);
+    cleanup_.reset();
   }
 
   bool Put(std::string_view key, sitos::Bytes value) override { return engine_->Put(key, value); }
@@ -42,19 +89,30 @@ class ContractEngine final : public sitos::StorageEngine {
     return engine_->List(prefix, sink);
   }
   std::shared_ptr<const sitos::StorageReader> TakeSnapshot() const override {
-    return engine_->TakeSnapshot();
+    auto snapshot = engine_->TakeSnapshot();
+    if (snapshot == nullptr) return nullptr;
+    return std::make_shared<SnapshotAdapter>(std::move(snapshot), cleanup_);
   }
 
  private:
+  std::shared_ptr<CleanupToken> cleanup_;
   std::unique_ptr<sitos::RocksDBEngine> engine_;
-  std::filesystem::path path_;
 };
 
 std::unique_ptr<sitos::StorageEngine> MakeContractEngine() {
   const auto path = MakeTestPath();
   auto result = sitos::RocksDBEngine::Open(path.string());
-  if (!result.IsOk()) return nullptr;
-  return std::make_unique<ContractEngine>(std::move(result).Value(), path);
+  if (!result.IsOk()) {
+    ADD_FAILURE() << "RocksDBEngine::Open failed: status="
+                  << static_cast<int>(result.StatusCode()) << ", message=" << result.Message()
+                  << ", cause=" << result.Error().category().name() << ":"
+                  << result.Error().value();
+    return nullptr;
+  }
+  auto engine = std::move(result).Value();
+  auto events = sitos::rocksdb_test::GetEventLog(*engine);
+  return std::make_unique<ContractEngine>(
+      std::move(engine), std::make_shared<CleanupToken>(path, std::move(events)));
 }
 
 }  // namespace
@@ -113,7 +171,7 @@ TEST(RocksDBEngineSnapshotLifetime, TakeSnapshotUsesNativePrimitiveWithoutEnumer
   ASSERT_NE(snapshot, nullptr);
   std::size_t snapshot_calls = 0;
   std::size_t enumeration_calls = 0;
-  sitos::RocksDBEngineTestAccess::GetSnapshotStats(*engine, snapshot_calls, enumeration_calls);
+  sitos::rocksdb_test::GetSnapshotStats(*engine, snapshot_calls, enumeration_calls);
   EXPECT_EQ(snapshot_calls, 1u);
   EXPECT_EQ(enumeration_calls, 0u);
   std::error_code error;
@@ -125,19 +183,116 @@ TEST(RocksDBEngineSnapshotLifetime, TakeSnapshotUsesNativePrimitiveWithoutEnumer
 TEST(RocksDBEngineSnapshotLifetime, SnapshotOutlivesEngine) {
   const auto path = MakeTestPath();
   std::shared_ptr<const sitos::StorageReader> snapshot;
+  std::shared_ptr<sitos::rocksdb_test::EventLog> events;
   {
     auto result = sitos::RocksDBEngine::Open(path.string());
     ASSERT_TRUE(result.IsOk());
     auto engine = std::move(result).Value();
+    events = sitos::rocksdb_test::GetEventLog(*engine);
+    auto cleanup = std::make_shared<CleanupToken>(path, events);
     ASSERT_TRUE(engine->Put("stable", std::vector<std::byte>{std::byte{0x01}}));
-    snapshot = engine->TakeSnapshot();
+    snapshot = std::make_shared<SnapshotAdapter>(engine->TakeSnapshot(), cleanup);
     ASSERT_NE(snapshot, nullptr);
     engine.reset();
     EXPECT_TRUE(snapshot->Get("stable", [](std::string_view, sitos::Bytes value) {
       return value.size() == 1 && value[0] == std::byte{0x01};
     }));
   }
+  ASSERT_EQ(events->events.size(), 1u);
+  EXPECT_EQ(events->events[0], "get_snapshot");
   snapshot.reset();
+  ASSERT_EQ(events->events.size(), 4u);
+  EXPECT_EQ(events->events[0], "get_snapshot");
+  EXPECT_EQ(events->events[1], "release_snapshot");
+  EXPECT_EQ(events->events[2], "db_close");
+  EXPECT_EQ(events->events[3], "directory_remove");
+  EXPECT_FALSE(std::filesystem::exists(path));
+}
+
+TEST(RocksDBEngineConcurrency, ConcurrentPutDeleteGetList) {
+  const auto path = MakeTestPath();
+  auto result = sitos::RocksDBEngine::Open(path.string());
+  ASSERT_TRUE(result.IsOk());
+  auto engine = std::move(result).Value();
+  ASSERT_NE(engine, nullptr);
+  auto snapshot = engine->TakeSnapshot();
+  ASSERT_NE(snapshot, nullptr);
+
+  constexpr int kWriters = 2;
+  constexpr int kReaders = 2;
+  constexpr int kOperations = 128;
+  constexpr int kThreads = kWriters + kReaders;
+  std::barrier start(kThreads + 1);
+  std::atomic<int> errors{0};
+  std::atomic<int> completed{0};
+
+  auto writer = [&](int id) {
+    start.arrive_and_wait();
+    for (int i = 0; i < kOperations; ++i) {
+      const auto key = "concurrent/" + std::to_string(id) + "/" + std::to_string(i);
+      const std::vector<std::byte> value{
+          std::byte{static_cast<unsigned char>(id)},
+          std::byte{static_cast<unsigned char>(i)}};
+      if (!engine->Put(key, value)) ++errors;
+      if ((i % 2) == 0 && !engine->Delete(key)) ++errors;
+    }
+    const auto final_key = "final/" + std::to_string(id);
+    const std::vector<std::byte> final_value{
+        std::byte{static_cast<unsigned char>(id)}};
+    if (!engine->Put(final_key, final_value)) ++errors;
+    ++completed;
+  };
+
+  auto reader = [&] {
+    start.arrive_and_wait();
+    for (int i = 0; i < kOperations; ++i) {
+      const auto key = "concurrent/" + std::to_string(i % kWriters) + "/" +
+                       std::to_string(i);
+      engine->Get(key, [&](std::string_view, sitos::Bytes value) {
+        if (value.size() != 2) ++errors;
+        return true;
+      });
+      if (!engine->List("concurrent/", [&](std::string_view entry_key, sitos::Bytes value) {
+            if (!entry_key.starts_with("concurrent/") || value.size() != 2) ++errors;
+            return true;
+          })) {
+        ++errors;
+      }
+    }
+    ++completed;
+  };
+
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int id = 0; id < kWriters; ++id) threads.emplace_back(writer, id);
+  for (int i = 0; i < kReaders; ++i) threads.emplace_back(reader);
+  start.arrive_and_wait();
+  for (auto& thread : threads) thread.join();
+
+  EXPECT_EQ(completed.load(), kThreads);
+  EXPECT_EQ(errors.load(), 0);
+  for (int id = 0; id < kWriters; ++id) {
+    const auto final_key = "final/" + std::to_string(id);
+    bool called = false;
+    ASSERT_TRUE(engine->Get(final_key, [&](std::string_view, sitos::Bytes value) {
+      called = true;
+      EXPECT_EQ(value.size(), 1u);
+      if (value.size() == 1) {
+        EXPECT_EQ(value[0], std::byte{static_cast<unsigned char>(id)});
+      }
+      return true;
+    }));
+    EXPECT_TRUE(called);
+  }
+  std::size_t final_count = 0;
+  ASSERT_TRUE(engine->List("final/", [&](std::string_view, sitos::Bytes value) {
+    ++final_count;
+    return value.size() == 1;
+  }));
+  EXPECT_EQ(final_count, static_cast<std::size_t>(kWriters));
+
+  snapshot.reset();
+  engine.reset();
   std::error_code error;
   std::filesystem::remove_all(path, error);
   EXPECT_FALSE(error);
@@ -150,31 +305,33 @@ TEST(RocksDBEngineNativeFailure, PutDeleteGetListHaveContractedFailures) {
   auto engine = std::move(result).Value();
   ASSERT_TRUE(engine->Put("fault", std::vector<std::byte>{std::byte{0x01}}));
 
-  sitos::RocksDBEngineTestAccess::SetFailures(*engine, sitos::RocksDBEngineTestAccess::kPut);
+  sitos::rocksdb_test::SetFailures(*engine, sitos::rocksdb_test::kPut);
   EXPECT_FALSE(engine->Put("fault", std::vector<std::byte>{std::byte{0x02}}));
   EXPECT_TRUE(engine->Get("fault", [](std::string_view, sitos::Bytes value) {
     return value.size() == 1 && value[0] == std::byte{0x01};
   }));
-  sitos::RocksDBEngineTestAccess::SetFailures(*engine, sitos::RocksDBEngineTestAccess::kDelete);
+  sitos::rocksdb_test::SetFailures(*engine, sitos::rocksdb_test::kDelete);
   EXPECT_FALSE(engine->Delete("fault"));
 
   bool called = false;
-  sitos::RocksDBEngineTestAccess::SetFailures(*engine, sitos::RocksDBEngineTestAccess::kGet);
+  sitos::rocksdb_test::SetFailures(*engine, sitos::rocksdb_test::kGet);
   EXPECT_FALSE(engine->Get("fault", [&](std::string_view, sitos::Bytes) {
     called = true;
     return true;
   }));
   EXPECT_FALSE(called);
-  sitos::RocksDBEngineTestAccess::SetFailures(*engine, sitos::RocksDBEngineTestAccess::kList);
+  sitos::rocksdb_test::SetFailures(*engine, sitos::rocksdb_test::kList);
   EXPECT_FALSE(engine->List("", [&](std::string_view, sitos::Bytes) {
     called = true;
     return true;
   }));
   EXPECT_FALSE(called);
 
-  sitos::RocksDBEngineTestAccess::SetFailures(*engine, 0);
+  sitos::rocksdb_test::SetFailures(*engine, 0);
+  engine.reset();
   std::error_code error;
   std::filesystem::remove_all(path, error);
+  EXPECT_FALSE(error);
 }
 
 TEST(RocksDBEngineSnapshotLifetime, MultipleSnapshotsRemainIndependent) {
@@ -188,10 +345,10 @@ TEST(RocksDBEngineSnapshotLifetime, MultipleSnapshotsRemainIndependent) {
   auto second = engine->TakeSnapshot();
   ASSERT_TRUE(engine->Put("key", std::vector<std::byte>{std::byte{0x03}}));
   ASSERT_TRUE(first->Get("key", [](std::string_view, sitos::Bytes value) {
-    return value[0] == std::byte{0x01};
+    return value.size() == 1 && value[0] == std::byte{0x01};
   }));
   ASSERT_TRUE(second->Get("key", [](std::string_view, sitos::Bytes value) {
-    return value[0] == std::byte{0x02};
+    return value.size() == 1 && value[0] == std::byte{0x02};
   }));
   std::error_code error;
   engine.reset();

--- a/tests/unit/rocksdb_engine_test.cpp
+++ b/tests/unit/rocksdb_engine_test.cpp
@@ -1,0 +1,201 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "storage_engine_contract.hpp"
+
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "sitos/rocksdb_engine.hpp"
+#include "rocksdb_engine_test_access.hpp"
+
+namespace {
+
+std::filesystem::path MakeTestPath() {
+  static std::atomic<unsigned int> next_id{0};
+  const auto id = next_id.fetch_add(1, std::memory_order_relaxed);
+  return std::filesystem::temp_directory_path() /
+         ("sitos-rocksdb-test-" + std::to_string(id));
+}
+
+class ContractEngine final : public sitos::StorageEngine {
+ public:
+  ContractEngine(std::unique_ptr<sitos::RocksDBEngine> engine, std::filesystem::path path)
+      : engine_(std::move(engine)), path_(std::move(path)) {}
+
+  ~ContractEngine() override {
+    engine_.reset();
+    std::error_code error;
+    std::filesystem::remove_all(path_, error);
+  }
+
+  bool Put(std::string_view key, sitos::Bytes value) override { return engine_->Put(key, value); }
+  bool Delete(std::string_view key) override { return engine_->Delete(key); }
+  bool Get(std::string_view key, const sitos::EntrySink& sink) const override {
+    return engine_->Get(key, sink);
+  }
+  bool List(std::string_view prefix, const sitos::EntrySink& sink) const override {
+    return engine_->List(prefix, sink);
+  }
+  std::shared_ptr<const sitos::StorageReader> TakeSnapshot() const override {
+    return engine_->TakeSnapshot();
+  }
+
+ private:
+  std::unique_ptr<sitos::RocksDBEngine> engine_;
+  std::filesystem::path path_;
+};
+
+std::unique_ptr<sitos::StorageEngine> MakeContractEngine() {
+  const auto path = MakeTestPath();
+  auto result = sitos::RocksDBEngine::Open(path.string());
+  if (!result.IsOk()) return nullptr;
+  return std::make_unique<ContractEngine>(std::move(result).Value(), path);
+}
+
+}  // namespace
+
+INSTANTIATE_STORAGE_ENGINE_CONTRACT_SUITE(RocksDBEngineContractTest, MakeContractEngine);
+
+TEST(RocksDBEngineOpenApi, EmptyPathIsInvalidArgument) {
+  const auto result = sitos::RocksDBEngine::Open("");
+  ASSERT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), sitos::Status::InvalidArgument);
+  EXPECT_TRUE(result.Error());
+}
+
+TEST(RocksDBEngineOpenApi, ExistingFilePathReturnsNativeErrorWithoutValueBytes) {
+  const auto path = MakeTestPath();
+  {
+    std::ofstream file(path);
+    file << "not-a-database";
+  }
+  const auto result = sitos::RocksDBEngine::Open(path.string());
+  ASSERT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), sitos::Status::Error);
+  EXPECT_TRUE(result.Error());
+  EXPECT_EQ(result.Message().find("not-a-database"), std::string_view::npos);
+  std::error_code error;
+  std::filesystem::remove(path, error);
+}
+
+TEST(RocksDBEngineOpenApi, CreatesAndReopensPersistentDatabase) {
+  const auto path = MakeTestPath();
+  {
+    auto result = sitos::RocksDBEngine::Open(path.string());
+    ASSERT_TRUE(result.IsOk());
+    auto engine = std::move(result).Value();
+    ASSERT_TRUE(engine->Put("persist", std::vector<std::byte>{std::byte{0x42}}));
+  }
+  {
+    auto result = sitos::RocksDBEngine::Open(path.string());
+    ASSERT_TRUE(result.IsOk());
+    auto engine = std::move(result).Value();
+    EXPECT_TRUE(engine->Get("persist", [](std::string_view, sitos::Bytes value) {
+      return value.size() == 1 && value[0] == std::byte{0x42};
+    }));
+  }
+  std::error_code error;
+  std::filesystem::remove_all(path, error);
+}
+
+TEST(RocksDBEngineSnapshotLifetime, TakeSnapshotUsesNativePrimitiveWithoutEnumeration) {
+  const auto path = MakeTestPath();
+  auto result = sitos::RocksDBEngine::Open(path.string());
+  ASSERT_TRUE(result.IsOk());
+  auto engine = std::move(result).Value();
+  ASSERT_TRUE(engine->Put("key", std::vector<std::byte>{std::byte{0x01}}));
+  auto snapshot = engine->TakeSnapshot();
+  ASSERT_NE(snapshot, nullptr);
+  std::size_t snapshot_calls = 0;
+  std::size_t enumeration_calls = 0;
+  sitos::RocksDBEngineTestAccess::GetSnapshotStats(*engine, snapshot_calls, enumeration_calls);
+  EXPECT_EQ(snapshot_calls, 1u);
+  EXPECT_EQ(enumeration_calls, 0u);
+  std::error_code error;
+  snapshot.reset();
+  engine.reset();
+  std::filesystem::remove_all(path, error);
+}
+
+TEST(RocksDBEngineSnapshotLifetime, SnapshotOutlivesEngine) {
+  const auto path = MakeTestPath();
+  std::shared_ptr<const sitos::StorageReader> snapshot;
+  {
+    auto result = sitos::RocksDBEngine::Open(path.string());
+    ASSERT_TRUE(result.IsOk());
+    auto engine = std::move(result).Value();
+    ASSERT_TRUE(engine->Put("stable", std::vector<std::byte>{std::byte{0x01}}));
+    snapshot = engine->TakeSnapshot();
+    ASSERT_NE(snapshot, nullptr);
+    engine.reset();
+    EXPECT_TRUE(snapshot->Get("stable", [](std::string_view, sitos::Bytes value) {
+      return value.size() == 1 && value[0] == std::byte{0x01};
+    }));
+  }
+  snapshot.reset();
+  std::error_code error;
+  std::filesystem::remove_all(path, error);
+  EXPECT_FALSE(error);
+}
+
+TEST(RocksDBEngineNativeFailure, PutDeleteGetListHaveContractedFailures) {
+  const auto path = MakeTestPath();
+  auto result = sitos::RocksDBEngine::Open(path.string());
+  ASSERT_TRUE(result.IsOk());
+  auto engine = std::move(result).Value();
+  ASSERT_TRUE(engine->Put("fault", std::vector<std::byte>{std::byte{0x01}}));
+
+  sitos::RocksDBEngineTestAccess::SetFailures(*engine, sitos::RocksDBEngineTestAccess::kPut);
+  EXPECT_FALSE(engine->Put("fault", std::vector<std::byte>{std::byte{0x02}}));
+  EXPECT_TRUE(engine->Get("fault", [](std::string_view, sitos::Bytes value) {
+    return value.size() == 1 && value[0] == std::byte{0x01};
+  }));
+  sitos::RocksDBEngineTestAccess::SetFailures(*engine, sitos::RocksDBEngineTestAccess::kDelete);
+  EXPECT_FALSE(engine->Delete("fault"));
+
+  bool called = false;
+  sitos::RocksDBEngineTestAccess::SetFailures(*engine, sitos::RocksDBEngineTestAccess::kGet);
+  EXPECT_FALSE(engine->Get("fault", [&](std::string_view, sitos::Bytes) {
+    called = true;
+    return true;
+  }));
+  EXPECT_FALSE(called);
+  sitos::RocksDBEngineTestAccess::SetFailures(*engine, sitos::RocksDBEngineTestAccess::kList);
+  EXPECT_FALSE(engine->List("", [&](std::string_view, sitos::Bytes) {
+    called = true;
+    return true;
+  }));
+  EXPECT_FALSE(called);
+
+  sitos::RocksDBEngineTestAccess::SetFailures(*engine, 0);
+  std::error_code error;
+  std::filesystem::remove_all(path, error);
+}
+
+TEST(RocksDBEngineSnapshotLifetime, MultipleSnapshotsRemainIndependent) {
+  const auto path = MakeTestPath();
+  auto result = sitos::RocksDBEngine::Open(path.string());
+  ASSERT_TRUE(result.IsOk());
+  auto engine = std::move(result).Value();
+  ASSERT_TRUE(engine->Put("key", std::vector<std::byte>{std::byte{0x01}}));
+  auto first = engine->TakeSnapshot();
+  ASSERT_TRUE(engine->Put("key", std::vector<std::byte>{std::byte{0x02}}));
+  auto second = engine->TakeSnapshot();
+  ASSERT_TRUE(engine->Put("key", std::vector<std::byte>{std::byte{0x03}}));
+  ASSERT_TRUE(first->Get("key", [](std::string_view, sitos::Bytes value) {
+    return value[0] == std::byte{0x01};
+  }));
+  ASSERT_TRUE(second->Get("key", [](std::string_view, sitos::Bytes value) {
+    return value[0] == std::byte{0x02};
+  }));
+  std::error_code error;
+  engine.reset();
+  first.reset();
+  second.reset();
+  std::filesystem::remove_all(path, error);
+}

--- a/tests/unit/rocksdb_engine_test.cpp
+++ b/tests/unit/rocksdb_engine_test.cpp
@@ -126,6 +126,25 @@ TEST(RocksDBEngineOpenApi, EmptyPathIsInvalidArgument) {
   EXPECT_TRUE(result.Error());
 }
 
+TEST(RocksDBEngineOpenApi, InjectedNativeOpenFailureReturnsError) {
+  const auto path = MakeTestPath();
+  sitos::rocksdb_test::SetOpenFailureForTest();
+  const auto result = sitos::RocksDBEngine::Open(path.string());
+  ASSERT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), sitos::Status::Error);
+  EXPECT_TRUE(result.Error());
+  EXPECT_FALSE(std::filesystem::exists(path));
+
+  auto retry = sitos::RocksDBEngine::Open(path.string());
+  ASSERT_TRUE(retry.IsOk());
+  auto engine = std::move(retry).Value();
+  ASSERT_NE(engine, nullptr);
+  engine.reset();
+  std::error_code error;
+  std::filesystem::remove_all(path, error);
+  EXPECT_FALSE(error);
+}
+
 TEST(RocksDBEngineOpenApi, ExistingFilePathReturnsNativeErrorWithoutValueBytes) {
   const auto path = MakeTestPath();
   {
@@ -198,14 +217,16 @@ TEST(RocksDBEngineSnapshotLifetime, SnapshotOutlivesEngine) {
       return value.size() == 1 && value[0] == std::byte{0x01};
     }));
   }
-  ASSERT_EQ(events->events.size(), 1u);
-  EXPECT_EQ(events->events[0], "get_snapshot");
+  ASSERT_EQ(events->events.size(), 2u);
+  EXPECT_EQ(events->events[0], "open");
+  EXPECT_EQ(events->events[1], "get_snapshot");
   snapshot.reset();
-  ASSERT_EQ(events->events.size(), 4u);
-  EXPECT_EQ(events->events[0], "get_snapshot");
-  EXPECT_EQ(events->events[1], "release_snapshot");
-  EXPECT_EQ(events->events[2], "db_close");
-  EXPECT_EQ(events->events[3], "directory_remove");
+  ASSERT_EQ(events->events.size(), 5u);
+  EXPECT_EQ(events->events[0], "open");
+  EXPECT_EQ(events->events[1], "get_snapshot");
+  EXPECT_EQ(events->events[2], "release_snapshot");
+  EXPECT_EQ(events->events[3], "db_close");
+  EXPECT_EQ(events->events[4], "directory_remove");
   EXPECT_FALSE(std::filesystem::exists(path));
 }
 

--- a/tests/unit/rocksdb_engine_test.cpp
+++ b/tests/unit/rocksdb_engine_test.cpp
@@ -217,16 +217,45 @@ TEST(RocksDBEngineSnapshotLifetime, SnapshotOutlivesEngine) {
       return value.size() == 1 && value[0] == std::byte{0x01};
     }));
   }
-  ASSERT_EQ(events->events.size(), 2u);
-  EXPECT_EQ(events->events[0], "open");
-  EXPECT_EQ(events->events[1], "get_snapshot");
+  auto recorded = events->Snapshot();
+  ASSERT_EQ(recorded.size(), 2u);
+  EXPECT_EQ(recorded[0], "open");
+  EXPECT_EQ(recorded[1], "get_snapshot");
   snapshot.reset();
-  ASSERT_EQ(events->events.size(), 5u);
-  EXPECT_EQ(events->events[0], "open");
-  EXPECT_EQ(events->events[1], "get_snapshot");
-  EXPECT_EQ(events->events[2], "release_snapshot");
-  EXPECT_EQ(events->events[3], "db_close");
-  EXPECT_EQ(events->events[4], "directory_remove");
+  recorded = events->Snapshot();
+  ASSERT_EQ(recorded.size(), 5u);
+  EXPECT_EQ(recorded[0], "open");
+  EXPECT_EQ(recorded[1], "get_snapshot");
+  EXPECT_EQ(recorded[2], "release_snapshot");
+  EXPECT_EQ(recorded[3], "db_close");
+  EXPECT_EQ(recorded[4], "directory_remove");
+  EXPECT_FALSE(std::filesystem::exists(path));
+}
+
+TEST(RocksDBEngineSnapshotLifetime, InjectedReleaseFailureFallsBackWithoutTerminating) {
+  const auto path = MakeTestPath();
+  std::shared_ptr<const sitos::StorageReader> snapshot;
+  std::shared_ptr<sitos::rocksdb_test::EventLog> events;
+  {
+    auto result = sitos::RocksDBEngine::Open(path.string());
+    ASSERT_TRUE(result.IsOk());
+    auto engine = std::move(result).Value();
+    events = sitos::rocksdb_test::GetEventLog(*engine);
+    auto cleanup = std::make_shared<CleanupToken>(path, events);
+    snapshot = std::make_shared<SnapshotAdapter>(engine->TakeSnapshot(), cleanup);
+    sitos::rocksdb_test::SetSnapshotReleaseFailureForTest(*engine);
+    engine.reset();
+  }
+
+  snapshot.reset();
+  const auto recorded = events->Snapshot();
+  ASSERT_EQ(recorded.size(), 6u);
+  EXPECT_EQ(recorded[0], "open");
+  EXPECT_EQ(recorded[1], "get_snapshot");
+  EXPECT_EQ(recorded[2], "release_snapshot_recovered");
+  EXPECT_EQ(recorded[3], "release_snapshot");
+  EXPECT_EQ(recorded[4], "db_close");
+  EXPECT_EQ(recorded[5], "directory_remove");
   EXPECT_FALSE(std::filesystem::exists(path));
 }
 

--- a/tests/unit/rocksdb_engine_test_access_test.cpp
+++ b/tests/unit/rocksdb_engine_test_access_test.cpp
@@ -1,0 +1,211 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#if defined(_WIN32)
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+#include "sitos/rocksdb_engine.hpp"
+#include "rocksdb_engine_test_access.hpp"
+
+namespace {
+
+std::filesystem::path MakeSeamTestPath() {
+  static std::atomic<unsigned int> next_id{0};
+  const auto id = next_id.fetch_add(1);
+#if defined(_WIN32)
+  const auto process_id = _getpid();
+#else
+  const auto process_id = getpid();
+#endif
+  const auto path = std::filesystem::temp_directory_path() /
+                    ("sitos-rocksdb-seam-test-" + std::to_string(process_id) + "-" +
+                     std::to_string(id));
+  std::error_code error;
+  std::filesystem::remove_all(path, error);
+  EXPECT_FALSE(error);
+  return path;
+}
+
+class EventCleanupToken final {
+ public:
+  EventCleanupToken(std::filesystem::path path,
+                    std::shared_ptr<sitos::rocksdb_test::EventLog> events)
+      : path_(std::move(path)), events_(std::move(events)) {}
+
+  ~EventCleanupToken() {
+    std::error_code error;
+    std::filesystem::remove_all(path_, error);
+    if (events_) events_->Add(error ? "directory_remove_failed" : "directory_remove");
+  }
+
+ private:
+  std::filesystem::path path_;
+  std::shared_ptr<sitos::rocksdb_test::EventLog> events_;
+};
+
+class SeamSnapshotAdapter final : public sitos::StorageReader {
+ public:
+  SeamSnapshotAdapter(std::shared_ptr<const sitos::StorageReader> snapshot,
+                      std::shared_ptr<EventCleanupToken> cleanup)
+      : cleanup_(std::move(cleanup)), snapshot_(std::move(snapshot)) {}
+
+  bool Get(std::string_view key, const sitos::EntrySink& sink) const override {
+    return snapshot_->Get(key, sink);
+  }
+  bool List(std::string_view prefix, const sitos::EntrySink& sink) const override {
+    return snapshot_->List(prefix, sink);
+  }
+
+ private:
+  std::shared_ptr<EventCleanupToken> cleanup_;
+  std::shared_ptr<const sitos::StorageReader> snapshot_;
+};
+
+}  // namespace
+
+TEST(RocksDBEngineTestSeam, InjectedNativeOpenFailureReturnsError) {
+  const auto path = MakeSeamTestPath();
+  sitos::rocksdb_test::SetOpenFailureForTest();
+  const auto result = sitos::RocksDBEngine::Open(path.string());
+  ASSERT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), sitos::Status::Error);
+  EXPECT_TRUE(result.Error());
+  EXPECT_FALSE(std::filesystem::exists(path));
+
+  auto retry = sitos::RocksDBEngine::Open(path.string());
+  ASSERT_TRUE(retry.IsOk());
+  auto engine = std::move(retry).Value();
+  ASSERT_NE(engine, nullptr);
+  engine.reset();
+  std::error_code error;
+  std::filesystem::remove_all(path, error);
+  EXPECT_FALSE(error);
+}
+
+TEST(RocksDBEngineTestSeam, TakeSnapshotUsesNativePrimitiveWithoutEnumeration) {
+  const auto path = MakeSeamTestPath();
+  auto result = sitos::RocksDBEngine::Open(path.string());
+  ASSERT_TRUE(result.IsOk());
+  auto engine = std::move(result).Value();
+  ASSERT_TRUE(engine->Put("key", std::vector<std::byte>{std::byte{0x01}}));
+  auto snapshot = engine->TakeSnapshot();
+  ASSERT_NE(snapshot, nullptr);
+  std::size_t snapshot_calls = 0;
+  std::size_t enumeration_calls = 0;
+  sitos::rocksdb_test::GetSnapshotStats(*engine, snapshot_calls, enumeration_calls);
+  EXPECT_EQ(snapshot_calls, 1u);
+  EXPECT_EQ(enumeration_calls, 0u);
+  std::error_code error;
+  snapshot.reset();
+  engine.reset();
+  std::filesystem::remove_all(path, error);
+  EXPECT_FALSE(error);
+}
+
+TEST(RocksDBEngineTestSeam, SnapshotOutlivesEngineWithOrderedCleanup) {
+  const auto path = MakeSeamTestPath();
+  std::shared_ptr<const sitos::StorageReader> snapshot;
+  std::shared_ptr<sitos::rocksdb_test::EventLog> events;
+  {
+    auto result = sitos::RocksDBEngine::Open(path.string());
+    ASSERT_TRUE(result.IsOk());
+    auto engine = std::move(result).Value();
+    events = sitos::rocksdb_test::GetEventLog(*engine);
+    auto cleanup = std::make_shared<EventCleanupToken>(path, events);
+    ASSERT_TRUE(engine->Put("stable", std::vector<std::byte>{std::byte{0x01}}));
+    snapshot = std::make_shared<SeamSnapshotAdapter>(engine->TakeSnapshot(), cleanup);
+    ASSERT_NE(snapshot, nullptr);
+    engine.reset();
+    EXPECT_TRUE(snapshot->Get("stable", [](std::string_view, sitos::Bytes value) {
+      return value.size() == 1 && value[0] == std::byte{0x01};
+    }));
+  }
+  auto recorded = events->Snapshot();
+  ASSERT_EQ(recorded.size(), 2u);
+  EXPECT_EQ(recorded[0], "open");
+  EXPECT_EQ(recorded[1], "get_snapshot");
+  snapshot.reset();
+  recorded = events->Snapshot();
+  ASSERT_EQ(recorded.size(), 5u);
+  EXPECT_EQ(recorded[0], "open");
+  EXPECT_EQ(recorded[1], "get_snapshot");
+  EXPECT_EQ(recorded[2], "release_snapshot");
+  EXPECT_EQ(recorded[3], "db_close");
+  EXPECT_EQ(recorded[4], "directory_remove");
+  EXPECT_FALSE(std::filesystem::exists(path));
+}
+
+TEST(RocksDBEngineTestSeam, InjectedReleaseFailureFallsBackWithoutTerminating) {
+  const auto path = MakeSeamTestPath();
+  std::shared_ptr<const sitos::StorageReader> snapshot;
+  std::shared_ptr<sitos::rocksdb_test::EventLog> events;
+  {
+    auto result = sitos::RocksDBEngine::Open(path.string());
+    ASSERT_TRUE(result.IsOk());
+    auto engine = std::move(result).Value();
+    events = sitos::rocksdb_test::GetEventLog(*engine);
+    auto cleanup = std::make_shared<EventCleanupToken>(path, events);
+    snapshot = std::make_shared<SeamSnapshotAdapter>(engine->TakeSnapshot(), cleanup);
+    sitos::rocksdb_test::SetSnapshotReleaseFailureForTest(*engine);
+    engine.reset();
+  }
+
+  snapshot.reset();
+  const auto recorded = events->Snapshot();
+  ASSERT_EQ(recorded.size(), 6u);
+  EXPECT_EQ(recorded[0], "open");
+  EXPECT_EQ(recorded[1], "get_snapshot");
+  EXPECT_EQ(recorded[2], "release_snapshot_recovered");
+  EXPECT_EQ(recorded[3], "release_snapshot");
+  EXPECT_EQ(recorded[4], "db_close");
+  EXPECT_EQ(recorded[5], "directory_remove");
+  EXPECT_FALSE(std::filesystem::exists(path));
+}
+
+TEST(RocksDBEngineTestSeam, NativeFailuresPreserveStorageContracts) {
+  const auto path = MakeSeamTestPath();
+  auto result = sitos::RocksDBEngine::Open(path.string());
+  ASSERT_TRUE(result.IsOk());
+  auto engine = std::move(result).Value();
+  ASSERT_TRUE(engine->Put("fault", std::vector<std::byte>{std::byte{0x01}}));
+
+  sitos::rocksdb_test::SetFailures(*engine, sitos::rocksdb_test::kPut);
+  EXPECT_FALSE(engine->Put("fault", std::vector<std::byte>{std::byte{0x02}}));
+  EXPECT_TRUE(engine->Get("fault", [](std::string_view, sitos::Bytes value) {
+    return value.size() == 1 && value[0] == std::byte{0x01};
+  }));
+  sitos::rocksdb_test::SetFailures(*engine, sitos::rocksdb_test::kDelete);
+  EXPECT_FALSE(engine->Delete("fault"));
+
+  bool called = false;
+  sitos::rocksdb_test::SetFailures(*engine, sitos::rocksdb_test::kGet);
+  EXPECT_FALSE(engine->Get("fault", [&](std::string_view, sitos::Bytes) {
+    called = true;
+    return true;
+  }));
+  EXPECT_FALSE(called);
+  sitos::rocksdb_test::SetFailures(*engine, sitos::rocksdb_test::kList);
+  EXPECT_FALSE(engine->List("", [&](std::string_view, sitos::Bytes) {
+    called = true;
+    return true;
+  }));
+  EXPECT_FALSE(called);
+
+  sitos::rocksdb_test::SetFailures(*engine, 0);
+  engine.reset();
+  std::error_code error;
+  std::filesystem::remove_all(path, error);
+  EXPECT_FALSE(error);
+}

--- a/tests/unit/storage_engine_contract.hpp
+++ b/tests/unit/storage_engine_contract.hpp
@@ -10,8 +10,9 @@
 //       return std::make_unique<MyEngine>();
 //   });
 //
-// Required test names (docs/06 §4.1): SnapshotIsIsolatedFromBasePut,
-// SnapshotFallbackCopiesForInMemory.
+// Required test names (docs/06 §5.1): SnapshotIsIsolatedFromBasePut,
+// SnapshotFallbackCopiesForInMemory, SnapshotIsIsolatedFromBaseDelete,
+// ListEmitsDeterministicKeyOrder.
 
 #ifndef SITOS_STORAGE_ENGINE_CONTRACT_HPP
 #define SITOS_STORAGE_ENGINE_CONTRACT_HPP
@@ -43,7 +44,10 @@ using EngineFactory = std::function<std::unique_ptr<StorageEngine>()>;
 /// mock (if any).  Not needed for the contract itself but kept as a convenience.
 class EngineContractTest : public ::testing::TestWithParam<EngineFactory> {
  protected:
-  void SetUp() override { engine_ = GetParam()(); }
+  void SetUp() override {
+    engine_ = GetParam()();
+    ASSERT_NE(engine_, nullptr);
+  }
   void TearDown() override { engine_.reset(); }
 
   StorageEngine& engine() { return *engine_; }
@@ -224,7 +228,7 @@ inline void ListEmptyEngine(sitos::StorageEngine& engine) {
   EXPECT_FALSE(called);
 }
 
-// docs/06 §4.1: SnapshotFallbackCopiesForInMemory
+// docs/06 §5.1: SnapshotFallbackCopiesForInMemory
 inline void SnapshotFallbackCopiesForInMemory(sitos::StorageEngine& engine) {
   ASSERT_TRUE(engine.Put("s1", BytesFromString("hello")));
   ASSERT_TRUE(engine.Put("s2", BytesFromString("world")));
@@ -259,7 +263,7 @@ inline void SnapshotFallbackCopiesForInMemory(sitos::StorageEngine& engine) {
   EXPECT_FALSE(found);
 }
 
-// docs/06 §4.1: SnapshotIsIsolatedFromBasePut
+// docs/06 §5.1: SnapshotIsIsolatedFromBasePut
 inline void SnapshotIsIsolatedFromBasePut(sitos::StorageEngine& engine) {
   ASSERT_TRUE(engine.Put("iso", BytesFromString("before")));
 
@@ -285,6 +289,37 @@ inline void SnapshotIsIsolatedFromBasePut(sitos::StorageEngine& engine) {
                  [&](std::string_view /*key*/, sitos::Bytes /*value*/) { found = true; return true; });
   EXPECT_FALSE(ok);
   EXPECT_FALSE(found);
+}
+
+inline void SnapshotIsIsolatedFromBaseDelete(sitos::StorageEngine& engine) {
+  ASSERT_TRUE(engine.Put("iso-delete", BytesFromString("before")));
+  auto snap = engine.TakeSnapshot();
+  ASSERT_NE(snap, nullptr);
+  ASSERT_TRUE(engine.Delete("iso-delete"));
+
+  bool found = false;
+  const bool ok = snap->Get("iso-delete", [&](std::string_view, sitos::Bytes value) {
+    found = true;
+    EXPECT_EQ(value.size(), 6u);
+    EXPECT_EQ(static_cast<char>(value[0]), 'b');
+    return value.size() == 6u && static_cast<char>(value[0]) == 'b';
+  });
+  EXPECT_TRUE(ok);
+  EXPECT_TRUE(found);
+  EXPECT_FALSE(engine.Get("iso-delete", [](std::string_view, sitos::Bytes) { return true; }));
+}
+
+inline void ListEmitsDeterministicKeyOrder(sitos::StorageEngine& engine) {
+  ASSERT_TRUE(engine.Put("order/z", BytesFromString("z")));
+  ASSERT_TRUE(engine.Put("order/a", BytesFromString("a")));
+  ASSERT_TRUE(engine.Put("order/m", BytesFromString("m")));
+
+  std::vector<std::string> keys;
+  ASSERT_TRUE(engine.List("order/", [&](std::string_view key, sitos::Bytes) {
+    keys.emplace_back(key);
+    return true;
+  }));
+  EXPECT_EQ(keys, (std::vector<std::string>{"order/a", "order/m", "order/z"}));
 }
 
 inline void SinkCanReenterReadOperations(sitos::testing::EngineFactory factory) {
@@ -489,6 +524,12 @@ inline void HandlesOpaqueBytes(sitos::StorageEngine& engine) {
   }                                                                                         \
   TEST_P(SuiteName, SnapshotIsIsolatedFromBasePut) {                                         \
     sitos_contract::SnapshotIsIsolatedFromBasePut(engine());                                 \
+  }                                                                                         \
+  TEST_P(SuiteName, SnapshotIsIsolatedFromBaseDelete) {                                      \
+    sitos_contract::SnapshotIsIsolatedFromBaseDelete(engine());                              \
+  }                                                                                         \
+  TEST_P(SuiteName, ListEmitsDeterministicKeyOrder) {                                        \
+    sitos_contract::ListEmitsDeterministicKeyOrder(engine());                                \
   }                                                                                         \
   TEST_P(SuiteName, HandlesOpaqueBytes) {                                                    \
     sitos_contract::HandlesOpaqueBytes(engine());                                            \

--- a/tests/vcpkg/validate_vcpkg_provisioning.cmake
+++ b/tests/vcpkg/validate_vcpkg_provisioning.cmake
@@ -84,19 +84,40 @@ set(_zlib_include_dir "${_feature_install}/${TRIPLET}/include")
 run_checked(
   "${CMAKE_COMMAND}" -S "${SITOS_SOURCE_DIR}" -B "${_sitos_build}"
   ${_generator_args} -DCMAKE_BUILD_TYPE=Release
-  -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF -DSITOS_WITH_ROCKSDB=ON
+  -DSITOS_BUILD_TESTS=ON -DSITOS_BUILD_BENCHMARKS=ON -DSITOS_WITH_ZENOH=OFF -DSITOS_WITH_ROCKSDB=ON
   "-DCMAKE_TOOLCHAIN_FILE=${_toolchain}"
   "-DVCPKG_MANIFEST_DIR=${SITOS_SOURCE_DIR}"
   -DVCPKG_MANIFEST_FEATURES=rocksdb
   "-DVCPKG_TARGET_TRIPLET=${TRIPLET}"
   "-DVCPKG_INSTALLED_DIR=${_feature_install}")
 run_checked("${CMAKE_COMMAND}" --build "${_sitos_build}")
+if(WIN32)
+  set(_benchmark_suffix ".exe")
+else()
+  set(_benchmark_suffix "")
+endif()
+set(_benchmark_executable
+  "${_sitos_build}/tests/bench/sitos_rocksdb_snapshot_bench${_benchmark_suffix}")
+if(NOT EXISTS "${_benchmark_executable}")
+  set(_benchmark_executable
+    "${_sitos_build}/tests/bench/Release/sitos_rocksdb_snapshot_bench${_benchmark_suffix}")
+endif()
+if(NOT EXISTS "${_benchmark_executable}")
+  message(FATAL_ERROR "Snapshot benchmark executable was not built: ${_benchmark_executable}")
+endif()
+run_checked(
+  "${_benchmark_executable}" --benchmark_filter=TakeSnapshot
+  --benchmark_repetitions=1 --benchmark_min_time=0.001)
 run_checked(
   "${CMAKE_CTEST_COMMAND}" --test-dir "${_sitos_build}" --output-on-failure --no-tests=error
   -R "RocksDBEngineContractTest|RocksDBEngineOpenApi|RocksDBEngineSnapshotLifetime|RocksDBEngineConcurrency|RocksDBEngineNativeFailure")
 run_checked(
   "${CMAKE_CTEST_COMMAND}" --test-dir "${_sitos_build}" --output-on-failure --no-tests=error)
 run_checked("${CMAKE_COMMAND}" --install "${_sitos_build}" --prefix "${_sitos_prefix}")
+run_checked(
+  "${CMAKE_COMMAND}" "-DSITOS_PREFIX=${_sitos_prefix}"
+  "-DSITOS_INSTALL_LIBDIR=lib"
+  -P "${SITOS_SOURCE_DIR}/tests/package/check_no_rocksdb_test_symbols.cmake")
 set(_sitos_relocated_prefix "${_work_dir}/sitos-rocksdb-relocated-prefix")
 run_checked("${CMAKE_COMMAND}" -E copy_directory "${_sitos_prefix}" "${_sitos_relocated_prefix}")
 run_checked(
@@ -173,6 +194,11 @@ run_checked(
   "-DVCPKG_TARGET_TRIPLET=${TRIPLET}"
   "-DVCPKG_INSTALLED_DIR=${_default_install}")
 run_checked("${CMAKE_COMMAND}" --build "${_default_build}")
+run_checked("${CMAKE_COMMAND}" --install "${_default_build}" --prefix "${_default_install}")
+run_checked(
+  "${CMAKE_COMMAND}" "-DSITOS_PREFIX=${_default_install}"
+  "-DSITOS_INSTALL_LIBDIR=lib"
+  -P "${SITOS_SOURCE_DIR}/tests/package/check_no_rocksdb_test_symbols.cmake")
 run_checked(
   "${CMAKE_COMMAND}" "-DVCPKG_INSTALLED_DIR=${_default_install}"
   -P "${SITOS_SOURCE_DIR}/tests/vcpkg/check_default_no_rocksdb.cmake")

--- a/tests/vcpkg/validate_vcpkg_provisioning.cmake
+++ b/tests/vcpkg/validate_vcpkg_provisioning.cmake
@@ -90,7 +90,9 @@ run_checked(
   "${CMAKE_COMMAND}" -S "${SITOS_SOURCE_DIR}/tests/package/consumer" -B "${_sitos_consumer_build}"
   ${_generator_args} -DCMAKE_BUILD_TYPE=Release
   -DSITOS_PACKAGE_CONSUMER_WITH_ROCKSDB=ON
-  "-DCMAKE_PREFIX_PATH=${_sitos_prefix};${_feature_install}/${TRIPLET}")
+  "-DCMAKE_PREFIX_PATH=${_sitos_prefix}"
+  "-DRocksDB_DIR=${_feature_install}/${TRIPLET}/share/rocksdb"
+  "-DZLIB_DIR=${_feature_install}/${TRIPLET}/share/zlib")
 run_checked("${CMAKE_COMMAND}" --build "${_sitos_consumer_build}")
 
 if(WIN32)

--- a/tests/vcpkg/validate_vcpkg_provisioning.cmake
+++ b/tests/vcpkg/validate_vcpkg_provisioning.cmake
@@ -75,6 +75,12 @@ run_checked("${CMAKE_COMMAND}" --build "${_feature_build}")
 set(_sitos_build "${_work_dir}/sitos-rocksdb-build")
 set(_sitos_prefix "${_work_dir}/sitos-rocksdb-prefix")
 set(_sitos_consumer_build "${_work_dir}/sitos-rocksdb-consumer-build")
+if(WIN32)
+  set(_zlib_library "${_feature_install}/${TRIPLET}/lib/z.lib")
+else()
+  set(_zlib_library "${_feature_install}/${TRIPLET}/lib/libz.a")
+endif()
+set(_zlib_include_dir "${_feature_install}/${TRIPLET}/include")
 run_checked(
   "${CMAKE_COMMAND}" -S "${SITOS_SOURCE_DIR}" -B "${_sitos_build}"
   ${_generator_args} -DCMAKE_BUILD_TYPE=Release
@@ -92,7 +98,8 @@ run_checked(
   -DSITOS_PACKAGE_CONSUMER_WITH_ROCKSDB=ON
   "-DCMAKE_PREFIX_PATH=${_sitos_prefix}"
   "-DRocksDB_DIR=${_feature_install}/${TRIPLET}/share/rocksdb"
-  "-DZLIB_DIR=${_feature_install}/${TRIPLET}/share/zlib")
+  "-DZLIB_LIBRARY=${_zlib_library}"
+  "-DZLIB_INCLUDE_DIR=${_zlib_include_dir}")
 run_checked("${CMAKE_COMMAND}" --build "${_sitos_consumer_build}")
 
 if(WIN32)

--- a/tests/vcpkg/validate_vcpkg_provisioning.cmake
+++ b/tests/vcpkg/validate_vcpkg_provisioning.cmake
@@ -84,19 +84,37 @@ set(_zlib_include_dir "${_feature_install}/${TRIPLET}/include")
 run_checked(
   "${CMAKE_COMMAND}" -S "${SITOS_SOURCE_DIR}" -B "${_sitos_build}"
   ${_generator_args} -DCMAKE_BUILD_TYPE=Release
-  -DSITOS_BUILD_TESTS=OFF -DSITOS_WITH_ZENOH=OFF -DSITOS_WITH_ROCKSDB=ON
+  -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF -DSITOS_WITH_ROCKSDB=ON
   "-DCMAKE_TOOLCHAIN_FILE=${_toolchain}"
   "-DVCPKG_MANIFEST_DIR=${SITOS_SOURCE_DIR}"
   -DVCPKG_MANIFEST_FEATURES=rocksdb
   "-DVCPKG_TARGET_TRIPLET=${TRIPLET}"
   "-DVCPKG_INSTALLED_DIR=${_feature_install}")
 run_checked("${CMAKE_COMMAND}" --build "${_sitos_build}")
+run_checked(
+  "${CMAKE_CTEST_COMMAND}" --test-dir "${_sitos_build}" --output-on-failure --no-tests=error
+  -R "RocksDBEngineContractTest|RocksDBEngineOpenApi|RocksDBEngineSnapshotLifetime|RocksDBEngineConcurrency|RocksDBEngineNativeFailure")
+run_checked(
+  "${CMAKE_CTEST_COMMAND}" --test-dir "${_sitos_build}" --output-on-failure --no-tests=error)
 run_checked("${CMAKE_COMMAND}" --install "${_sitos_build}" --prefix "${_sitos_prefix}")
+set(_sitos_relocated_prefix "${_work_dir}/sitos-rocksdb-relocated-prefix")
+run_checked("${CMAKE_COMMAND}" -E copy_directory "${_sitos_prefix}" "${_sitos_relocated_prefix}")
+run_checked(
+  "${CMAKE_COMMAND}" "-DSITOS_PREFIX=${_sitos_prefix}"
+  "-DSITOS_INSTALL_LIBDIR=lib"
+  -P "${SITOS_SOURCE_DIR}/tests/package/check_clean_install.cmake")
+run_checked(
+  "${CMAKE_COMMAND}" "-DSITOS_PREFIX=${_sitos_relocated_prefix}"
+  "-DSITOS_SOURCE_DIR=${SITOS_SOURCE_DIR}"
+  "-DSITOS_BUILD_DIR=${_sitos_build}"
+  "-DORIGINAL_PREFIX=${_sitos_prefix}"
+  "-DSITOS_INSTALL_LIBDIR=lib"
+  -P "${SITOS_SOURCE_DIR}/tests/package/check_relocatable.cmake")
 run_checked(
   "${CMAKE_COMMAND}" -S "${SITOS_SOURCE_DIR}/tests/package/consumer" -B "${_sitos_consumer_build}"
   ${_generator_args} -DCMAKE_BUILD_TYPE=Release
   -DSITOS_PACKAGE_CONSUMER_WITH_ROCKSDB=ON
-  "-DCMAKE_PREFIX_PATH=${_sitos_prefix}"
+  "-DCMAKE_PREFIX_PATH=${_sitos_relocated_prefix}"
   "-DRocksDB_DIR=${_feature_install}/${TRIPLET}/share/rocksdb"
   "-DZLIB_LIBRARY=${_zlib_library}"
   "-DZLIB_INCLUDE_DIR=${_zlib_include_dir}")

--- a/tests/vcpkg/validate_vcpkg_provisioning.cmake
+++ b/tests/vcpkg/validate_vcpkg_provisioning.cmake
@@ -108,9 +108,12 @@ endif()
 run_checked(
   "${_benchmark_executable}" --benchmark_filter=TakeSnapshot
   --benchmark_repetitions=1 --benchmark_min_time=0.001)
+string(CONCAT _rocksdb_test_regex
+  "RocksDBEngineContractTest|RocksDBEngineOpenApi|"
+  "RocksDBEngineSnapshotLifetime|RocksDBEngineConcurrency|RocksDBEngineTestSeam")
 run_checked(
   "${CMAKE_CTEST_COMMAND}" --test-dir "${_sitos_build}" --output-on-failure --no-tests=error
-  -R "RocksDBEngineContractTest|RocksDBEngineOpenApi|RocksDBEngineSnapshotLifetime|RocksDBEngineConcurrency|RocksDBEngineNativeFailure")
+  -R "${_rocksdb_test_regex}")
 run_checked(
   "${CMAKE_CTEST_COMMAND}" --test-dir "${_sitos_build}" --output-on-failure --no-tests=error)
 run_checked("${CMAKE_COMMAND}" --install "${_sitos_build}" --prefix "${_sitos_prefix}")

--- a/tests/vcpkg/validate_vcpkg_provisioning.cmake
+++ b/tests/vcpkg/validate_vcpkg_provisioning.cmake
@@ -72,6 +72,27 @@ run_checked(
   "-DPROBE_RUNTIME_DIR=${_feature_stage}")
 run_checked("${CMAKE_COMMAND}" --build "${_feature_build}")
 
+set(_sitos_build "${_work_dir}/sitos-rocksdb-build")
+set(_sitos_prefix "${_work_dir}/sitos-rocksdb-prefix")
+set(_sitos_consumer_build "${_work_dir}/sitos-rocksdb-consumer-build")
+run_checked(
+  "${CMAKE_COMMAND}" -S "${SITOS_SOURCE_DIR}" -B "${_sitos_build}"
+  ${_generator_args} -DCMAKE_BUILD_TYPE=Release
+  -DSITOS_BUILD_TESTS=OFF -DSITOS_WITH_ZENOH=OFF -DSITOS_WITH_ROCKSDB=ON
+  "-DCMAKE_TOOLCHAIN_FILE=${_toolchain}"
+  "-DVCPKG_MANIFEST_DIR=${SITOS_SOURCE_DIR}"
+  -DVCPKG_MANIFEST_FEATURES=rocksdb
+  "-DVCPKG_TARGET_TRIPLET=${TRIPLET}"
+  "-DVCPKG_INSTALLED_DIR=${_feature_install}")
+run_checked("${CMAKE_COMMAND}" --build "${_sitos_build}")
+run_checked("${CMAKE_COMMAND}" --install "${_sitos_build}" --prefix "${_sitos_prefix}")
+run_checked(
+  "${CMAKE_COMMAND}" -S "${SITOS_SOURCE_DIR}/tests/package/consumer" -B "${_sitos_consumer_build}"
+  ${_generator_args} -DCMAKE_BUILD_TYPE=Release
+  -DSITOS_PACKAGE_CONSUMER_WITH_ROCKSDB=ON
+  "-DCMAKE_PREFIX_PATH=${_sitos_prefix};${_feature_install}/${TRIPLET}")
+run_checked("${CMAKE_COMMAND}" --build "${_sitos_consumer_build}")
+
 if(WIN32)
   # The pinned baseline's zlib 1.3.2 port exports the canonical z.dll name.
   # Never rename it or add a compatibility copy under the pre-1.3.2 name.


### PR DESCRIPTION
Closes #8

## Summary

- Add the optional PImpl-only `RocksDBEngine` with persistent CRUD and native snapshot readers.
- Keep the public header and linkable `operation_not_supported` stub available in RocksDB-OFF builds.
- Require RocksDB 11.1.2 EXACT in ON builds and reconstruct the exact dependency for installed ON packages.
- Share native CRUD, List, and snapshot operations between production and isolated test seams.
- Extend the existing vcpkg validation scripts and add Proposed ADR-0033.

## Scope

- [x] Wire the existing `SITOS_WITH_ROCKSDB` option (default OFF).
- [x] Install `include/sitos/rocksdb_engine.hpp` independently with no native RocksDB types.
- [x] Provide the OFF-mode linkable `Status::Error` / `operation_not_supported` stub.
- [x] Implement ON-mode Open, Put, Get, List, Delete, and native O(1) snapshots.
- [x] Reconstruct the exact build-time RocksDB dependency in installed ON packages.
- [x] Preserve unlocked sinks, callback-view lifetime, consistent List sets, deterministic order,
      opaque bytes, concurrency, and Put/Delete snapshot isolation.
- [x] Run reusable contract and concurrency coverage against the shipped `sitos` archive.
- [x] Isolate native failure and lifecycle seams in a separate executable that does not link the
      production archive and delegates successful operations to shared native helpers.
- [x] Audit the installed production archive for test-control symbols.
- [x] Add the informational 1k/100k snapshot benchmark scenarios without a blocking threshold.
- [x] Extend the existing `vcpkg-linux`/`vcpkg-windows` validation path without changing `vcpkg.json`
      or duplicating provisioning jobs.
- [x] Add Proposed ADR-0033; it remains Proposed and requires owner acceptance before merge.

## Acceptance criteria

- [x] RocksDB-OFF public header, stub, focused build/test, clean install, and external consumer pass.
- [x] RocksDB-ON configure/build uses `find_package(RocksDB 11.1.2 EXACT CONFIG REQUIRED)` and
      consumes `RocksDB::rocksdb`.
- [x] Contract coverage includes Put/Delete snapshot isolation, deterministic order, opaque bytes,
      reentrant sinks, concurrency, and consistent reads.
- [x] Native snapshot acquisition is structurally counted as `GetSnapshot()` without enumeration.
- [x] Snapshot ownership allows a snapshot to outlive the engine; release precedes final DB close and
      filesystem cleanup, including exception containment in snapshot destruction.
- [x] Native failure tests verify Put/Delete false and Get/List false with zero sink calls.
- [x] Production Get/List and snapshot Get/List share the same native read paths; List has one native
      `NewIterator` implementation and destroys it before invoking sinks.
- [x] Public and installed headers remain RocksDB-type-free.
- [x] Existing vcpkg jobs build and run focused RocksDB tests, validate 1k/100k benchmark scenarios,
      install and relocate the package, link the non-executed consumer, and audit archive symbols.

## TDD / RED evidence

The implementation branch does not claim a contemporaneous behavioral RED log that was not retained.
A truthful baseline reproduction was run against the pre-implementation checkout (`origin/main`):

```text
cl /nologo /std:c++20 /I C:\Users\tetet\gw\sitos\include /c issue8-red.cpp
fatal error C1083: Cannot open include file: 'sitos/rocksdb_engine.hpp': No such file or directory
```

This is retrospective baseline RED for the standalone public-header requirement, not fabricated
contemporaneous evidence. Review-driven regression work recorded focused structural RED checks before
implementation, including three native `NewIterator` paths before consolidation to one. The owner
explicitly accepted the absent pre-implementation behavioral RED evidence for V1, V2, and V5-V9 in
[the recorded disposition](https://github.com/tetsuh/sitos/pull/128#issuecomment-5116713055).

## Validation

### Local Windows/MSVC

Validated with the exact RocksDB 11.1.2 dependency and its matching MSVC 19.51 toolchain:

- RocksDB-ON production and isolated seam targets: built successfully.
- RocksDBEngine production contract, concurrency, lifecycle, and seam tests: **29/29 passed**.
- RocksDB-OFF focused target and `RocksDBEngineOffTest`: **1/1 passed**.
- Installed production archive test-symbol audit: passed.
- Production test executable links `sitos.lib`; seam executable excludes `sitos.lib`: verified.
- Native List path count (`NewIterator`): exactly one.
- `git diff --check`, 100-column audit, and forbidden-keyword audit: passed.

### CI-owned validation

Head `93fbef4` passed Windows/Linux builds and packages, vcpkg Windows/Linux, ASan/UBSan, TSan,
CodeQL, wheels, integration checks, CodeRabbit, and SonarCloud. The canonical vcpkg jobs ran the
focused RocksDB tests, 1k/100k benchmark scenarios, clean installation and relocation checks,
non-executed consumer linkage, and production archive symbol audit. SonarCloud duplication fell from
5.7% to **0.0%**, and the Quality Gate passed. The documentation-only head `e9abe28` restores the
normative cleanup-ordering clause and pending-owner Status wording; its exact-head CI is running.

## ADR gate

ADR-0033 (`Define the RocksDB engine, snapshot, and installed-package boundary`) remains
**Proposed — pending owner acceptance immediately before merge**. It cites ADR-0004 as the sole O(1),
copy-free snapshot authority and owns shared DB lifetime, release/close/filesystem ordering, package
reconstruction, production/seam test isolation, and ABI responsibility. It must be explicitly
accepted by the owner immediately before merge.

## Commits

- `ac436c5` test(engine): define RocksDB contract coverage (#8)
- `ba5ad3c` feat(engine): add optional RocksDB storage engine (#8)
- `45ea0cd` docs(adr): propose RocksDB engine boundary decision (#8)
- `ebf5e59` fix(engine): preserve RocksDB ownership during Open allocation (#8)
- `9bb6d8a` test(engine): cover RocksDB disabled behavior (#8)
- `fe76088` fix(build): link the RocksDB OFF stub into sitos (#8)
- `a0099b7` fix(engine): use RocksDB 11.1.2 unique Open ownership (#8)
- `3d6df09` fix(build): resolve RocksDB package dependencies in consumer validation (#8)
- `b25a909` fix(build): seed zlib discovery for RocksDB package consumers (#8)
- `2264c37` fix(engine): harden RocksDB lifecycle and validation (#8)
- `16795a6` fix(engine): isolate RocksDB test instrumentation (#8)
- `d3ec23b` fix(engine): make snapshot release noexcept (#8)
- `c5a0069` fix(engine): unify RocksDB production test paths (#8)
- `93fbef4` docs(adr): clarify RocksDB ownership boundary (#8)
- `e9abe28` docs(adr): restore RocksDB cleanup ordering (#8)

## Residual risks

- ADR-0033 still requires explicit owner acceptance immediately before merge.
- Exact RocksDB version equality does not alone prove external compiler, CRT, standard-library,
  build-configuration, or compile-option ABI compatibility.
