### PR TITLE
feat(key): add mixed buffer key contract (#139)

### DIFF
--- a/docs/01_requirements.md
+++ b/docs/01_requirements.md
@@ -48,11 +48,12 @@ the preceding legacy parameter store implementation.
 
 | ID | Priority | Requirement |
 |---|---|---|
-| C01 | MUST | payload v1 (1-byte type tag + LE raw value) is the wire and storage format and is strictly defined in [03_wire_protocol.md](03_wire_protocol.md) |
+| C01 | MUST | Parameter values use payload v1 (1-byte type tag plus little-endian raw value) as the wire and storage format defined in [03_wire_protocol.md](03_wire_protocol.md) |
 | C02 | MUST | A format identifier is set in zenoh `Encoding`, making coexistence with future payload v2 (CBOR, etc.) possible |
 | C03 | MUST | Reading and writing are possible using only standard zenoh APIs (get/put/subscribe) — interoperability with clients that do not depend on the sitos library (such as zenoh-python) |
 | C04 | MUST | Semantic versioning is adopted, and wire compatibility is broken only in major versions |
 | C05 | MUST | Provide an API that allows external compatibility adapters (such as wrappers for legacy KV APIs) to be implemented without changing the sitos core. In particular, Get with arithmetic casts between numeric types, prefix enumeration, and batch Put semantics must be available from the public API |
+| C06 | MUST | Session buffer values use opaque bare `zenoh/bytes`; durable values are retrievable by Get/List, while ephemeral values are live-only and leave no node-retained state |
 
 > **Note**: Compatibility layers for product-specific legacy APIs are outside
 > the scope of sitos (public OSS). C05 specifies only the responsibility on the

--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -275,8 +275,10 @@ cache behavior are outside this pseudocode and must not be implemented until #14
 
 Pseudocode for implementers. StorageNode does not use the raw zenoh-c API directly; it goes through
 the `Transport` abstraction ([09_dependency_policy.md](09_dependency_policy.md) §3).
-`BuildBufferKey(sid, buffer_class, key)` emits the durable or ephemeral route segment, and #56
-extends `ParsedKey` and `ParseKey` with `KeyKind::Buffer` and `buffer_class`. `AppendDiagnostic`
+`BuildBufferKey(prefix, sid, buffer_class, user_key)` emits the durable or ephemeral route
+segment. `BufferClass` selects `durable` or `ephemeral`; `KeyKind::Buffer` and
+`ParsedKey::buffer_class` identify parsed buffer routes, while non-buffer parsed keys leave
+`buffer_class` disengaged. `AppendDiagnostic`
 records a diagnostic without calling external code. `EmitDiagnostics` invokes the configured
 `LogSink` only after the serialized application scope has released `subscriber_mutex`,
 `session_mutex`, and every Session admission lease. `EmitLog` and `EmitDiagnosticsNoThrow` are

--- a/docs/04_api_cpp.md
+++ b/docs/04_api_cpp.md
@@ -88,7 +88,11 @@ struct ClientConfig {
 Result<void> ValidateClientConfig(const ClientConfig& config);
 
 /// Payload format identifier ([03] §2.2). Corresponds to transport Encoding.
-enum class Encoding { SitosV1, SitosV1Batch, Raw };
+struct Encoding {
+    static constexpr std::string_view kSitosV1 = "sitos.v1";
+    static constexpr std::string_view kSitosV1Batch = "sitos.v1.batch";
+    std::string id;
+};
 
 /// Common sink for List APIs. Returning false aborts enumeration.
 using ListSink = std::function<bool(std::string_view key, const ParamValue&)>;
@@ -280,9 +284,10 @@ external factory, rolls back every resource already created on failure, and publ
 Only a valid, non-null engine may commit `Creating` to `Active`. For a Session requesting
 durable buffers, a factory `Err` preserves its status, cause, and message. An empty factory,
 `Ok(nullptr)`, or a factory exception fails with a non-OK Result; exceptions are contained. The
-exact Status taxonomy for empty, null, and exception outcomes is deferred to the Issue #56 scope
-freeze. The non-commit path releases resources created by that attempt and removes only the same
-`Creating` reservation, allowing same-SID retry.
+exact Status taxonomy for empty, null, and exception outcomes is defined by
+DEC-56-FACTORY-FAILURE-001 and implemented in stage #141; it is not deferred to the final #56
+integration. The non-commit path releases resources created by that attempt and removes only the
+same `Creating` reservation, allowing same-SID retry.
 The `session_mutex` is not held during external factory or engine operations, callback
 quiescence, resource destruction, or logging. Close leaves a `Closing` record reserved until
 callbacks quiesce and every Session-owned resource, including the durable engine, is released.
@@ -301,14 +306,23 @@ SIDs whose records are `SessionPhase::Active`. It releases `session_mutex` and t
 before returning, retains no Session resources after enumeration, and never externally lists
 `Creating` or `Closing` records.
 
-The existing `CreateSession(sid)` source call remains supported. Its exact member-pointer shape,
-`Result<void> (StorageNode::*)(std::string_view)`, is preserved by the distinct overload; the
-new two-argument overload adds buffer options without replacing that API. Adding
-`durable_buffer_engine_factory` extends the public `StorageNodeConfig` layout/ABI, so consumers
-must rebuild against the updated library or package. Issue #56 adds no C++ or Python
-BufferPublisher, BufferSubscriber, or engine-factory API beyond this node factory and
-SessionOptions boundary. Buffer values use the route-selected wire contract in ADR-0032, not
-ParamStore or ParamCache APIs.
+Existing `KeyKind` enumerator values remain unchanged, and existing five-field positional
+`ParsedKey` aggregate initialization remains valid because `buffer_class` is appended with a
+`= std::nullopt` default. Five-element structured bindings and exhaustive `KeyKind` switches may
+require source changes when they need to handle the new Buffer kind. The existing
+`CreateSession(sid)` source call remains a distinct overload with member-pointer shape
+`Result<void> (StorageNode::*)(std::string_view)`. Adding `durable_buffer_engine_factory` extends
+the public `StorageNodeConfig` layout; no binary ABI compatibility is promised, and consumers must
+rebuild against the updated library or package. Issue #56 adds no C++ or Python BufferPublisher or
+BufferSubscriber API. The public C++ engine-factory API and SessionOptions boundary are implemented
+in stage #141; no Python engine-factory API is added. Buffer values use the route-selected wire
+contract in ADR-0032, not ParamStore or ParamCache APIs. The key API uses
+`BufferClass { Durable, Ephemeral }`, appends `KeyKind::Buffer`, and exposes
+`std::optional<BufferClass> ParsedKey::buffer_class`, engaged only for buffer routes.
+`BuildBufferKey(prefix, sid, buffer_class, user_key)` returns
+`<prefix>/buffers/<sid>/{durable,ephemeral}/<key>` and returns `std::nullopt` for invalid
+components or an undefined enum value. Existing non-buffer parsed keys leave `buffer_class`
+disengaged.
 
 ## 4. ParamCache — Subscriber-Side Hot Path
 

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -242,6 +242,67 @@ major behaviors.
 | `RawZenohClientCanSendBatch` | C03/F09 | Batch interoperability using only zenoh-python |
 | `PutAckTimesOutWhenNodeUnavailable` | N10 | ack timeout/status mapping |
 | `PythonCallbackDoesNotDeadlockWithGet` | P04 | get inside callback does not deadlock |
+| `BufferKeyTest.BufferRoutesRoundTrip` | C06/X03 | Build and parse canonical durable and ephemeral routes; custom prefix and non-buffer nullopt |
+| `BufferKeyTest.InvalidBufferRoutesAreRejected` | C06 | Reject malformed routes, unknown classes, and undefined BufferClass values |
+| `BufferKeyTest.BufferClassIsReservedOnlyInTheClassPosition` | C06 | Permit durable/ephemeral chunks inside a hierarchical user key |
+
+### 5.1.1 Session buffer implementation stages
+
+The Session buffer work is split into four sequential implementation Issues. The fixed tests in
+this section are the acceptance-name authority for each stage.
+
+**Stage #139 — mixed buffer key contract**
+
+The three `BufferKeyTest.*` tests above verify only canonical route grammar, parser
+classification, invalid-form rejection, class-position reservation, and the custom-prefix portion
+of X03. They do not prove bare-byte admission, durable retrieval, ephemeral non-retention, or raw
+client interoperability.
+
+**Stage #140 — SessionRecord and admission lifecycle**
+
+- `StorageNodeSessionLifecycleTest.CreatingAndClosingCollisionsAreDeterministic`
+- `StorageNodeSessionLifecycleTest.CreateRollbackAllowsSameSidRetry`
+- `StorageNodeSessionLifecycleTest.CloseQuiescesAdmittedOperations`
+- `StorageNodeSessionLifecycleTest.DestroysResourcesBeforeCloseReturns`
+- `StorageNodeSessionLifecycleTest.StopWaitsForAdmittedCreate`
+- `SessionViewTest.CloseWaitsForCapturedRead`
+- `SessionViewTest.StaleViewRejectsSameSidReplacement`
+
+**Stage #141 — capabilities, factory, and routing**
+
+- `StorageNodeBufferApiTest.PreservesLegacyCreateSessionOverload`
+- `StorageNodeBufferApiTest.ExposesCapabilityOverloadAndFactory`
+- `StorageNodeBufferLifecycleTest.FactoryFailureTaxonomyAndRollback`
+- `StorageNodeBufferLifecycleTest.FactoryAndStopLinearizeDeterministically`
+- `StorageNodeBufferLifecycleTest.CloseQuiescesDurableOperationsAndDestroysEngine`
+- `StorageNodeBufferLifecycleTest.SameSidRecreationUsesFreshEngine`
+- `StorageNodeBufferRoutingTest.CapabilityMatrix`
+- `StorageNodeBufferRoutingTest.DurablePutIsByteExactAndWriteOnce`
+- `StorageNodeBufferRoutingTest.PutFailureRereadsAuthoritativeEngineState`
+- `StorageNodeBufferRoutingTest.WholeSubscriberSerializationPreventsConflictingPuts`
+- `StorageNodeBufferRoutingTest.EphemeralPutNeverTouchesEngine`
+- `StorageNodeBufferRoutingTest.NonBytesEncodingIsRejected`
+- `StorageNodeBufferRoutingTest.DurableQuerySelectorsAndFailures`
+- `StorageNodeBufferRoutingTest.EngineFailuresAndExceptionsAreContained`
+- `StorageNodeBufferRoutingTest.BufferRoutesDoNotEnterParameterSurfaces`
+- `StorageNodeBufferRoutingTest.BufferDeleteAndControlRoutesAreRejected`
+
+These tests verify C06 bare-byte admission, durable Get/List, write-once handling, and absence of
+node-retained ephemeral state.
+
+**Final stage #56 — raw interoperability and durable late join**
+
+- `BufferLateJoinTest.OrdersMaterializedBufferedAndLiveSamples`
+- `BufferLateJoinTest.DurableLateJoinDoesNotLoseDistinctKeys`
+- `BufferLateJoinTest.FailureInvokesNoObserverAndCleansUp`
+- `RawZenohClientCanUseMixedSessionBuffers`
+- `RawZenohDurableLateJoinPreservesDistinctKeys`
+- `RawZenohBufferInteropFixtureBoundaries`
+- `RocksDBBufferLifecycleTest.CloseReleasesEngineBeforeReturn`
+- `RocksDBBufferLifecycleTest.SameSidRecreationUsesFreshEngine`
+
+These tests verify C03/C06 raw-client interoperability and the process-isolated durable late-join
+boundary. The final stage also owns combined Zenoh-ON/RocksDB-ON package and CI evidence.
 
 ## 5.2 Lifecycle sanitizer runs
 

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -18,7 +18,7 @@ Milestone = release boundary).
 | **v0.1** | The zenoh-independent core works. Payload fixtures and InMemoryEngine contract tests are green | #1, #4, #5, #6, #7 |
 | **v0.2** | StorageNode/ParamStore/ParamCache work in C++ through same-process zenoh sessions | #2, #3, #9–#13, #15, #18, #19, #21 |
 | **v0.3** | Basic Python APIs work (InMemory, ParamStore, ParamCache, NumPy read) | #16, #22, #23, #24, #25, #27 |
-| **v0.4** | Cross-platform vcpkg foundation, RocksDB engine, process-isolated raw-Zenoh interop, session-scoped buffers, benchmarks, and C++/Python examples are in place | #122, #8, #29, #31, #32, #33, #56 |
+| **v0.4** | Cross-platform vcpkg foundation, RocksDB engine, process-isolated raw-Zenoh interop, session-scoped buffers, benchmarks, and C++/Python examples are in place | #122, #8, #29, #31, #32, #33, #139, #140, #141, #56 |
 | **v0.5** | Reliable and durable session-buffer delivery is ready for downstream application integration | #14, #17, #99, #105–#109 |
 | **v1.0** | Public OSS quality, reconnect recovery, advanced Python extensions, raw batch/ack interop, documentation, and publication readiness are complete | #20, #26, #28, #30, #34, #35 |
 
@@ -26,7 +26,9 @@ Milestone = release boundary).
 so it is not a v0.2 blocker. Include it by v0.5.
 
 For v0.4, #122 precedes #8; #8 precedes the RocksDB-dependent #31, #33, and #56; #29 precedes
-raw-Zenoh consumers such as #32 and #56.
+raw-Zenoh consumers such as #32 and #56. The accepted ADR-0032 implementation sequence is
+#139 (key contract), #140 (SessionRecord lifecycle), #141 (capabilities and routing), then #56
+(final raw-Zenoh, RocksDB, package, and combined-CI integration).
 
 ---
 
@@ -253,55 +255,105 @@ raw-Zenoh consumers such as #32 and #56.
   handling, timeout, error preservation, and callback-quiescent lifecycle tests
 * Depends on: #14; requires an Accepted ADR before merge
 
-### #56 Session-scoped buffers
+### #139 Mixed Session buffer key contract
 * Milestone: v0.4
-* References: ADR-0032, [01] F03/F04/F10/N05/N07/C03/X01/X03, [02] §2/§4,
-  [03] §1/§4
-* Implementation targets: `include/sitos/key.hpp` (`KeyKind::Buffer`, `BuildBufferKey`,
-  `ParseKey`), `src/storage_node.cpp` (buffer routing and lifecycle), SessionController
-  (`SessionOptions`, one durable engine factory result per Session), `StorageNodeConfig`
-* Scope: independent `<prefix>/buffers/<sid>/durable/<key>` and
-  `<prefix>/buffers/<sid>/ephemeral/<key>` routes. Payloads are plain `zenoh/bytes`; route
-  selects persistence. StorageNode stores durable PUTs, while Zenoh independently fans out both
-  route classes; ephemeral PUTs are live-only and StorageNode retains no ephemeral state. Keys
-  are write-once: same-byte retries are idempotent, conflicting PUTs are protocol-invalid and
-  not persisted. Buffer DELETE, `:batch`, `:fence`, snapshots, and control namespaces are
-  unsupported. Existing `CreateSession(sid)` enables neither capability. Use one owned Session
-  record and a per-Session admission gate; preserve global subscriber sequencing. Durable late
-  join is buffering subscribe → synchronous Get/materialize → drain under one ordering boundary →
-  live. Creation uses the callback-shared State generation and must preserve the documented
-  transactional factory and reentrancy boundaries. Exact Status taxonomy for empty, null, and
-  exception outcomes is deferred to the Issue #56 scope freeze. Do not add a production
-  BufferSubscriber API.
+* References: ADR-0032, [01] C06/X03, [02] §2, [03] §1, [04] §1
+* Implementation targets: `include/sitos/key.hpp`, `src/key.cpp`, `tests/unit/key_test.cpp`,
+  and the listed documentation reconciliation files
+* Scope: append `KeyKind::Buffer` and `ParsedKey::buffer_class`, add `BufferClass` and
+  `BuildBufferKey(prefix, sid, buffer_class, user_key)`, and parse the canonical durable and
+  ephemeral routes. Preserve existing `KeyKind` integral values and five-field positional
+  `ParsedKey` aggregate initialization by appending the defaulted member. Five-element structured
+  bindings and exhaustive switches may require source changes or rebuild; no binary ABI promise is
+  made. Reject undefined enum values and leave non-buffer `buffer_class` disengaged. This stage has
+  no StorageNode routing,
+  Session lifecycle, capability, factory, interop, RocksDB, package, or CI behavior.
 * Acceptance criteria:
-  * Deterministic, sleep-free latch/barrier/fake-engine tests cover factory `Err`, exception,
-    empty factory, and `Ok(nullptr)`. Each proves that every Session record, admission state, and
-    engine state created by the attempt is removed or released before same-SID retry. Factory and
-    LogSink re-entry remains a documented caller precondition, not a runtime test outcome.
-  * A deterministic capability matrix covers none, durable-only, ephemeral-only, and both.
-    StorageNode admits durable PUT/Get/List and ephemeral PUT only when the matching capability
-    is enabled. Disabled durable routes create or mutate no durable engine state; disabled
-    ephemeral traffic is rejected by StorageNode admission without retracting independent Zenoh
-    fanout.
-  * The matrix covers `Creating`/`Closing` collisions and blocked admitted durable Get/List and
-    PUT versus `CloseSession`.
-  * The matrix proves engine destruction before `CloseSession` returns, recreation ordering, and
-    ordinary cross-thread `Stop` concurrency.
-  * Deterministic sleep-free fake-Transport/barrier tests prove durable late-join ordering:
-    materialized Get replies, then buffered samples, then post-transition live samples. Only
-    documented same-byte duplicates may be deduplicated; the process-isolated raw-Zenoh lane
-    must prove the same ordering.
-  * Route key round-trip, plain-byte push and durable Get equality, first durable bytes remain
-    stored after a conflicting PUT, ephemeral no-Get/replay, late-join no-loss, close quiescence,
-    fresh or logically empty recreation, and ParamCache isolation pass.
-  * Raw-Zenoh interop, including late join, is a separate test lane that reuses #29's
-    process-isolation safeguards: one Transport/session topology as applicable, bounded readiness
-    and command handshakes, failure-safe cleanup, unique identifiers, and hash-locked Python
-    dependencies.
+  * `BufferKeyTest.BufferRoutesRoundTrip` verifies canonical routes, parsed fields, custom prefix,
+    and nullopt for non-buffer keys.
+  * `BufferKeyTest.InvalidBufferRoutesAreRejected` verifies malformed routes and undefined enum
+    rejection.
+  * `BufferKeyTest.BufferClassIsReservedOnlyInTheClassPosition` verifies hierarchical user keys.
+* Depends on: #133; implementation precedes #140 and #141.
+* Contract Registry: none; the buffer row remains `Normative / Planned / ADR-0032 / —`.
+
+### #140 Unified SessionRecord and admission lifecycle
+* Milestone: v0.4
+* References: ADR-0032, [02] §4, [04] §3, [06] §5.1.1
+* Implementation targets: `include/sitos/storage_node.hpp`, `include/sitos/session.hpp`,
+  `src/storage_node.cpp`, `src/session_view.cpp`, focused lifecycle tests, and existing sanitizer
+  test selection
+* Scope: replace separate Session ownership tables with generation-safe Creating/Active/Closing
+  SessionRecord admission while preserving existing parameter, snapshot, overlay, and SessionView
+  behavior. Enforce callback-gate and lock-order contracts, rollback, quiescent Close, Stop
+  ordering, and stale same-SID View rejection. Do not add buffer capability or routing behavior.
+* Acceptance criteria:
+  * `StorageNodeSessionLifecycleTest.CreatingAndClosingCollisionsAreDeterministic`
+  * `StorageNodeSessionLifecycleTest.CreateRollbackAllowsSameSidRetry`
+  * `StorageNodeSessionLifecycleTest.CloseQuiescesAdmittedOperations`
+  * `StorageNodeSessionLifecycleTest.DestroysResourcesBeforeCloseReturns`
+  * `StorageNodeSessionLifecycleTest.StopWaitsForAdmittedCreate`
+  * `SessionViewTest.CloseWaitsForCapturedRead`
+  * `SessionViewTest.StaleViewRejectsSameSidReplacement`
+* Depends on: #139; implementation precedes #141 and final #56.
+* Contract Registry: none.
+
+### #141 Mixed Session buffer capability and routing
+* Milestone: v0.4
+* References: ADR-0032, [01] C06/X01/X03, [02] §2/§4, [04] §3, [06] §5.1.1
+* Implementation targets: `include/sitos/session.hpp`, `include/sitos/storage_node.hpp`,
+  `src/storage_node.cpp`, focused buffer API/lifecycle/routing tests, and sanitizer test selection
+* Scope: add SessionOptions and the node-level C++ DurableBufferEngineFactory, then implement
+  deterministic in-process capability admission and durable/ephemeral routing on #140. Apply the
+  owner-approved factory taxonomy, bare `zenoh/bytes` validation, engine-authoritative write-once
+  handling, query selectors, exception containment, and no node-retained ephemeral state. Do not
+  add raw-Zenoh, RocksDB, package, combined-CI, or production subscriber APIs.
+* Acceptance criteria:
+  * The fixed API, lifecycle, and routing tests from [06] §5.1.1 pass for all four capability
+    combinations and all DEC-56 failure, encoding, persistence, and Stop contracts.
+  * Disabled durable capability creates or mutates no engine state; disabled ephemeral capability
+    retains no node state; query failures produce no partial replies.
+* Depends on: #139 and #140; implementation precedes final #56.
+* Contract Registry: none; the buffer row remains Planned.
+
+### #56 Session-scoped buffer integration
+* Milestone: v0.4
+* References: ADR-0032, [01] F03/F04/F10/N05/N07/C03/C06/X01/X03, [02] §2/§4,
+  [03] §1/§4, [06] §5.1.1
+* Implementation targets: raw-Zenoh buffer fixture and Python controller, focused RocksDB buffer
+  lifecycle tests, installed consumer validation, `tests/vcpkg/validate_vcpkg_provisioning.cmake`,
+  `.github/workflows/ci.yml`, and the final documentation/Contract Registry transition
+* Scope: integrate #139, #140, and #141 with process-isolated raw-Zenoh interoperability, test-only
+  durable late join, RocksDB lifecycle evidence, combined Zenoh-ON/RocksDB-ON Windows and Linux
+  validation, and installed configure/build/link consumers. Preserve existing Zenoh-ON/RocksDB-OFF
+  and RocksDB-ON/Zenoh-OFF jobs. The buffer Registry row remains Contract `Normative`,
+  Implementation `Planned` until this final #56 PR, then `Implemented`, Normative spec `ADR-0032`,
+  and Design authority `—`. Do not add BufferPublisher/BufferSubscriber or absorb Issues #105-#108.
+* Acceptance criteria:
+  * Revalidate the merged #140 lifecycle and #141 capability/routing contracts at the integration
+    boundary without duplicating their deterministic in-process factory, lifecycle, capability, or
+    routing acceptance suites. Their fixed tests remain owned by #140 and #141.
+  * Reuse #29's process-isolated fixture safeguards: one Transport/session topology as applicable,
+    bounded readiness and command handshakes, independent stdout/stderr draining, failure-safe
+    cleanup, unique identifiers, port-race recovery, and hash-locked Python dependencies.
+  * `BufferLateJoinTest.OrdersMaterializedBufferedAndLiveSamples` and
+    `BufferLateJoinTest.DurableLateJoinDoesNotLoseDistinctKeys` prove materialized Get replies,
+    then buffered samples, then post-transition live samples, with only documented same-byte
+    duplicate handling. `FailureInvokesNoObserverAndCleansUp` proves failure cleanup.
+  * `RawZenohClientCanUseMixedSessionBuffers`,
+    `RawZenohDurableLateJoinPreservesDistinctKeys`, and
+    `RawZenohBufferInteropFixtureBoundaries` prove raw-client interoperability using canonical
+    routes, bare `zenoh/bytes`, capability behavior, and the durable late-join boundary.
+  * `RocksDBBufferLifecycleTest.CloseReleasesEngineBeforeReturn` and
+    `RocksDBBufferLifecycleTest.SameSidRecreationUsesFreshEngine` prove RocksDB-specific release
+    ordering and fresh recreation without claiming restart retention or #108 catalog behavior.
+  * Installed Linux and Windows consumers configure, build, and link against the combined package;
+    they do not execute `RocksDBEngine::Open`. Wheels remain RocksDB-free and no fixture binary
+    enters installed production artifacts.
   * Combined Windows/Linux Zenoh-ON+RocksDB-ON validation passes while preserving
     Zenoh-ON/RocksDB-OFF and RocksDB-ON/Zenoh-OFF/vcpkg configurations. Buffer payloads remain
     plain `zenoh/bytes`.
-* Depends on: #8, #12, #29, #121
+* Depends on: #8, #12, #29, #121, #139, #140, #141
 * F10 applies here as the Session resource-release principle: CloseSession releases the durable
   buffer engine and other owned resources after callback quiescence.
 * Boundaries: #105 owns durability barriers; #106 owns publisher fences; #107 owns applied and

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -193,6 +193,16 @@ The following must not change after zenoh updates:
 * The loss-prevention sequence of `ParamCache::Attach`
 * Snapshot isolation semantics
 * Python API exception mapping
+* Buffer key paths are exactly `buffers/<sid>/durable/<key>` and
+  `buffers/<sid>/ephemeral/<key>`; `BufferClass` is reserved only in the route-class position.
+* Buffer values use opaque bare `zenoh/bytes`; parameter values retain payload-v1 encoding.
+* Durable buffer values are retrievable by Get/List, ephemeral values are live-only, and no
+  ephemeral state is retained by StorageNode.
+* Durable late join observes materialized Get replies, then buffered samples, then post-transition
+  live samples, with only documented same-byte duplicate handling.
+
+These buffer invariants are owned by Accepted ADR-0032 and are validated across stages #139, #141,
+and final #56; they add no dependency and do not change the transport adapter boundary.
 
 ## 7. RocksDB / Python dependencies
 

--- a/docs/adr/0032-mixed-session-buffer-routes.md
+++ b/docs/adr/0032-mixed-session-buffer-routes.md
@@ -115,9 +115,10 @@ We will define durable late-join delivery and admission semantics by:
 * Neutral: Durability barriers belong to #105, publisher fences to #106, and applied or
   synchronized BufferPublisher fences to #107; #56 adds none of those mechanisms or an
   acknowledgement mechanism.
-* Neutral: #56 adds no BufferPublisher, BufferSubscriber, Python buffer, or engine-factory API and
-  preserves the existing Zenoh-ON/RocksDB-OFF and RocksDB-ON/Zenoh-OFF/vcpkg configurations while
-  adding combined Zenoh-ON+RocksDB-ON validation on Windows and Linux.
+* Neutral: #56 adds no BufferPublisher, BufferSubscriber, Python buffer, or Python
+  engine-factory API and preserves the existing Zenoh-ON/RocksDB-OFF and
+  RocksDB-ON/Zenoh-OFF/vcpkg configurations while adding combined
+  Zenoh-ON+RocksDB-ON validation on Windows and Linux.
 * Neutral: The #56 evidence must cover the approved lifecycle, capability, rollback, ordering,
   and interop matrix; it reuses #29's process-isolation safeguards. Backpressure, chunking,
   shared memory, TTL, history, and generation management remain outside this decision.

--- a/include/sitos/key.hpp
+++ b/include/sitos/key.hpp
@@ -23,6 +23,9 @@ struct Scope {
   std::string sid;
 };
 
+/// Persistence class for a Session buffer route.
+enum class BufferClass { Durable, Ephemeral };
+
 /// Key kind, used by the incoming-key parser for StorageNode routing.
 /// See docs/03_wire_protocol.md §1.1.
 enum class KeyKind {
@@ -31,22 +34,25 @@ enum class KeyKind {
   Snapshot,     ///< <prefix>/snap/<sid>/<key> (read-only; no :batch)
   MetaSession,  ///< <prefix>/meta/session/<sid>
   MetaAck,      ///< <prefix>/meta/ack/<uuid>
+  Buffer,       ///< <prefix>/buffers/<sid>/{durable,ephemeral}/<key>
 };
 
 /// Result of parsing an incoming zenoh key expression. The inverse of the
 /// Build*Key functions. See docs/03_wire_protocol.md §1.1.
 struct ParsedKey {
   KeyKind kind;
-  /// Session id for Session / Snapshot / MetaSession. Empty for Base / MetaAck.
+  /// Session id for Session / Snapshot / Buffer / MetaSession. Empty for Base / MetaAck.
   std::string sid;
   /// Ack UUID for MetaAck. Empty for all other kinds.
   std::string uuid;
-  /// Relative user key for Base / Session / Snapshot. Empty for Meta paths and
+  /// Relative user key for Base / Session / Snapshot / Buffer. Empty for Meta paths and
   /// for :batch paths (where is_batch is true instead).
   std::string relative_key;
   /// True for the special <prefix>/base/:batch and <prefix>/session/<sid>/:batch
   /// paths. Only Base and Session may be batch.
   bool is_batch = false;
+  /// Persistence class for Buffer. Nullopt for all non-buffer paths.
+  std::optional<BufferClass> buffer_class = std::nullopt;
 };
 
 /// Validates a user key according to wire protocol §1.2. Rejects empty
@@ -73,6 +79,12 @@ std::optional<Scope> ParseScope(std::string_view scope);
 /// Returns std::nullopt if any component is invalid.
 std::optional<std::string> BuildKey(std::string_view prefix, std::string_view scope,
                                     std::string_view user_key);
+
+/// Builds a Session buffer key: <prefix>/buffers/<sid>/{durable,ephemeral}/<key>.
+/// Returns std::nullopt if any component or the BufferClass is invalid.
+std::optional<std::string> BuildBufferKey(std::string_view prefix, std::string_view sid,
+                                          BufferClass buffer_class,
+                                          std::string_view user_key);
 
 /// Builds a :batch key for the given scope: <prefix>/base/:batch or
 /// <prefix>/session/<sid>/:batch. Batch is not defined for snap; returns

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -119,6 +119,39 @@ std::optional<std::string> BuildKey(std::string_view prefix, std::string_view sc
   return result;
 }
 
+std::optional<std::string> BuildBufferKey(std::string_view prefix, std::string_view sid,
+                                          BufferClass buffer_class,
+                                          std::string_view user_key) {
+  if (!IsValidPrefix(prefix) || !IsValidSessionId(sid) || !IsValidKey(user_key)) {
+    return std::nullopt;
+  }
+  std::string_view class_name;
+  switch (buffer_class) {
+    case BufferClass::Durable:
+      class_name = "durable";
+      break;
+    case BufferClass::Ephemeral:
+      class_name = "ephemeral";
+      break;
+    default:
+      return std::nullopt;
+  }
+  constexpr std::string_view kBuffers = "buffers";
+  std::string result;
+  result.reserve(prefix.size() + 1 + kBuffers.size() + 1 + sid.size() + 1 + class_name.size() +
+                 1 + user_key.size());
+  result.append(prefix);
+  result.push_back('/');
+  result.append(kBuffers);
+  result.push_back('/');
+  result.append(sid);
+  result.push_back('/');
+  result.append(class_name);
+  result.push_back('/');
+  result.append(user_key);
+  return result;
+}
+
 std::optional<std::string> BuildBatchKey(std::string_view prefix, std::string_view scope) {
   if (!IsValidPrefix(prefix)) {
     return std::nullopt;
@@ -265,6 +298,35 @@ std::optional<ParsedKey> ParseKey(std::string_view prefix, std::string_view full
         return std::nullopt;  // rejects snap/<sid>/:batch as a read-only batch path
       }
       return ParsedKey{KeyKind::Snapshot, std::string(sid), "", std::string(value), false};
+    }
+    if (head == "buffers") {
+      // buffers/<sid>/durable/<key...> or buffers/<sid>/ephemeral/<key...>
+      auto sid_split = SplitFirst(tail);
+      if (!sid_split) {
+        return std::nullopt;
+      }
+      auto [sid, class_and_key] = *sid_split;
+      if (!IsValidSessionId(sid)) {
+        return std::nullopt;
+      }
+      auto class_split = SplitFirst(class_and_key);
+      if (!class_split) {
+        return std::nullopt;
+      }
+      auto [class_name, user_key] = *class_split;
+      BufferClass buffer_class;
+      if (class_name == "durable") {
+        buffer_class = BufferClass::Durable;
+      } else if (class_name == "ephemeral") {
+        buffer_class = BufferClass::Ephemeral;
+      } else {
+        return std::nullopt;
+      }
+      if (!IsValidKey(user_key)) {
+        return std::nullopt;
+      }
+      return ParsedKey{KeyKind::Buffer, std::string(sid), "", std::string(user_key), false,
+                       buffer_class};
     }
     if (head == "meta") {
       // meta/session/<sid> or meta/ack/<uuid>

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -305,7 +305,7 @@ std::optional<ParsedKey> ParseKey(std::string_view prefix, std::string_view full
       if (!sid_split) {
         return std::nullopt;
       }
-      auto [sid, class_and_key] = *sid_split;
+      const auto& [sid, class_and_key] = *sid_split;
       if (!IsValidSessionId(sid)) {
         return std::nullopt;
       }
@@ -313,7 +313,7 @@ std::optional<ParsedKey> ParseKey(std::string_view prefix, std::string_view full
       if (!class_split) {
         return std::nullopt;
       }
-      auto [class_name, user_key] = *class_split;
+      const auto& [class_name, user_key] = *class_split;
       BufferClass buffer_class;
       if (class_name == "durable") {
         buffer_class = BufferClass::Durable;

--- a/tests/unit/key_test.cpp
+++ b/tests/unit/key_test.cpp
@@ -407,5 +407,106 @@ TEST(KeyTest, InvalidKeysAreRejected) {
   EXPECT_FALSE(BuildKey("sitos", "base", "bad*key"));
 }
 
+TEST(BufferKeyTest, BufferRoutesRoundTrip) {
+  const auto durable = BuildBufferKey("my/app", "session-1", BufferClass::Durable,
+                                      "durable/part");
+  ASSERT_TRUE(durable.has_value());
+  EXPECT_EQ(*durable, "my/app/buffers/session-1/durable/durable/part");
+  const auto durable_parsed = ParseKey("my/app", *durable);
+  ASSERT_TRUE(durable_parsed.has_value());
+  EXPECT_EQ(durable_parsed->kind, KeyKind::Buffer);
+  EXPECT_EQ(durable_parsed->sid, "session-1");
+  ASSERT_TRUE(durable_parsed->buffer_class.has_value());
+  EXPECT_EQ(*durable_parsed->buffer_class, BufferClass::Durable);
+  EXPECT_EQ(durable_parsed->relative_key, "durable/part");
+  EXPECT_TRUE(durable_parsed->uuid.empty());
+  EXPECT_FALSE(durable_parsed->is_batch);
+
+  const auto ephemeral = BuildBufferKey("my/app", "session-1", BufferClass::Ephemeral,
+                                        "ephemeral/part");
+  ASSERT_TRUE(ephemeral.has_value());
+  EXPECT_EQ(*ephemeral, "my/app/buffers/session-1/ephemeral/ephemeral/part");
+  const auto ephemeral_parsed = ParseKey("my/app", *ephemeral);
+  ASSERT_TRUE(ephemeral_parsed.has_value());
+  EXPECT_EQ(ephemeral_parsed->kind, KeyKind::Buffer);
+  EXPECT_EQ(ephemeral_parsed->sid, "session-1");
+  ASSERT_TRUE(ephemeral_parsed->buffer_class.has_value());
+  EXPECT_EQ(*ephemeral_parsed->buffer_class, BufferClass::Ephemeral);
+  EXPECT_EQ(ephemeral_parsed->relative_key, "ephemeral/part");
+  EXPECT_TRUE(ephemeral_parsed->uuid.empty());
+  EXPECT_FALSE(ephemeral_parsed->is_batch);
+
+  const auto base = ParseKey("my/app", "my/app/base/key");
+  ASSERT_TRUE(base.has_value());
+  EXPECT_FALSE(base->buffer_class.has_value());
+  const auto session = ParseKey("my/app", "my/app/session/session-1/key");
+  ASSERT_TRUE(session.has_value());
+  EXPECT_FALSE(session->buffer_class.has_value());
+  const auto snapshot = ParseKey("my/app", "my/app/snap/session-1/key");
+  ASSERT_TRUE(snapshot.has_value());
+  EXPECT_FALSE(snapshot->buffer_class.has_value());
+  const auto meta_session = ParseKey("my/app", "my/app/meta/session/session-1");
+  ASSERT_TRUE(meta_session.has_value());
+  EXPECT_FALSE(meta_session->buffer_class.has_value());
+  const auto meta_ack = ParseKey("my/app", "my/app/meta/ack/ack-1");
+  ASSERT_TRUE(meta_ack.has_value());
+  EXPECT_FALSE(meta_ack->buffer_class.has_value());
+}
+
+TEST(BufferKeyTest, InvalidBufferRoutesAreRejected) {
+  EXPECT_FALSE(BuildBufferKey("", "session-1", BufferClass::Durable, "key"));
+  EXPECT_FALSE(BuildBufferKey("sitos", "", BufferClass::Durable, "key"));
+  EXPECT_FALSE(BuildBufferKey("sitos", "session-1", BufferClass::Durable, ""));
+  EXPECT_FALSE(BuildBufferKey("sitos", "bad/sid", BufferClass::Durable, "key"));
+  EXPECT_FALSE(BuildBufferKey("sitos", "session-1", BufferClass::Durable, "bad*key"));
+  EXPECT_FALSE(BuildBufferKey("sitos", "session-1", BufferClass::Ephemeral, "key/"));
+  EXPECT_FALSE(BuildBufferKey("sitos", "session-1", static_cast<BufferClass>(99), "key"));
+
+  EXPECT_FALSE(ParseKey("sitos", "sitos/buffers/session-1/key"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/buffers/session-1/unknown/key"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/buffers//durable/key"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/buffers/session-1//key"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/buffers/session-1/durable"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/buffers/session-1/durable/"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/buffers/session 1/durable/key"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/buffers/session-1/durable/bad*key"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/buffers/session-1/durable//key"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/buffers/session-1/durable/:batch"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/buffers/session-1/durable/:fence"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/buffers/session-1/durable/:control"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/buffers/session-1/durable/key/:fence"));
+  EXPECT_FALSE(ParseKey("sitos", "sitos/buffers/session-1/durable/key/extra/"));
+}
+
+TEST(BufferKeyTest, BufferClassIsReservedOnlyInTheClassPosition) {
+  const auto durable = BuildBufferKey("sitos", "session-1", BufferClass::Durable,
+                                      "nested/durable/ephemeral");
+  ASSERT_TRUE(durable.has_value());
+  EXPECT_EQ(*durable, "sitos/buffers/session-1/durable/nested/durable/ephemeral");
+  const auto durable_parsed = ParseKey("sitos", *durable);
+  ASSERT_TRUE(durable_parsed.has_value());
+  EXPECT_EQ(durable_parsed->kind, KeyKind::Buffer);
+  EXPECT_EQ(durable_parsed->sid, "session-1");
+  EXPECT_TRUE(durable_parsed->uuid.empty());
+  EXPECT_EQ(durable_parsed->relative_key, "nested/durable/ephemeral");
+  EXPECT_FALSE(durable_parsed->is_batch);
+  ASSERT_TRUE(durable_parsed->buffer_class.has_value());
+  EXPECT_EQ(*durable_parsed->buffer_class, BufferClass::Durable);
+
+  const auto ephemeral = BuildBufferKey("sitos", "session-1", BufferClass::Ephemeral,
+                                        "nested/durable/ephemeral");
+  ASSERT_TRUE(ephemeral.has_value());
+  EXPECT_EQ(*ephemeral, "sitos/buffers/session-1/ephemeral/nested/durable/ephemeral");
+  const auto ephemeral_parsed = ParseKey("sitos", *ephemeral);
+  ASSERT_TRUE(ephemeral_parsed.has_value());
+  EXPECT_EQ(ephemeral_parsed->kind, KeyKind::Buffer);
+  EXPECT_EQ(ephemeral_parsed->sid, "session-1");
+  EXPECT_TRUE(ephemeral_parsed->uuid.empty());
+  EXPECT_EQ(ephemeral_parsed->relative_key, "nested/durable/ephemeral");
+  EXPECT_FALSE(ephemeral_parsed->is_batch);
+  ASSERT_TRUE(ephemeral_parsed->buffer_class.has_value());
+  EXPECT_EQ(*ephemeral_parsed->buffer_class, BufferClass::Ephemeral);
+}
+
 }  // namespace
 }  // namespace sitos


### PR DESCRIPTION
## Summary

Closes #139

Adds the canonical mixed Session buffer-key contract: public key types, construction/parsing,
fixed grammar tests, and the approved staged documentation reconciliation. It does not implement
StorageNode buffer routing, lifecycle, capabilities, factories, raw Zenoh, RocksDB, packages, or CI.

## Requirements

- C01: Parameter values remain payload v1; the requirement is scoped to parameter values.
- C06: Session buffer routes are documented as opaque bare `zenoh/bytes`; this stage covers route
grammar only.
- X03: `BufferKeyTest.BufferRoutesRoundTrip` covers the custom-prefix grammar portion only.

## Contract Registry

N/A — the existing buffer row remains `Normative / Planned / ADR-0032 / —`. Only final Issue #56
may change its Implementation column to `Implemented`.

## Frozen Issue Checklist

The following is the owner-frozen Issue #139 checklist (Issue comment 5144339962), as subsequently
clarified only by owner decision DEC-139-SOURCE-COMPAT-001 (Issue comment 5144690646):

## Summary

Add the public key grammar for ADR-0032 mixed Session buffer routes and reconcile the
implementation plan that later Issues will consume.

This is stage 1 of the owner-approved Issue #56 split in DEC-56-SPLIT-001. It does not add
StorageNode buffer routing, Session capabilities, a durable engine factory, or interoperability
behavior.

## Branch

`feat/139-mixed-buffer-key-contract`

## Normative references

- ADR-0032, Accepted on 2026-07-31
- `docs/01_requirements.md`
- `docs/02_architecture.md` buffer key grammar
- `docs/03_wire_protocol.md` buffer routes and bare `zenoh/bytes`
- `docs/04_api_cpp.md` key and Session API direction
- DEC-56-PUBLIC-API-001

## Public key contract

- [x] Add `BufferClass { Durable, Ephemeral }` to `include/sitos/key.hpp`.
- [x] Append `KeyKind::Buffer` after every existing enumerator.
- [x] Append `std::optional<BufferClass> ParsedKey::buffer_class = std::nullopt` after the existing
  `is_batch` member. It is engaged only for buffer keys, preserving existing aggregate source
  compatibility.
- [x] Add this exact builder shape:

  ```cpp
  std::optional<std::string> BuildBufferKey(
      std::string_view prefix,
      std::string_view sid,
      BufferClass buffer_class,
      std::string_view user_key);
  ```

- [x] Build and parse these canonical routes:
  - `<prefix>/buffers/<sid>/durable/<key>`
  - `<prefix>/buffers/<sid>/ephemeral/<key>`
- [x] Apply the existing prefix, SID, and hierarchical user-key validation rules.
- [x] Reserve `durable` and `ephemeral` only in the class position. The same chunks remain valid
  inside a user key.
- [x] Reject missing SID, class, or user key; unknown classes; empty chunks; trailing slashes; and
  control or malformed forms already rejected by the common key grammar.
- [x] Return `std::nullopt` when the builder receives an undefined `BufferClass` enum value.
- [x] Leave the existing valid-prefix precondition of `ParseKey` unchanged.
- [x] Do not add a public Encoding constant or any StorageNode behavior.

## Documentation reconciliation

- [x] Correct ADR-0032's contradictory consequence text to say that Issue #56 adds no Python
  engine-factory API; the accepted public C++ node factory remains authoritative.
- [x] Replace C01 with: `Parameter values use payload v1 (1-byte type tag plus little-endian raw
  value) as the wire and storage format defined in docs/03_wire_protocol.md.`
- [x] Add `C06 | MUST | Session buffer values use opaque bare zenoh/bytes; durable values are
  retrievable by Get/List, while ephemeral values are live-only and leave no node-retained state.`
- [x] Map the three fixed key tests only to the route-grammar portion of C06; map
  `BufferRoutesRoundTrip` also to the custom-prefix portion of X03.
- [x] Map the named tests for #141 to C06 bare-byte admission, durable Get/List, write-once handling,
  and absence of node-retained ephemeral state.
- [x] Map the fixed final #56 raw-Zenoh tests to C03/C06 interoperability and the
  process-isolated durable late-join boundary.
- [x] Correct `docs/04_api_cpp.md` so `Encoding` is the existing identifier struct, not a `Raw`
  enum value.
- [x] Record independent #139, #140, #141, and final #56 stages, their dependency order, exact
  targets, and final #56 ownership of the Registry transition in `docs/07`.
- [x] Record every exact fixed acceptance-test name from the four current Issue bodies in `docs/06`.
- [x] Replace stale `docs/04` and `docs/07` taxonomy deferral text with
  DEC-56-FACTORY-FAILURE-001 and stage #141 ownership.
- [x] Correct `docs/02` to use
  `BuildBufferKey(prefix, sid, buffer_class, user_key)` and document the exact public key types in
  `docs/04`.
- [x] Add the accepted buffer-route, Encoding, and late-join compatibility invariants to
  `docs/09_dependency_policy.md` without adding a dependency.
- [x] Leave the Contract Registry buffer row `Normative / Planned / ADR-0032 / —`.

## TDD and fixed acceptance tests

Write the tests first and record the RED compile or assertion failures in the PR body.

- [x] `BufferKeyTest.BufferRoutesRoundTrip`
- [x] `BufferKeyTest.InvalidBufferRoutesAreRejected`
- [x] `BufferKeyTest.BufferClassIsReservedOnlyInTheClassPosition`

`BufferRoutesRoundTrip` must also prove that Base, Session, Snapshot, MetaSession, and MetaAck leave
`buffer_class` disengaged. `InvalidBufferRoutesAreRejected` covers unknown class text and an
undefined `BufferClass` enum value.

The tests must independently assert complete expected strings and parsed fields. A shared golden
fixture file is not required; the later raw-wire tests must make their own canonical-route
assertions.

These three tests are not complete evidence for C06. They verify only canonical route grammar,
parser classification, invalid-form rejection, class-position reservation, and the custom-prefix
portion of X03. Opaque-byte admission, durable retrieval, ephemeral non-retention, and raw-client
interoperability remain assigned to #141 and final #56 as listed above.

### Later fixed names to register in docs/06

Stage #140:

- `StorageNodeSessionLifecycleTest.CreatingAndClosingCollisionsAreDeterministic`
- `StorageNodeSessionLifecycleTest.CreateRollbackAllowsSameSidRetry`
- `StorageNodeSessionLifecycleTest.CloseQuiescesAdmittedOperations`
- `StorageNodeSessionLifecycleTest.DestroysResourcesBeforeCloseReturns`
- `StorageNodeSessionLifecycleTest.StopWaitsForAdmittedCreate`
- `SessionViewTest.CloseWaitsForCapturedRead`
- `SessionViewTest.StaleViewRejectsSameSidReplacement`

Stage #141:

- `StorageNodeBufferApiTest.PreservesLegacyCreateSessionOverload`
- `StorageNodeBufferApiTest.ExposesCapabilityOverloadAndFactory`
- `StorageNodeBufferLifecycleTest.FactoryFailureTaxonomyAndRollback`
- `StorageNodeBufferLifecycleTest.FactoryAndStopLinearizeDeterministically`
- `StorageNodeBufferLifecycleTest.CloseQuiescesDurableOperationsAndDestroysEngine`
- `StorageNodeBufferLifecycleTest.SameSidRecreationUsesFreshEngine`
- `StorageNodeBufferRoutingTest.CapabilityMatrix`
- `StorageNodeBufferRoutingTest.DurablePutIsByteExactAndWriteOnce`
- `StorageNodeBufferRoutingTest.PutFailureRereadsAuthoritativeEngineState`
- `StorageNodeBufferRoutingTest.WholeSubscriberSerializationPreventsConflictingPuts`
- `StorageNodeBufferRoutingTest.EphemeralPutNeverTouchesEngine`
- `StorageNodeBufferRoutingTest.NonBytesEncodingIsRejected`
- `StorageNodeBufferRoutingTest.DurableQuerySelectorsAndFailures`
- `StorageNodeBufferRoutingTest.EngineFailuresAndExceptionsAreContained`
- `StorageNodeBufferRoutingTest.BufferRoutesDoNotEnterParameterSurfaces`
- `StorageNodeBufferRoutingTest.BufferDeleteAndControlRoutesAreRejected`

Final stage #56:

- `BufferLateJoinTest.OrdersMaterializedBufferedAndLiveSamples`
- `BufferLateJoinTest.DurableLateJoinDoesNotLoseDistinctKeys`
- `BufferLateJoinTest.FailureInvokesNoObserverAndCleansUp`
- `RawZenohClientCanUseMixedSessionBuffers`
- `RawZenohDurableLateJoinPreservesDistinctKeys`
- `RawZenohBufferInteropFixtureBoundaries`
- `RocksDBBufferLifecycleTest.CloseReleasesEngineBeforeReturn`
- `RocksDBBufferLifecycleTest.SameSidRecreationUsesFreshEngine`

## Expected files

- `include/sitos/key.hpp`
- `src/key.cpp`
- `tests/unit/key_test.cpp`
- `docs/adr/0032-mixed-session-buffer-routes.md`
- `docs/01_requirements.md`
- `docs/02_architecture.md`
- `docs/04_api_cpp.md`
- `docs/06_build_test_packaging.md`
- `docs/07_issue_breakdown.md`
- `docs/09_dependency_policy.md`

Any additional file requires owner approval before implementation.

## Dependencies and registry

- Depends on completed Issue #133 and Accepted ADR-0032.
- Parent integration issue: #56.
- Contract Registry change: none.

## Out of scope

- `SessionOptions` or `DurableBufferEngineFactory`
- StorageNode Session lifecycle changes
- durable or ephemeral routing
- production or test-only buffer subscriber algorithms
- RocksDB, raw Zenoh, package, or CI changes
- Issues #105-#108 behavior

## Governance

- [x] Independent pre-implementation review completed.
- [x] Owner declares this exact checklist ready and frozen for implementation.
- [ ] RED evidence captured before production edits.

  Exception: DEC-142-TDD-001 accepts a retrospective RED reproduction for this exact PR head;
  it does not claim or reconstruct pre-production-edit chronology.
- [ ] Independent exact-head review completed.
- [ ] Separate one-time owner merge authorization recorded.

## Acceptance Criteria Verification

- MSVC 19.51.36248.0, Debug, `SITOS_BUILD_TESTS=ON`, `SITOS_WITH_ZENOH=OFF`:
  `cmake --build build-key-final-green --target sitos_key_test -j2` — passed.
- `sitos_key_test.exe --gtest_filter='BufferKeyTest.*'` — passed, 3/3.
- `sitos_key_test.exe` — passed, 51/51.
- Review-driven Sonar cleanup commit `65ccea7` resolves `cpp:S6032` issues
  `AZ-47_O4jq0GFC1seUCT` and `AZ-47_O4jq0GFC1seUCU` by binding parsed buffer-route
  `std::string_view` values by `const` reference; no parser behavior or public contract changed.
- Post-cleanup MSVC 19.51 validation rebuilt `sitos_key_test` and passed the three focused
  `BufferKeyTest` cases (3/3) and the complete key suite (51/51).
- `git diff --check`, exact ten-path scope, changed non-table 100-column check, 18 relative-link
  checks, forbidden-token check, and Accepted ADR-0032 typo-only semantic-diff check — passed.
- Independent Sol and Terra pre-commit reviews — HANDOFF READY with no findings.

## RED-phase Evidence

- Command: With the final tests retained, saved the production two-file patch; temporarily restored
  only `include/sitos/key.hpp` and `src/key.cpp` to HEAD; then ran MSVC 19.51.36248.0:
  `cmake -S . -B build-key-final-red -G Ninja -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF -DCMAKE_BUILD_TYPE=Debug && cmake --build build-key-final-red --target sitos_key_test -j2`.
- Failing test name: `BufferKeyTest.*` compilation in `sitos_key_test`.
- Expected failure reason: the baseline public key API has no `BufferClass`, `KeyKind::Buffer`, or
  `BuildBufferKey`.
- Representative failure-message line: `tests/unit/key_test.cpp(411): error C2653: 'BufferClass'`.
- Result: exit code 2. The saved production patch was reapplied byte-identically before the GREEN
  build above.
- Complete CI-log link: N/A — local MSVC remediation log was sufficient and independently reviewed.

## ADR Needed?

- [x] No — this implements the accepted ADR-0032 key contract and makes only its owner-approved
  Python-factory typo correction; it introduces no new architectural decision.
- [ ] Yes — ADR PR: #

## Owner Merge Authorization

- Status: Pending
- Authorized head SHA:
- Owner instruction link:
