### PR TITLE
feat(node): unify Session admission lifecycle (#140)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,17 +148,24 @@ jobs:
           ctest --test-dir build/sanitizer-tsan --output-on-failure --timeout 60 \
             --repeat until-fail:100 \
             -R 'ParamStoreSubscribeTest.(CloseWaitsForBlockedCallback|DeclarationFailureWaitsForAdmittedCallbackCopy)'
+          lifecycle_filter="StorageNodeLifecycleTest|StorageNodeSessionTest|"
+          lifecycle_filter+="StorageNodeSessionLifecycleTest|StorageNodeBatchTest|"
+          lifecycle_filter+="TransportGetCompletionTest|ParamStoreSubscribeTest|"
+          lifecycle_filter+="ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture"
           ctest --test-dir build/sanitizer-tsan --output-on-failure --timeout 60 \
-            --repeat until-fail:10 \
-            -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|TransportGetCompletionTest|ParamStoreSubscribeTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
+            --repeat until-fail:10 -R "$lifecycle_filter"
 
       - name: Run lifecycle tests
         env:
           TSAN_OPTIONS: halt_on_error=1
           UBSAN_OPTIONS: halt_on_error=1
-        run: >-
-          ctest --test-dir build/sanitizer-${{ matrix.name }}
-          --output-on-failure --timeout 60 -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|TransportGetCompletionTest|ParamStoreSubscribeTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
+        run: |
+          lifecycle_filter="StorageNodeLifecycleTest|StorageNodeSessionTest|"
+          lifecycle_filter+="StorageNodeSessionLifecycleTest|StorageNodeBatchTest|"
+          lifecycle_filter+="TransportGetCompletionTest|ParamStoreSubscribeTest|"
+          lifecycle_filter+="ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture"
+          ctest --test-dir build/sanitizer-${{ matrix.name }} \
+            --output-on-failure --timeout 60 -R "$lifecycle_filter"
 
   build-windows:
     runs-on: windows-latest

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -316,9 +316,10 @@ cmake -S . -B build/tsan -G Ninja -DCMAKE_BUILD_TYPE=Debug \
   -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF -DSITOS_ENABLE_TSAN=ON
 cmake --build build/tsan
 lifecycle_filter="StorageNodeLifecycleTest|StorageNodeSessionTest|"
-lifecycle_filter+="StorageNodeSessionLifecycleTest|StorageNodeBatchTest|"
-lifecycle_filter+="TransportGetCompletionTest|ParamStoreSubscribeTest|"
-lifecycle_filter+="ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture"
+lifecycle_filter="${lifecycle_filter}StorageNodeSessionLifecycleTest|StorageNodeBatchTest|"
+lifecycle_filter="${lifecycle_filter}TransportGetCompletionTest|ParamStoreSubscribeTest|"
+lifecycle_filter="${lifecycle_filter}ParamCacheTest|ParamCacheReadTest|"
+lifecycle_filter="${lifecycle_filter}SessionViewTest|SessionViewFixture"
 ctest --test-dir build/tsan --output-on-failure --timeout 60 -R "$lifecycle_filter"
 
 cmake -S . -B build/asan -G Ninja -DCMAKE_BUILD_TYPE=Debug \

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -315,14 +315,16 @@ zenoh-independent fake-Transport paths; ASan/UBSan runs the same paths separatel
 cmake -S . -B build/tsan -G Ninja -DCMAKE_BUILD_TYPE=Debug \
   -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF -DSITOS_ENABLE_TSAN=ON
 cmake --build build/tsan
-ctest --test-dir build/tsan --output-on-failure --timeout 60 \
-  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|TransportGetCompletionTest|ParamStoreSubscribeTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
+lifecycle_filter="StorageNodeLifecycleTest|StorageNodeSessionTest|"
+lifecycle_filter+="StorageNodeSessionLifecycleTest|StorageNodeBatchTest|"
+lifecycle_filter+="TransportGetCompletionTest|ParamStoreSubscribeTest|"
+lifecycle_filter+="ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture"
+ctest --test-dir build/tsan --output-on-failure --timeout 60 -R "$lifecycle_filter"
 
 cmake -S . -B build/asan -G Ninja -DCMAKE_BUILD_TYPE=Debug \
   -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF -DSITOS_ENABLE_ASAN_UBSAN=ON
 cmake --build build/asan
-ctest --test-dir build/asan --output-on-failure --timeout 60 \
-  -R 'StorageNodeLifecycleTest|StorageNodeSessionTest|StorageNodeBatchTest|TransportGetCompletionTest|ParamStoreSubscribeTest|ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture'
+ctest --test-dir build/asan --output-on-failure --timeout 60 -R "$lifecycle_filter"
 ```
 
 The TSan CI lane additionally repeats the two subscription lifecycle regressions 100 times and the

--- a/include/sitos/session.hpp
+++ b/include/sitos/session.hpp
@@ -1,9 +1,9 @@
 // Copyright 2026 sitos contributors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Session table types used by StorageNode to manage engine-native snapshots
-// (snap/<sid>/**), per-session overlays (session/<sid>/**), and session
-// metadata (meta/session/<sid>).
+// Legacy Session table aliases retained for source compatibility. StorageNode
+// keeps its active ownership and membership in private generation-safe
+// SessionRecord instances instead of these aliases.
 // See docs/02_architecture.md §4.1-4.3 and docs/03_wire_protocol.md §7.
 
 #ifndef SITOS_SESSION_HPP
@@ -24,16 +24,16 @@ struct SessionMeta {
   std::string created_at;
 };
 
-/// sid -> engine-native snapshot taken at CreateSession. Reads for
-/// snap/<sid>/** resolve against this consistent, immutable view.
+/// Legacy sid -> engine-native snapshot map shape retained for source
+/// compatibility; StorageNode does not use this alias as an ownership table.
 using SnapshotTable = std::unordered_map<std::string, std::shared_ptr<const StorageReader>>;
 
-/// sid -> per-session overlay engine. Writes to session/<sid>/** land here and
-/// reads for the same scope resolve from it.
+/// Legacy sid -> per-session overlay map shape retained for source
+/// compatibility; StorageNode does not use this alias as an ownership table.
 using OverlayTable = std::unordered_map<std::string, std::shared_ptr<StorageEngine>>;
 
-/// sid -> session metadata. Membership is the source of truth for whether a
-/// session is active.
+/// Legacy sid -> session metadata map shape retained for source compatibility;
+/// StorageNode does not use this alias as its membership source.
 using SessionTable = std::unordered_map<std::string, SessionMeta>;
 
 }  // namespace sitos

--- a/include/sitos/storage_node.hpp
+++ b/include/sitos/storage_node.hpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <unordered_map>
 #include <vector>
 
 #include "sitos/logging.hpp"
@@ -47,6 +48,9 @@ struct StorageNodeConfig {
 };
 
 class SessionView;
+namespace storage_node_test_access {
+class StorageNodeTestAccess;
+}
 
 /// Serves base-scope Get/List queries and base writes through Transport declarations.
 class StorageNode {
@@ -96,6 +100,73 @@ class StorageNode {
 
  private:
   friend class SessionView;
+  friend class storage_node_test_access::StorageNodeTestAccess;
+
+  struct SessionRecord {
+    enum class Phase { Creating, Active, Closing };
+
+    class AdmissionLease {
+     public:
+      explicit AdmissionLease(SessionRecord* record) : record_(record) {}
+      ~AdmissionLease() {
+        if (record_ != nullptr) record_->LeaveAdmission();
+      }
+      AdmissionLease(const AdmissionLease&) = delete;
+      AdmissionLease& operator=(const AdmissionLease&) = delete;
+      AdmissionLease(AdmissionLease&& other) noexcept : record_(other.record_) {
+        other.record_ = nullptr;
+      }
+      AdmissionLease& operator=(AdmissionLease&& other) noexcept {
+        if (this != &other) {
+          if (record_ != nullptr) record_->LeaveAdmission();
+          record_ = other.record_;
+          other.record_ = nullptr;
+        }
+        return *this;
+      }
+
+     private:
+      SessionRecord* record_;
+    };
+
+    std::optional<AdmissionLease> TryAcquire() noexcept {
+      std::scoped_lock lock(admission_mutex);
+      if (phase != Phase::Active || !accepting) return std::nullopt;
+      ++admitted;
+      return AdmissionLease(this);
+    }
+
+    bool BeginClose() noexcept {
+      std::scoped_lock lock(admission_mutex);
+      if (phase != Phase::Active) return false;
+      phase = Phase::Closing;
+      accepting = false;
+      admission_cv.notify_all();
+      return true;
+    }
+
+    void WaitForAdmission() noexcept {
+      std::unique_lock lock(admission_mutex);
+      admission_cv.wait(lock, [this] { return admitted == 0; });
+    }
+
+    void LeaveAdmission() noexcept {
+      std::scoped_lock lock(admission_mutex);
+      assert(admitted > 0);
+      if (admitted == 0) return;
+      --admitted;
+      if (admitted == 0) admission_cv.notify_all();
+    }
+
+    Phase phase = Phase::Creating;
+    bool accepting = false;
+    std::size_t admitted = 0;
+    std::mutex admission_mutex;
+    std::condition_variable admission_cv;
+    std::shared_ptr<const StorageReader> snapshot;
+    std::shared_ptr<StorageEngine> overlay;
+    SessionMeta metadata;
+  };
 
   struct State {
     State(std::shared_ptr<StorageEngine> storage, std::string key_prefix,
@@ -147,6 +218,7 @@ class StorageNode {
     void DeactivateAndWait() noexcept {
       std::unique_lock lock(gate_mutex);
       accepting = false;
+      gate_cv.notify_all();
       gate_cv.wait(lock, [this] { return in_flight == 0; });
     }
 
@@ -169,13 +241,13 @@ class StorageNode {
     // session locks are released before engine writes.
     std::mutex subscriber_mutex;
 
-    // Session tables. Guarded by session_mutex. Callbacks and session
-    // operations alike enter the callback gate before locking session_mutex,
-    // so the gate -> subscriber_mutex -> session_mutex ordering never cycles.
+    // Session records are the sole internal ownership and membership source.
+    // Guarded by session_mutex. Callbacks and session operations alike enter
+    // the callback gate before locking session_mutex, so the
+    // gate -> subscriber_mutex -> session_mutex -> admission ordering never
+    // cycles.
     std::shared_mutex session_mutex;
-    SnapshotTable snapshots;
-    OverlayTable overlays;
-    SessionTable sessions;
+    std::unordered_map<std::string, std::shared_ptr<SessionRecord>> sessions;
   };
 
   static void OnQuery(const std::shared_ptr<State>& state, TransportQuery& query);

--- a/include/sitos/storage_node.hpp
+++ b/include/sitos/storage_node.hpp
@@ -9,6 +9,7 @@
 #include <cassert>
 #include <condition_variable>
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -168,6 +169,14 @@ class StorageNode {
     SessionMeta metadata;
   };
 
+  struct SessionKeyHash {
+    using is_transparent = void;
+
+    std::size_t operator()(std::string_view value) const noexcept {
+      return std::hash<std::string_view>{}(value);
+    }
+  };
+
   struct State {
     State(std::shared_ptr<StorageEngine> storage, std::string key_prefix,
           std::shared_ptr<LogSink> diagnostics)
@@ -247,9 +256,18 @@ class StorageNode {
     // gate -> subscriber_mutex -> session_mutex -> admission ordering never
     // cycles.
     std::shared_mutex session_mutex;
-    std::unordered_map<std::string, std::shared_ptr<SessionRecord>> sessions;
+    std::unordered_map<std::string, std::shared_ptr<SessionRecord>, SessionKeyHash,
+                       std::equal_to<>>
+        sessions;
   };
 
+  struct SessionAccess {
+    std::optional<SessionRecord::AdmissionLease> admission;
+    std::shared_ptr<SessionRecord> record;
+  };
+
+  static SessionAccess AcquireSession(const std::shared_ptr<State>& state,
+                                      std::string_view sid);
   static void OnQuery(const std::shared_ptr<State>& state, TransportQuery& query);
   static void OnSample(const std::shared_ptr<State>& state, const TransportSample& sample);
   // Answers a get in the session or snap scope from the matching overlay or

--- a/include/sitos/storage_node.hpp
+++ b/include/sitos/storage_node.hpp
@@ -137,6 +137,20 @@ class StorageNode {
       return AdmissionLease(this);
     }
 
+    bool Activate() noexcept {
+      std::scoped_lock lock(admission_mutex);
+      if (phase != Phase::Creating) return false;
+      phase = Phase::Active;
+      accepting = true;
+      admission_cv.notify_all();
+      return true;
+    }
+
+    bool IsActive() noexcept {
+      std::scoped_lock lock(admission_mutex);
+      return phase == Phase::Active;
+    }
+
     bool BeginClose() noexcept {
       std::scoped_lock lock(admission_mutex);
       if (phase != Phase::Active) return false;
@@ -144,6 +158,11 @@ class StorageNode {
       accepting = false;
       admission_cv.notify_all();
       return true;
+    }
+
+    void WaitForClosing() noexcept {
+      std::unique_lock lock(admission_mutex);
+      admission_cv.wait(lock, [this] { return phase == Phase::Closing; });
     }
 
     void WaitForAdmission() noexcept {

--- a/src/session_view.cpp
+++ b/src/session_view.cpp
@@ -70,6 +70,7 @@ struct SessionView::Impl {
 struct SessionView::Readers {
   std::shared_ptr<void> state_owner;
   std::optional<StorageNode::State::CallbackLease> lease;
+  std::optional<StorageNode::SessionRecord::AdmissionLease> admission;
   std::shared_ptr<StorageEngine> overlay;
   std::shared_ptr<const StorageReader> snapshot;
 };
@@ -102,23 +103,28 @@ Result<SessionView> SessionView::Open(const StorageNode& node, std::string_view 
   auto lease = state->Enter();
   if (!lease) return Result<SessionView>::Err(Status::Disconnected, "StorageNode is stopped");
 
-  std::shared_ptr<StorageEngine> overlay;
+  std::weak_ptr<void> overlay_owner;
+  std::optional<StorageNode::SessionRecord::AdmissionLease> admission;
   {
     std::shared_lock lock(state->session_mutex);
     const std::string key(sid);
-    if (!state->sessions.contains(key)) {
+    auto it = state->sessions.find(key);
+    if (it == state->sessions.end() ||
+        it->second->phase != StorageNode::SessionRecord::Phase::Active ||
+        !it->second->overlay) {
       return Result<SessionView>::Err(Status::NotFound, "session not found");
     }
-    auto it = state->overlays.find(key);
-    if (it == state->overlays.end()) {
+    admission = it->second->TryAcquire();
+    if (!admission.has_value()) {
       return Result<SessionView>::Err(Status::NotFound, "session not found");
     }
-    overlay = it->second;
+    const std::shared_ptr<StorageEngine>& overlay = it->second->overlay;
+    overlay_owner = overlay;
   }
 
   auto impl = std::make_unique<Impl>();
   impl->state = state;
-  impl->overlay_owner = overlay;
+  impl->overlay_owner = std::move(overlay_owner);
   impl->sid = std::string(sid);
   return Result<SessionView>::Ok(SessionView(std::move(impl)));
 }
@@ -136,15 +142,19 @@ Result<SessionView::Readers> SessionView::AcquireReaders() const {
   readers.lease = std::move(lease);
   {
     std::shared_lock lock(state->session_mutex);
-    if (!state->sessions.contains(impl_->sid)) return Result<Readers>::ErrFrom(NotFound());
-    auto overlay_it = state->overlays.find(impl_->sid);
-    auto snapshot_it = state->snapshots.find(impl_->sid);
-    if (overlay_it == state->overlays.end() || snapshot_it == state->snapshots.end() ||
-        !SameOwner(impl_->overlay_owner, overlay_it->second)) {
+    auto it = state->sessions.find(impl_->sid);
+    if (it == state->sessions.end() ||
+        it->second->phase != StorageNode::SessionRecord::Phase::Active) {
       return Result<Readers>::ErrFrom(NotFound());
     }
-    readers.overlay = overlay_it->second;
-    readers.snapshot = snapshot_it->second;
+    auto& record = it->second;
+    readers.admission = record->TryAcquire();
+    if (!readers.admission.has_value() || !record->snapshot || !record->overlay ||
+        !SameOwner(impl_->overlay_owner, record->overlay)) {
+      return Result<Readers>::ErrFrom(NotFound());
+    }
+    readers.overlay = record->overlay;
+    readers.snapshot = record->snapshot;
   }
   return Result<Readers>::Ok(std::move(readers));
 }
@@ -256,6 +266,7 @@ Result<void> SessionView::List(std::string_view prefix, const ListSink& sink) co
 
   readers.overlay.reset();
   readers.snapshot.reset();
+  readers.admission.reset();
   readers.lease.reset();
   readers.state_owner.reset();
   for (const auto& item : values) {

--- a/src/session_view.cpp
+++ b/src/session_view.cpp
@@ -108,8 +108,7 @@ Result<SessionView> SessionView::Open(const StorageNode& node, std::string_view 
   {
     std::shared_lock lock(state->session_mutex);
     auto it = state->sessions.find(sid);
-    if (it == state->sessions.end() ||
-        it->second->phase != StorageNode::SessionRecord::Phase::Active ||
+    if (it == state->sessions.end() || !it->second->IsActive() ||
         !it->second->overlay) {
       return Result<SessionView>::Err(Status::NotFound, "session not found");
     }
@@ -142,8 +141,7 @@ Result<SessionView::Readers> SessionView::AcquireReaders() const {
   {
     std::shared_lock lock(state->session_mutex);
     auto it = state->sessions.find(impl_->sid);
-    if (it == state->sessions.end() ||
-        it->second->phase != StorageNode::SessionRecord::Phase::Active) {
+    if (it == state->sessions.end() || !it->second->IsActive()) {
       return Result<Readers>::ErrFrom(NotFound());
     }
     const auto& record = it->second;

--- a/src/session_view.cpp
+++ b/src/session_view.cpp
@@ -107,8 +107,7 @@ Result<SessionView> SessionView::Open(const StorageNode& node, std::string_view 
   std::optional<StorageNode::SessionRecord::AdmissionLease> admission;
   {
     std::shared_lock lock(state->session_mutex);
-    const std::string key(sid);
-    auto it = state->sessions.find(key);
+    auto it = state->sessions.find(sid);
     if (it == state->sessions.end() ||
         it->second->phase != StorageNode::SessionRecord::Phase::Active ||
         !it->second->overlay) {
@@ -147,7 +146,7 @@ Result<SessionView::Readers> SessionView::AcquireReaders() const {
         it->second->phase != StorageNode::SessionRecord::Phase::Active) {
       return Result<Readers>::ErrFrom(NotFound());
     }
-    auto& record = it->second;
+    const auto& record = it->second;
     readers.admission = record->TryAcquire();
     if (!readers.admission.has_value() || !record->snapshot || !record->overlay ||
         !SameOwner(impl_->overlay_owner, record->overlay)) {

--- a/src/storage_node.cpp
+++ b/src/storage_node.cpp
@@ -318,9 +318,7 @@ Result<void> StorageNode::CreateSession(std::string_view sid) {
   {
     std::unique_lock lock(state->session_mutex);
     if (auto it = state->sessions.find(key); it != state->sessions.end()) {
-      if (it->second->phase != SessionRecord::Phase::Active) {
-        return Result<void>::Err(OperationInProgress());
-      }
+      if (!it->second->IsActive()) return Result<void>::Err(OperationInProgress());
       return Result<void>::Err(SessionAlreadyExists());
     }
     state->sessions.try_emplace(key, record);
@@ -373,11 +371,8 @@ Result<void> StorageNode::CreateSession(std::string_view sid) {
   {
     std::unique_lock lock(state->session_mutex);
     auto it = state->sessions.find(key);
-    if (it != state->sessions.end() && it->second == record &&
-        record->phase == SessionRecord::Phase::Creating) {
-      record->phase = SessionRecord::Phase::Active;
-      record->accepting = true;
-      committed = true;
+    if (it != state->sessions.end() && it->second == record) {
+      committed = record->Activate();
     }
   }
   if (!committed) return Result<void>::Err(OperationInProgress());
@@ -431,7 +426,7 @@ std::vector<std::string> StorageNode::ActiveSessions() const {
   std::vector<std::string> result;
   result.reserve(state->sessions.size());
   for (const auto& [id, record] : state->sessions) {
-    if (record->phase == SessionRecord::Phase::Active) result.push_back(id);
+    if (record->IsActive()) result.push_back(id);
   }
   return result;
 }
@@ -440,8 +435,7 @@ StorageNode::SessionAccess StorageNode::AcquireSession(const std::shared_ptr<Sta
                                                         std::string_view sid) {
   SessionAccess access;
   std::shared_lock lock(state->session_mutex);
-  auto it = state->sessions.find(sid);
-  if (it != state->sessions.end()) {
+  if (auto it = state->sessions.find(sid); it != state->sessions.end()) {
     access.record = it->second;
     access.admission = access.record->TryAcquire();
   }
@@ -468,8 +462,8 @@ void StorageNode::OnSample(const std::shared_ptr<State>& state, const TransportS
         } else if (parsed->kind == KeyKind::Base) {
           ApplyBatch(diagnostics, *state->engine, sample.payload);
         } else {
-          auto access = AcquireSession(state, parsed->sid);
-          if (!access.record || !access.admission.has_value()) {
+          if (auto access = AcquireSession(state, parsed->sid);
+              !access.record || !access.admission.has_value()) {
             diagnostics.push_back({LogLevel::kWarning, kUnknownSession});
           } else {
             ApplyBatch(diagnostics, *access.record->overlay, sample.payload);
@@ -481,8 +475,8 @@ void StorageNode::OnSample(const std::shared_ptr<State>& state, const TransportS
             ApplyWrite(diagnostics, *state->engine, parsed->relative_key, sample);
             break;
           case KeyKind::Session: {
-            auto access = AcquireSession(state, parsed->sid);
-            if (!access.record || !access.admission.has_value()) {
+            if (auto access = AcquireSession(state, parsed->sid);
+                !access.record || !access.admission.has_value()) {
               diagnostics.push_back({LogLevel::kWarning, kUnknownSession});
             } else {
               ApplyWrite(diagnostics, *access.record->overlay, parsed->relative_key, sample);
@@ -568,8 +562,7 @@ void StorageNode::ReplyMetaQuery(const std::shared_ptr<State>& state, TransportQ
   {
     std::shared_lock lock(state->session_mutex);
     auto it = state->sessions.find(parsed->sid);
-    if (it == state->sessions.end() ||
-        it->second->phase != SessionRecord::Phase::Active) {
+    if (it == state->sessions.end() || !it->second->IsActive()) {
       return;  // Unknown or non-active sid: 0 replies.
     }
     admission = it->second->TryAcquire();

--- a/src/storage_node.cpp
+++ b/src/storage_node.cpp
@@ -310,23 +310,68 @@ Result<void> StorageNode::CreateSession(std::string_view sid) {
     state = state_;
   }
   if (!state) return Result<void>::Err(InvalidArgument());
-  // Enroll in the callback gate so a concurrent Stop() cannot tear the node down
-  // mid-operation; a node already quiescing rejects the request.
   auto lease = state->Enter();
   if (!lease) return Result<void>::Err(InvalidArgument());
 
-  // Take the snapshot before locking the session table: TakeSnapshot() may be
-  // O(n) and the engine is independently thread-safe.
-  auto snapshot = state->engine->TakeSnapshot();
-  auto overlay = std::make_shared<InMemoryEngine>();
-  SessionMeta meta{NowIso8601()};
-
   const std::string key(sid);
-  std::unique_lock lock(state->session_mutex);
-  if (state->sessions.contains(key)) return Result<void>::Err(SessionAlreadyExists());
-  state->snapshots.emplace(key, std::move(snapshot));
-  state->overlays.emplace(key, std::move(overlay));
-  state->sessions.emplace(key, std::move(meta));
+  auto record = std::make_shared<SessionRecord>();
+  {
+    std::unique_lock lock(state->session_mutex);
+    if (auto it = state->sessions.find(key); it != state->sessions.end()) {
+      if (it->second->phase != SessionRecord::Phase::Active) {
+        return Result<void>::Err(OperationInProgress());
+      }
+      return Result<void>::Err(SessionAlreadyExists());
+    }
+    state->sessions.emplace(key, record);
+  }
+
+  struct SessionRollbackGuard {
+    State* state;
+    const std::string& key;
+    std::shared_ptr<SessionRecord> record;
+    bool active = true;
+
+    ~SessionRollbackGuard() noexcept {
+      if (!active) return;
+      record->snapshot.reset();
+      record->overlay.reset();
+      record->metadata = {};
+      std::unique_lock lock(state->session_mutex);
+      auto it = state->sessions.find(key);
+      if (it != state->sessions.end() && it->second == record) state->sessions.erase(it);
+    }
+
+    void Dismiss() noexcept { active = false; }
+  } rollback{state.get(), key, record};
+
+  std::shared_ptr<const StorageReader> snapshot;
+  try {
+    snapshot = state->engine->TakeSnapshot();
+  } catch (...) {
+    return Result<void>::Err(Status::Error, "base snapshot creation threw an exception");
+  }
+  if (!snapshot) {
+    return Result<void>::Err(Status::Error, "base snapshot creation returned null");
+  }
+
+  record->snapshot = std::move(snapshot);
+  record->overlay = std::make_shared<InMemoryEngine>();
+  record->metadata = SessionMeta{NowIso8601()};
+
+  bool committed = false;
+  {
+    std::unique_lock lock(state->session_mutex);
+    auto it = state->sessions.find(key);
+    if (it != state->sessions.end() && it->second == record &&
+        record->phase == SessionRecord::Phase::Creating) {
+      record->phase = SessionRecord::Phase::Active;
+      record->accepting = true;
+      committed = true;
+    }
+  }
+  if (!committed) return Result<void>::Err(OperationInProgress());
+  rollback.Dismiss();
   return Result<void>::Ok();
 }
 
@@ -341,12 +386,24 @@ Result<void> StorageNode::CloseSession(std::string_view sid) {
   if (!lease) return Result<void>::Err(InvalidArgument());
 
   const std::string key(sid);
-  std::unique_lock lock(state->session_mutex);
-  auto it = state->sessions.find(key);
-  if (it == state->sessions.end()) return Result<void>::Err(NoSuchSession());
-  state->sessions.erase(it);
-  state->snapshots.erase(key);
-  state->overlays.erase(key);
+  std::shared_ptr<SessionRecord> record;
+  {
+    std::unique_lock lock(state->session_mutex);
+    auto it = state->sessions.find(key);
+    if (it == state->sessions.end()) return Result<void>::Err(NoSuchSession());
+    record = it->second;
+    if (!record->BeginClose()) return Result<void>::Err(OperationInProgress());
+  }
+
+  record->WaitForAdmission();
+  record->snapshot.reset();
+  record->overlay.reset();
+  record->metadata = {};
+  {
+    std::unique_lock lock(state->session_mutex);
+    auto it = state->sessions.find(key);
+    if (it != state->sessions.end() && it->second == record) state->sessions.erase(it);
+  }
   return Result<void>::Ok();
 }
 
@@ -363,9 +420,8 @@ std::vector<std::string> StorageNode::ActiveSessions() const {
   std::shared_lock lock(state->session_mutex);
   std::vector<std::string> result;
   result.reserve(state->sessions.size());
-  for (const auto& [id, meta] : state->sessions) {
-    (void)meta;
-    result.push_back(id);
+  for (const auto& [id, record] : state->sessions) {
+    if (record->phase == SessionRecord::Phase::Active) result.push_back(id);
   }
   return result;
 }
@@ -390,16 +446,20 @@ void StorageNode::OnSample(const std::shared_ptr<State>& state, const TransportS
         } else if (parsed->kind == KeyKind::Base) {
           ApplyBatch(diagnostics, *state->engine, sample.payload);
         } else {
-          std::shared_ptr<StorageEngine> overlay;
+          std::optional<SessionRecord::AdmissionLease> admission;
+          std::shared_ptr<SessionRecord> record;
           {
             std::shared_lock lock(state->session_mutex);
-            auto it = state->overlays.find(parsed->sid);
-            if (it != state->overlays.end()) overlay = it->second;
+            auto it = state->sessions.find(parsed->sid);
+            if (it != state->sessions.end()) {
+              record = it->second;
+              admission = record->TryAcquire();
+            }
           }
-          if (!overlay) {
+          if (!record || !admission.has_value()) {
             diagnostics.push_back({LogLevel::kWarning, kUnknownSession});
           } else {
-            ApplyBatch(diagnostics, *overlay, sample.payload);
+            ApplyBatch(diagnostics, *record->overlay, sample.payload);
           }
         }
       } else {
@@ -408,16 +468,20 @@ void StorageNode::OnSample(const std::shared_ptr<State>& state, const TransportS
             ApplyWrite(diagnostics, *state->engine, parsed->relative_key, sample);
             break;
           case KeyKind::Session: {
-            std::shared_ptr<StorageEngine> overlay;
+            std::optional<SessionRecord::AdmissionLease> admission;
+            std::shared_ptr<SessionRecord> record;
             {
               std::shared_lock lock(state->session_mutex);
-              auto it = state->overlays.find(parsed->sid);
-              if (it != state->overlays.end()) overlay = it->second;
+              auto it = state->sessions.find(parsed->sid);
+              if (it != state->sessions.end()) {
+                record = it->second;
+                admission = record->TryAcquire();
+              }
             }
-            if (!overlay) {
+            if (!record || !admission.has_value()) {
               diagnostics.push_back({LogLevel::kWarning, kUnknownSession});
             } else {
-              ApplyWrite(diagnostics, *overlay, parsed->relative_key, sample);
+              ApplyWrite(diagnostics, *record->overlay, parsed->relative_key, sample);
             }
             break;
           }
@@ -470,18 +534,21 @@ void StorageNode::ReplyScopedQuery(const std::shared_ptr<State>& state, std::str
   auto selector = ParseRelativeSelector(relative);
   if (!selector) return;
 
+  std::optional<SessionRecord::AdmissionLease> admission;
+  std::shared_ptr<SessionRecord> record;
   std::shared_ptr<const StorageReader> reader;
   {
     std::shared_lock lock(state->session_mutex);
-    if (scope == "snap") {
-      auto it = state->snapshots.find(std::string(sid));
-      if (it != state->snapshots.end()) reader = it->second;
-    } else {
-      auto it = state->overlays.find(std::string(sid));
-      if (it != state->overlays.end()) reader = it->second;
+    auto it = state->sessions.find(std::string(sid));
+    if (it != state->sessions.end()) {
+      record = it->second;
+      admission = record->TryAcquire();
+      if (admission.has_value()) {
+        reader = scope == "snap" ? record->snapshot : record->overlay;
+      }
     }
   }
-  if (!reader) return;  // Unknown sid: 0 replies.
+  if (!record || !admission.has_value() || !reader) return;
 
   const std::string scope_path = std::string(scope) + "/" + std::string(sid);
   ReplyFromReader(*reader, *selector, state->prefix, scope_path, query);
@@ -493,11 +560,18 @@ void StorageNode::ReplyMetaQuery(const std::shared_ptr<State>& state, TransportQ
   if (!parsed || parsed->kind != KeyKind::MetaSession) return;
 
   std::string json;
+  std::optional<SessionRecord::AdmissionLease> admission;
   {
     std::shared_lock lock(state->session_mutex);
     auto it = state->sessions.find(parsed->sid);
-    if (it == state->sessions.end()) return;  // Unknown sid: 0 replies.
-    json = std::format(R"({{"state":"active","created_at":"{}"}})", it->second.created_at);
+    if (it == state->sessions.end() ||
+        it->second->phase != SessionRecord::Phase::Active) {
+      return;  // Unknown or non-active sid: 0 replies.
+    }
+    admission = it->second->TryAcquire();
+    if (!admission.has_value()) return;
+    json = std::format(R"({{"state":"active","created_at":"{}"}})",
+                       it->second->metadata.created_at);
   }
   const auto payload = ParamValue(json).Encode();
   query.Reply(query.keyexpr, payload, SitosEncoding());

--- a/src/storage_node.cpp
+++ b/src/storage_node.cpp
@@ -323,7 +323,7 @@ Result<void> StorageNode::CreateSession(std::string_view sid) {
       }
       return Result<void>::Err(SessionAlreadyExists());
     }
-    state->sessions.emplace(key, record);
+    state->sessions.try_emplace(key, record);
   }
 
   struct SessionRollbackGuard {
@@ -331,6 +331,15 @@ Result<void> StorageNode::CreateSession(std::string_view sid) {
     const std::string& key;
     std::shared_ptr<SessionRecord> record;
     bool active = true;
+
+    SessionRollbackGuard(State* state_in, const std::string& key_in,
+                         std::shared_ptr<SessionRecord> record_in)
+        : state(state_in), key(key_in), record(std::move(record_in)) {}
+
+    SessionRollbackGuard(const SessionRollbackGuard&) = delete;
+    SessionRollbackGuard& operator=(const SessionRollbackGuard&) = delete;
+    SessionRollbackGuard(SessionRollbackGuard&&) = delete;
+    SessionRollbackGuard& operator=(SessionRollbackGuard&&) = delete;
 
     ~SessionRollbackGuard() noexcept {
       if (!active) return;
@@ -343,7 +352,8 @@ Result<void> StorageNode::CreateSession(std::string_view sid) {
     }
 
     void Dismiss() noexcept { active = false; }
-  } rollback{state.get(), key, record};
+  };
+  SessionRollbackGuard rollback{state.get(), key, record};
 
   std::shared_ptr<const StorageReader> snapshot;
   try {
@@ -426,6 +436,18 @@ std::vector<std::string> StorageNode::ActiveSessions() const {
   return result;
 }
 
+StorageNode::SessionAccess StorageNode::AcquireSession(const std::shared_ptr<State>& state,
+                                                        std::string_view sid) {
+  SessionAccess access;
+  std::shared_lock lock(state->session_mutex);
+  auto it = state->sessions.find(sid);
+  if (it != state->sessions.end()) {
+    access.record = it->second;
+    access.admission = access.record->TryAcquire();
+  }
+  return access;
+}
+
 void StorageNode::OnSample(const std::shared_ptr<State>& state, const TransportSample& sample) {
   auto lease = state->Enter();
   if (!lease) return;
@@ -446,20 +468,11 @@ void StorageNode::OnSample(const std::shared_ptr<State>& state, const TransportS
         } else if (parsed->kind == KeyKind::Base) {
           ApplyBatch(diagnostics, *state->engine, sample.payload);
         } else {
-          std::optional<SessionRecord::AdmissionLease> admission;
-          std::shared_ptr<SessionRecord> record;
-          {
-            std::shared_lock lock(state->session_mutex);
-            auto it = state->sessions.find(parsed->sid);
-            if (it != state->sessions.end()) {
-              record = it->second;
-              admission = record->TryAcquire();
-            }
-          }
-          if (!record || !admission.has_value()) {
+          auto access = AcquireSession(state, parsed->sid);
+          if (!access.record || !access.admission.has_value()) {
             diagnostics.push_back({LogLevel::kWarning, kUnknownSession});
           } else {
-            ApplyBatch(diagnostics, *record->overlay, sample.payload);
+            ApplyBatch(diagnostics, *access.record->overlay, sample.payload);
           }
         }
       } else {
@@ -468,20 +481,11 @@ void StorageNode::OnSample(const std::shared_ptr<State>& state, const TransportS
             ApplyWrite(diagnostics, *state->engine, parsed->relative_key, sample);
             break;
           case KeyKind::Session: {
-            std::optional<SessionRecord::AdmissionLease> admission;
-            std::shared_ptr<SessionRecord> record;
-            {
-              std::shared_lock lock(state->session_mutex);
-              auto it = state->sessions.find(parsed->sid);
-              if (it != state->sessions.end()) {
-                record = it->second;
-                admission = record->TryAcquire();
-              }
-            }
-            if (!record || !admission.has_value()) {
+            auto access = AcquireSession(state, parsed->sid);
+            if (!access.record || !access.admission.has_value()) {
               diagnostics.push_back({LogLevel::kWarning, kUnknownSession});
             } else {
-              ApplyWrite(diagnostics, *record->overlay, parsed->relative_key, sample);
+              ApplyWrite(diagnostics, *access.record->overlay, parsed->relative_key, sample);
             }
             break;
           }
@@ -539,7 +543,7 @@ void StorageNode::ReplyScopedQuery(const std::shared_ptr<State>& state, std::str
   std::shared_ptr<const StorageReader> reader;
   {
     std::shared_lock lock(state->session_mutex);
-    auto it = state->sessions.find(std::string(sid));
+    auto it = state->sessions.find(sid);
     if (it != state->sessions.end()) {
       record = it->second;
       admission = record->TryAcquire();

--- a/src/storage_node_test_access.hpp
+++ b/src/storage_node_test_access.hpp
@@ -1,0 +1,106 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SITOS_STORAGE_NODE_TEST_ACCESS_HPP
+#define SITOS_STORAGE_NODE_TEST_ACCESS_HPP
+
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "sitos/storage_engine.hpp"
+#include "sitos/storage_node.hpp"
+
+namespace sitos::storage_node_test_access {
+
+/// Source-private access used only by StorageNode lifecycle tests.
+struct SessionResourceObservation {
+  std::weak_ptr<void> record;
+  std::weak_ptr<const void> snapshot;
+  std::weak_ptr<void> overlay;
+};
+
+class StorageNodeTestAccess {
+ public:
+  // Non-owning: the test must capture this while node.state_ is published and
+  // keep an admitted operation alive until WaitForClosed() completes.
+  struct GateObserver {
+    StorageNode::State* state = nullptr;
+
+    bool WaitForClosed() const {
+      if (state == nullptr) return false;
+      std::unique_lock lock(state->gate_mutex);
+      state->gate_cv.wait(lock, [this] { return !state->accepting; });
+      return state->in_flight > 0;
+    }
+  };
+
+  static std::optional<GateObserver> CaptureGateObserver(StorageNode& node) {
+    std::scoped_lock lock(node.lifecycle_mutex_);
+    if (node.state_ == nullptr) return std::nullopt;
+    return GateObserver{node.state_.get()};
+  }
+
+  static std::optional<SessionResourceObservation> ObserveSession(StorageNode& node,
+                                                                    std::string_view sid) {
+    std::shared_ptr<StorageNode::State> state;
+    {
+      std::scoped_lock lock(node.lifecycle_mutex_);
+      state = node.state_;
+    }
+    if (state == nullptr) return std::nullopt;
+    std::shared_lock lock(state->session_mutex);
+    auto it = state->sessions.find(std::string(sid));
+    if (it == state->sessions.end()) return std::nullopt;
+    SessionResourceObservation observation;
+    observation.record = it->second;
+    observation.snapshot = it->second->snapshot;
+    observation.overlay = it->second->overlay;
+    return observation;
+  }
+
+  static bool WaitForClosing(StorageNode& node, std::string_view sid) {
+    std::shared_ptr<StorageNode::State> state;
+    {
+      std::scoped_lock lock(node.lifecycle_mutex_);
+      state = node.state_;
+    }
+    if (state == nullptr) return false;
+    std::shared_ptr<StorageNode::SessionRecord> record;
+    {
+      std::shared_lock state_lock(state->session_mutex);
+      auto it = state->sessions.find(std::string(sid));
+      if (it == state->sessions.end()) return false;
+      record = it->second;
+    }
+    std::unique_lock lock(record->admission_mutex);
+    record->admission_cv.wait(lock, [&] {
+      return record->phase == StorageNode::SessionRecord::Phase::Closing;
+    });
+    return true;
+  }
+
+  static bool ReplaceSessionOverlay(StorageNode& node, std::string_view sid,
+                                    std::shared_ptr<StorageEngine> overlay) {
+    std::shared_ptr<StorageNode::State> state;
+    {
+      std::scoped_lock lock(node.lifecycle_mutex_);
+      state = node.state_;
+    }
+    if (state == nullptr) return false;
+    std::unique_lock lock(state->session_mutex);
+    auto it = state->sessions.find(std::string(sid));
+    if (it == state->sessions.end() ||
+        it->second->phase != StorageNode::SessionRecord::Phase::Active) {
+      return false;
+    }
+    it->second->overlay = std::move(overlay);
+    return true;
+  }
+};
+
+}  // namespace sitos::storage_node_test_access
+
+#endif  // SITOS_STORAGE_NODE_TEST_ACCESS_HPP

--- a/src/storage_node_test_access.hpp
+++ b/src/storage_node_test_access.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <string>
 #include <string_view>
 
@@ -51,13 +52,18 @@ class StorageNodeTestAccess {
       state = node.state_;
     }
     if (state == nullptr) return std::nullopt;
+    std::optional<StorageNode::SessionRecord::AdmissionLease> admission;
+    std::shared_ptr<StorageNode::SessionRecord> record;
     std::shared_lock lock(state->session_mutex);
     auto it = state->sessions.find(sid);
     if (it == state->sessions.end()) return std::nullopt;
+    record = it->second;
+    admission = record->TryAcquire();
+    if (!admission.has_value()) return std::nullopt;
     SessionResourceObservation observation;
-    observation.record = it->second;
-    observation.snapshot = it->second->snapshot;
-    observation.overlay = it->second->overlay;
+    observation.record = record;
+    observation.snapshot = record->snapshot;
+    observation.overlay = record->overlay;
     return observation;
   }
 
@@ -75,10 +81,7 @@ class StorageNodeTestAccess {
       if (it == state->sessions.end()) return false;
       record = it->second;
     }
-    std::unique_lock lock(record->admission_mutex);
-    record->admission_cv.wait(lock, [&] {
-      return record->phase == StorageNode::SessionRecord::Phase::Closing;
-    });
+    record->WaitForClosing();
     return true;
   }
 
@@ -90,13 +93,17 @@ class StorageNodeTestAccess {
       state = node.state_;
     }
     if (state == nullptr) return false;
-    std::unique_lock lock(state->session_mutex);
-    auto it = state->sessions.find(sid);
-    if (it == state->sessions.end() ||
-        it->second->phase != StorageNode::SessionRecord::Phase::Active) {
-      return false;
+    std::optional<StorageNode::SessionRecord::AdmissionLease> admission;
+    std::shared_ptr<StorageNode::SessionRecord> record;
+    {
+      std::unique_lock lock(state->session_mutex);
+      auto it = state->sessions.find(sid);
+      if (it == state->sessions.end()) return false;
+      record = it->second;
+      admission = record->TryAcquire();
+      if (!admission.has_value()) return false;
+      record->overlay = std::move(overlay);
     }
-    it->second->overlay = std::move(overlay);
     return true;
   }
 };

--- a/src/storage_node_test_access.hpp
+++ b/src/storage_node_test_access.hpp
@@ -52,7 +52,7 @@ class StorageNodeTestAccess {
     }
     if (state == nullptr) return std::nullopt;
     std::shared_lock lock(state->session_mutex);
-    auto it = state->sessions.find(std::string(sid));
+    auto it = state->sessions.find(sid);
     if (it == state->sessions.end()) return std::nullopt;
     SessionResourceObservation observation;
     observation.record = it->second;
@@ -71,7 +71,7 @@ class StorageNodeTestAccess {
     std::shared_ptr<StorageNode::SessionRecord> record;
     {
       std::shared_lock state_lock(state->session_mutex);
-      auto it = state->sessions.find(std::string(sid));
+      auto it = state->sessions.find(sid);
       if (it == state->sessions.end()) return false;
       record = it->second;
     }
@@ -91,7 +91,7 @@ class StorageNodeTestAccess {
     }
     if (state == nullptr) return false;
     std::unique_lock lock(state->session_mutex);
-    auto it = state->sessions.find(std::string(sid));
+    auto it = state->sessions.find(sid);
     if (it == state->sessions.end() ||
         it->second->phase != StorageNode::SessionRecord::Phase::Active) {
       return false;

--- a/tests/unit/session_view_test.cpp
+++ b/tests/unit/session_view_test.cpp
@@ -24,6 +24,7 @@
 #include "sitos/in_memory_engine.hpp"
 #include "sitos/storage_node.hpp"
 #include "sitos/param_value.hpp"
+#include "storage_node_test_access.hpp"
 #include "transport/declaration_handle_test_access.hpp"
 
 namespace sitos {
@@ -163,6 +164,37 @@ class BlockingSnapshotEngine final : public InMemoryEngine {
 
  private:
   std::shared_ptr<BlockingReadControl> control_;
+};
+
+class BlockingOverlayEngine final : public StorageEngine {
+ public:
+  explicit BlockingOverlayEngine(std::shared_ptr<BlockingReadControl> control)
+      : control_(std::move(control)) {}
+
+  bool Put(std::string_view key, Bytes value) override {
+    control_->Enter();
+    std::lock_guard lock(mutex_);
+    value_ = std::vector<std::byte>(value.begin(), value.end());
+    key_ = std::string(key);
+    return true;
+  }
+
+  bool Delete(std::string_view) override { return false; }
+
+  bool Get(std::string_view key, const EntrySink& sink) const override {
+    control_->Enter();
+    std::lock_guard lock(mutex_);
+    if (key_ != key) return false;
+    return sink(key_, value_);
+  }
+
+  bool List(std::string_view, const EntrySink&) const override { return false; }
+
+ private:
+  std::shared_ptr<BlockingReadControl> control_;
+  mutable std::mutex mutex_;
+  std::string key_;
+  std::vector<std::byte> value_;
 };
 
 class TrackingSnapshotReader final : public StorageReader {
@@ -445,7 +477,7 @@ TEST(SessionViewTest, ListReleasesSnapshotBeforeSink) {
   EXPECT_TRUE(listed.IsOk());
 }
 
-TEST(SessionViewTest, CapturedReadCompletesAcrossClose) {
+TEST(SessionViewTest, CloseWaitsForCapturedRead) {
   TestTransport transport;
   auto control = std::make_shared<BlockingReadControl>();
   auto engine = std::make_shared<BlockingSnapshotEngine>(control);
@@ -455,14 +487,32 @@ TEST(SessionViewTest, CapturedReadCompletesAcrossClose) {
   ASSERT_TRUE(node.CreateSession("s1").IsOk());
   auto view = SessionView::Open(node, "s1");
   ASSERT_TRUE(view.IsOk());
+  const auto resources =
+      storage_node_test_access::StorageNodeTestAccess::ObserveSession(node, "s1");
+  ASSERT_TRUE(resources.has_value());
 
   Result<ParamValue> read = Result<ParamValue>::Err(Status::Error, "not started");
   std::thread reader([&] { read = view.Value().Get("key"); });
   control->WaitUntilEntered();
-  ASSERT_TRUE(node.CloseSession("s1").IsOk());
+  std::atomic<bool> close_returned{false};
+  Result<void> close_result = Result<void>::Err(Status::Error, "not started");
+  std::thread closer([&] {
+    close_result = node.CloseSession("s1");
+    close_returned.store(true, std::memory_order_release);
+  });
+  ASSERT_TRUE(storage_node_test_access::StorageNodeTestAccess::WaitForClosing(node, "s1"));
+  EXPECT_FALSE(close_returned.load(std::memory_order_acquire));
+  EXPECT_FALSE(resources->record.expired());
+  EXPECT_FALSE(resources->snapshot.expired());
+  EXPECT_FALSE(resources->overlay.expired());
   EXPECT_EQ(view.Value().Get("key").StatusCode(), Status::NotFound);
   control->Release();
   reader.join();
+  closer.join();
+  ASSERT_TRUE(close_result.IsOk());
+  EXPECT_TRUE(resources->record.expired());
+  EXPECT_TRUE(resources->snapshot.expired());
+  EXPECT_TRUE(resources->overlay.expired());
   ASSERT_TRUE(read.IsOk());
   auto value = read.Value().As<std::int64_t>();
   ASSERT_TRUE(value.has_value());
@@ -659,6 +709,47 @@ TEST(SessionViewTest, OpenRacingStopHasOnlyAdmissibleOutcomes) {
   if (opened.IsOk()) {
     EXPECT_EQ(opened.Value().Get("key").StatusCode(), Status::Disconnected);
   }
+}
+
+TEST(SessionViewTest, StaleViewRejectsSameSidReplacement) {
+  TestTransport transport;
+  auto engine = std::make_shared<InMemoryEngine>();
+  StorageNode node(transport);
+  ASSERT_TRUE(node.Start(engine, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+  auto control = std::make_shared<BlockingReadControl>();
+  auto blocking = std::make_shared<BlockingOverlayEngine>(control);
+  ASSERT_TRUE(storage_node_test_access::StorageNodeTestAccess::ReplaceSessionOverlay(
+      node, "s1", blocking));
+  auto stale = SessionView::Open(node, "s1");
+  ASSERT_TRUE(stale.IsOk());
+
+  Result<ParamValue> old_read = Result<ParamValue>::Err(Status::Error, "not started");
+  std::thread reader([&] { old_read = stale.Value().Get("old"); });
+  control->WaitUntilEntered();
+  std::atomic<bool> close_returned{false};
+  std::thread closer([&] {
+    EXPECT_TRUE(node.CloseSession("s1").IsOk());
+    close_returned.store(true, std::memory_order_release);
+  });
+  ASSERT_TRUE(storage_node_test_access::StorageNodeTestAccess::WaitForClosing(node, "s1"));
+  EXPECT_FALSE(close_returned.load(std::memory_order_acquire));
+  EXPECT_EQ(node.CreateSession("s1").Error(),
+            std::make_error_code(std::errc::operation_in_progress));
+  control->Release();
+  reader.join();
+  closer.join();
+  EXPECT_EQ(old_read.StatusCode(), Status::NotFound);
+
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+  auto fresh = SessionView::Open(node, "s1");
+  ASSERT_TRUE(fresh.IsOk());
+  transport.Publish("sitos/session/s1/replacement", ParamValue(std::int64_t{7}).Encode(),
+                    Encoding{std::string(Encoding::kSitosV1)});
+  EXPECT_EQ(stale.Value().Get("replacement").StatusCode(), Status::NotFound);
+  auto replacement = fresh.Value().Get<std::int64_t>("replacement");
+  ASSERT_TRUE(replacement.IsOk());
+  EXPECT_EQ(replacement.Value(), 7);
 }
 
 TEST(SessionViewTest, ConcurrentReaderAndSessionReplacementHaveSafeOutcomes) {

--- a/tests/unit/storage_node_test.cpp
+++ b/tests/unit/storage_node_test.cpp
@@ -1529,7 +1529,8 @@ class StopOrderedSnapshotReader final : public StorageReader {
     }
     control_->cv.notify_all();
     std::unique_lock lock(control_->mutex);
-    control_->cv.wait(lock, [this] { return control_->release; });
+    control_->cv.wait_for(lock, std::chrono::seconds(2),
+                          [this] { return control_->release; });
   }
 
   bool Get(std::string_view key, const EntrySink& sink) const override {
@@ -1617,7 +1618,8 @@ class DestructionTrackedEngine final : public StorageEngine {
     }
     control_->cv.notify_all();
     std::unique_lock lock(control_->mutex);
-    control_->cv.wait(lock, [this] { return control_->release; });
+    control_->cv.wait_for(lock, std::chrono::seconds(2),
+                          [this] { return control_->release; });
   }
 
   bool Put(std::string_view, Bytes) override { return true; }

--- a/tests/unit/storage_node_test.cpp
+++ b/tests/unit/storage_node_test.cpp
@@ -1,6 +1,7 @@
 // Copyright 2026 sitos contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sitos/session_view.hpp"
 #include "sitos/storage_node.hpp"
 
 #include <gtest/gtest.h>
@@ -15,6 +16,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <type_traits>
@@ -25,6 +27,7 @@
 #include "sitos/in_memory_engine.hpp"
 #include "sitos/logging.hpp"
 #include "sitos/param_value.hpp"
+#include "storage_node_test_access.hpp"
 #include "transport/declaration_handle_test_access.hpp"
 
 namespace sitos {
@@ -157,8 +160,10 @@ class FakeTransport final : public Transport {
     }
     ++subscriber_declarations;
     return Result<Subscription>::Ok(
-        transport_test_access::DeclarationHandleTestAccess::MakeSubscription(
-            [this] { ++subscriber_resets; }));
+        transport_test_access::DeclarationHandleTestAccess::MakeSubscription([this] {
+          ++subscriber_resets;
+          if (clear_callbacks_on_reset) subscriber_callback = {};
+        }));
   }
 
   void InvokeSubscriber(std::string key, TransportSample::Kind kind,
@@ -192,8 +197,10 @@ class FakeTransport final : public Transport {
       query_callback(query);
     }
     return Result<Queryable>::Ok(
-        transport_test_access::DeclarationHandleTestAccess::MakeQueryable(
-            [this] { ++queryable_resets; }));
+        transport_test_access::DeclarationHandleTestAccess::MakeQueryable([this] {
+          ++queryable_resets;
+          if (clear_callbacks_on_reset) query_callback = {};
+        }));
   }
 
   std::vector<ReplyRecord> Invoke(std::string keyexpr, bool fail_after_first = false) {
@@ -222,6 +229,7 @@ class FakeTransport final : public Transport {
   std::optional<ErrorInfo> queryable_failure;
   std::optional<ErrorInfo> subscriber_failure;
   bool invoke_queryable_during_declare = false;
+  bool clear_callbacks_on_reset = false;
   int queryable_declarations = 0;
   int subscriber_declarations = 0;
   int queryable_resets = 0;
@@ -1322,6 +1330,11 @@ TEST(StorageNodeSessionTest, CloseUnknownSessionFails) {
   FakeTransport transport;
   StorageNode node;
   ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos"}).IsOk());
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+  const auto malformed = node.CloseSession("bad/sid");
+  EXPECT_EQ(malformed.StatusCode(), Status::Error);
+  EXPECT_EQ(malformed.Error(), std::make_error_code(std::errc::no_such_file_or_directory));
+  EXPECT_TRUE(malformed.Message().empty());
   EXPECT_EQ(node.CloseSession("nope").Error(),
             std::make_error_code(std::errc::no_such_file_or_directory));
 }
@@ -1431,6 +1444,425 @@ TEST(StorageNodeSessionTest, CreateCloseLoopReleasesResources) {
     EXPECT_TRUE(transport.Invoke("sitos/session/s1/p").empty());
   }
   EXPECT_TRUE(node.ActiveSessions().empty());
+}
+
+class SnapshotFailureEngine final : public InMemoryEngine {
+ public:
+  enum class Failure { Healthy, Null, Throw, BadAlloc };
+
+  explicit SnapshotFailureEngine(Failure failure) : failure_(failure) {}
+
+  void SetFailure(Failure failure) { failure_ = failure; }
+
+  std::shared_ptr<const StorageReader> TakeSnapshot() const override {
+    switch (failure_) {
+      case Failure::Healthy:
+        return InMemoryEngine::TakeSnapshot();
+      case Failure::Null:
+        return nullptr;
+      case Failure::Throw:
+        throw std::runtime_error("snapshot failure");
+      case Failure::BadAlloc:
+        throw std::bad_alloc();
+    }
+    return nullptr;
+  }
+
+ private:
+  Failure failure_;
+};
+
+class FirstSnapshotBlockingEngine final : public InMemoryEngine {
+ public:
+  std::shared_ptr<const StorageReader> TakeSnapshot() const override {
+    const auto call = calls_.fetch_add(1, std::memory_order_acq_rel);
+    if (call == 0) {
+      {
+        std::lock_guard lock(mutex_);
+        entered_ = true;
+      }
+      cv_.notify_all();
+      std::unique_lock lock(mutex_);
+      cv_.wait(lock, [this] { return released_; });
+    }
+    return InMemoryEngine::TakeSnapshot();
+  }
+
+  void WaitEntered() {
+    std::unique_lock lock(mutex_);
+    ASSERT_TRUE(cv_.wait_for(lock, std::chrono::seconds(2), [this] { return entered_; }));
+  }
+
+  void Release() {
+    {
+      std::lock_guard lock(mutex_);
+      released_ = true;
+    }
+    cv_.notify_all();
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  mutable std::condition_variable cv_;
+  mutable std::atomic<unsigned> calls_{0};
+  mutable bool entered_ = false;
+  bool released_ = false;
+};
+
+class StopOrderedSnapshotReader final : public StorageReader {
+ public:
+  struct Control {
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool entered = false;
+    bool release = false;
+  };
+
+  StopOrderedSnapshotReader(std::shared_ptr<const StorageReader> inner,
+                            std::shared_ptr<Control> control)
+      : inner_(std::move(inner)), control_(std::move(control)) {}
+
+  ~StopOrderedSnapshotReader() override {
+    {
+      std::lock_guard lock(control_->mutex);
+      control_->entered = true;
+    }
+    control_->cv.notify_all();
+    std::unique_lock lock(control_->mutex);
+    control_->cv.wait(lock, [this] { return control_->release; });
+  }
+
+  bool Get(std::string_view key, const EntrySink& sink) const override {
+    return inner_->Get(key, sink);
+  }
+
+  bool List(std::string_view prefix, const EntrySink& sink) const override {
+    return inner_->List(prefix, sink);
+  }
+
+ private:
+  std::shared_ptr<const StorageReader> inner_;
+  std::shared_ptr<Control> control_;
+};
+
+class StopOrderedSnapshotEngine final : public InMemoryEngine {
+ public:
+  StopOrderedSnapshotEngine()
+      : setup_(std::make_shared<StopOrderedSnapshotReader::Control>()),
+        destruction_(std::make_shared<StopOrderedSnapshotReader::Control>()) {}
+
+  std::shared_ptr<const StorageReader> TakeSnapshot() const override {
+    {
+      std::lock_guard lock(setup_->mutex);
+      setup_->entered = true;
+    }
+    setup_->cv.notify_all();
+    {
+      std::unique_lock lock(setup_->mutex);
+      setup_->cv.wait(lock, [this] { return setup_->release; });
+    }
+    return std::make_shared<StopOrderedSnapshotReader>(InMemoryEngine::TakeSnapshot(),
+                                                       destruction_);
+  }
+
+  void WaitSetup() const {
+    std::unique_lock lock(setup_->mutex);
+    ASSERT_TRUE(setup_->cv.wait_for(lock, std::chrono::seconds(2),
+                                    [this] { return setup_->entered; }));
+  }
+
+  void ReleaseSetup() const {
+    {
+      std::lock_guard lock(setup_->mutex);
+      setup_->release = true;
+    }
+    setup_->cv.notify_all();
+  }
+
+  void WaitDestruction() const {
+    std::unique_lock lock(destruction_->mutex);
+    ASSERT_TRUE(destruction_->cv.wait_for(lock, std::chrono::seconds(2),
+                                          [this] { return destruction_->entered; }));
+  }
+
+  void ReleaseDestruction() const {
+    {
+      std::lock_guard lock(destruction_->mutex);
+      destruction_->release = true;
+    }
+    destruction_->cv.notify_all();
+  }
+
+ private:
+  std::shared_ptr<StopOrderedSnapshotReader::Control> setup_;
+  std::shared_ptr<StopOrderedSnapshotReader::Control> destruction_;
+};
+
+class DestructionTrackedEngine final : public StorageEngine {
+ public:
+  struct Control {
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool entered = false;
+    bool release = false;
+  };
+
+  explicit DestructionTrackedEngine(std::shared_ptr<Control> control)
+      : control_(std::move(control)) {}
+
+  ~DestructionTrackedEngine() override {
+    {
+      std::lock_guard lock(control_->mutex);
+      control_->entered = true;
+    }
+    control_->cv.notify_all();
+    std::unique_lock lock(control_->mutex);
+    control_->cv.wait(lock, [this] { return control_->release; });
+  }
+
+  bool Put(std::string_view, Bytes) override { return true; }
+  bool Delete(std::string_view) override { return true; }
+  bool Get(std::string_view, const EntrySink&) const override { return false; }
+  bool List(std::string_view, const EntrySink&) const override { return false; }
+
+  static void WaitEntered(const std::shared_ptr<Control>& control) {
+    std::unique_lock lock(control->mutex);
+    ASSERT_TRUE(control->cv.wait_for(lock, std::chrono::seconds(2),
+                                     [&] { return control->entered; }));
+  }
+
+  static void Release(const std::shared_ptr<Control>& control) {
+    {
+      std::lock_guard lock(control->mutex);
+      control->release = true;
+    }
+    control->cv.notify_all();
+  }
+
+ private:
+  std::shared_ptr<Control> control_;
+};
+
+TEST(StorageNodeSessionLifecycleTest, CreatingAndClosingCollisionsAreDeterministic) {
+  auto engine = std::make_shared<FirstSnapshotBlockingEngine>();
+  FakeTransport transport;
+  StorageNode node(transport);
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+
+  Result<void> creating = Result<void>::Err(Status::Error, "not started");
+  std::thread creator([&] { creating = node.CreateSession("s1"); });
+  engine->WaitEntered();
+
+  EXPECT_EQ(node.CreateSession("s1").Error(),
+            std::make_error_code(std::errc::operation_in_progress));
+  EXPECT_EQ(node.CloseSession("s1").Error(),
+            std::make_error_code(std::errc::operation_in_progress));
+  EXPECT_TRUE(node.ActiveSessions().empty());
+  EXPECT_TRUE(SessionView::Open(node, "s1").StatusCode() == Status::NotFound);
+  EXPECT_TRUE(transport.Invoke("sitos/snap/s1/key").empty());
+  EXPECT_TRUE(transport.Invoke("sitos/session/s1/key").empty());
+  EXPECT_TRUE(transport.Invoke("sitos/meta/session/s1").empty());
+
+  engine->Release();
+  creator.join();
+  ASSERT_TRUE(creating.IsOk());
+
+  auto blocking = std::make_shared<BlockingEngine>();
+  ASSERT_TRUE(storage_node_test_access::StorageNodeTestAccess::ReplaceSessionOverlay(
+      node, "s1", blocking));
+  const auto resources =
+      storage_node_test_access::StorageNodeTestAccess::ObserveSession(node, "s1");
+  ASSERT_TRUE(resources.has_value());
+  std::thread reader([&] { static_cast<void>(transport.Invoke("sitos/session/s1/key")); });
+  blocking->WaitForGet();
+  std::atomic<bool> closed{false};
+  std::thread closer([&] {
+    EXPECT_TRUE(node.CloseSession("s1").IsOk());
+    closed.store(true, std::memory_order_release);
+  });
+  ASSERT_TRUE(storage_node_test_access::StorageNodeTestAccess::WaitForClosing(node, "s1"));
+  EXPECT_FALSE(resources->record.expired());
+  EXPECT_FALSE(resources->snapshot.expired());
+  EXPECT_FALSE(resources->overlay.expired());
+  EXPECT_TRUE(node.ActiveSessions().empty());
+  EXPECT_EQ(SessionView::Open(node, "s1").StatusCode(), Status::NotFound);
+  EXPECT_TRUE(transport.Invoke("sitos/snap/s1/key").empty());
+  EXPECT_TRUE(transport.Invoke("sitos/session/s1/key").empty());
+  EXPECT_TRUE(transport.Invoke("sitos/meta/session/s1").empty());
+  EXPECT_EQ(node.CreateSession("s1").Error(),
+            std::make_error_code(std::errc::operation_in_progress));
+  EXPECT_FALSE(closed.load(std::memory_order_acquire));
+  EXPECT_EQ(node.CloseSession("s1").Error(),
+            std::make_error_code(std::errc::operation_in_progress));
+  blocking->Release();
+  reader.join();
+  closer.join();
+  blocking.reset();
+  EXPECT_TRUE(resources->record.expired());
+  EXPECT_TRUE(resources->snapshot.expired());
+  EXPECT_TRUE(resources->overlay.expired());
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+}
+
+TEST(StorageNodeSessionLifecycleTest, CreateRollbackAllowsSameSidRetry) {
+  for (const auto failure : {SnapshotFailureEngine::Failure::Null,
+                             SnapshotFailureEngine::Failure::Throw,
+                             SnapshotFailureEngine::Failure::BadAlloc}) {
+    FakeTransport transport;
+    StorageNode node(transport);
+    auto failing = std::make_shared<SnapshotFailureEngine>(failure);
+    ASSERT_TRUE(node.Start(failing, transport, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+    const auto result = node.CreateSession("s1");
+    EXPECT_EQ(result.StatusCode(), Status::Error);
+    EXPECT_EQ(result.Error(), MakeErrorCode(Status::Error));
+    EXPECT_EQ(result.Message(), failure == SnapshotFailureEngine::Failure::Null
+                                   ? "base snapshot creation returned null"
+                                   : "base snapshot creation threw an exception");
+    EXPECT_TRUE(node.ActiveSessions().empty());
+    EXPECT_FALSE(storage_node_test_access::StorageNodeTestAccess::ObserveSession(node, "s1")
+                     .has_value());
+    EXPECT_EQ(SessionView::Open(node, "s1").StatusCode(), Status::NotFound);
+    EXPECT_TRUE(transport.Invoke("sitos/snap/s1/key").empty());
+    EXPECT_TRUE(transport.Invoke("sitos/session/s1/key").empty());
+    EXPECT_TRUE(transport.Invoke("sitos/meta/session/s1").empty());
+    failing->SetFailure(SnapshotFailureEngine::Failure::Healthy);
+    EXPECT_TRUE(node.CreateSession("s1").IsOk());
+    node.Stop();
+  }
+}
+
+TEST(StorageNodeSessionLifecycleTest, CloseQuiescesAdmittedOperations) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  StorageNode node(transport);
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+  auto blocking = std::make_shared<BlockingEngine>();
+  ASSERT_TRUE(storage_node_test_access::StorageNodeTestAccess::ReplaceSessionOverlay(
+      node, "s1", blocking));
+  const auto query_resources =
+      storage_node_test_access::StorageNodeTestAccess::ObserveSession(node, "s1");
+  ASSERT_TRUE(query_resources.has_value());
+
+  std::thread query([&] { static_cast<void>(transport.Invoke("sitos/session/s1/key")); });
+  blocking->WaitForGet();
+  std::atomic<bool> closed{false};
+  std::thread closer([&] {
+    EXPECT_TRUE(node.CloseSession("s1").IsOk());
+    closed.store(true, std::memory_order_release);
+  });
+  ASSERT_TRUE(storage_node_test_access::StorageNodeTestAccess::WaitForClosing(node, "s1"));
+  EXPECT_FALSE(query_resources->record.expired());
+  EXPECT_FALSE(query_resources->snapshot.expired());
+  EXPECT_FALSE(query_resources->overlay.expired());
+  EXPECT_FALSE(closed.load(std::memory_order_acquire));
+  EXPECT_EQ(node.CreateSession("s1").Error(),
+            std::make_error_code(std::errc::operation_in_progress));
+  blocking->Release();
+  query.join();
+  closer.join();
+  blocking.reset();
+  EXPECT_TRUE(closed.load(std::memory_order_acquire));
+  EXPECT_TRUE(query_resources->record.expired());
+  EXPECT_TRUE(query_resources->snapshot.expired());
+  EXPECT_TRUE(query_resources->overlay.expired());
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+
+  auto subscriber_blocking = std::make_shared<BlockingEngine>();
+  ASSERT_TRUE(storage_node_test_access::StorageNodeTestAccess::ReplaceSessionOverlay(
+      node, "s1", subscriber_blocking));
+  const auto subscriber_resources =
+      storage_node_test_access::StorageNodeTestAccess::ObserveSession(node, "s1");
+  ASSERT_TRUE(subscriber_resources.has_value());
+  std::thread subscriber([&] {
+    transport.InvokeSubscriber("sitos/session/s1/write", TransportSample::Kind::Put,
+                               {std::byte{0x01}}, kV1);
+  });
+  subscriber_blocking->WaitForPut();
+  closed.store(false, std::memory_order_release);
+  std::thread subscriber_closer([&] {
+    EXPECT_TRUE(node.CloseSession("s1").IsOk());
+    closed.store(true, std::memory_order_release);
+  });
+  ASSERT_TRUE(storage_node_test_access::StorageNodeTestAccess::WaitForClosing(node, "s1"));
+  EXPECT_FALSE(subscriber_resources->record.expired());
+  EXPECT_FALSE(subscriber_resources->snapshot.expired());
+  EXPECT_FALSE(subscriber_resources->overlay.expired());
+  EXPECT_FALSE(closed.load(std::memory_order_acquire));
+  subscriber_blocking->Release();
+  subscriber.join();
+  subscriber_closer.join();
+  subscriber_blocking.reset();
+  EXPECT_TRUE(closed.load(std::memory_order_acquire));
+  EXPECT_TRUE(subscriber_resources->record.expired());
+  EXPECT_TRUE(subscriber_resources->snapshot.expired());
+  EXPECT_TRUE(subscriber_resources->overlay.expired());
+}
+
+TEST(StorageNodeSessionLifecycleTest, DestroysResourcesBeforeCloseReturns) {
+  auto engine = std::make_shared<InMemoryEngine>();
+  FakeTransport transport;
+  StorageNode node(transport);
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  ASSERT_TRUE(node.CreateSession("s1").IsOk());
+  auto control = std::make_shared<DestructionTrackedEngine::Control>();
+  auto tracked = std::make_shared<DestructionTrackedEngine>(control);
+  std::weak_ptr<DestructionTrackedEngine> weak = tracked;
+  ASSERT_TRUE(storage_node_test_access::StorageNodeTestAccess::ReplaceSessionOverlay(
+      node, "s1", tracked));
+  const auto resources =
+      storage_node_test_access::StorageNodeTestAccess::ObserveSession(node, "s1");
+  ASSERT_TRUE(resources.has_value());
+  tracked.reset();
+
+  std::atomic<bool> closed{false};
+  std::thread closer([&] {
+    EXPECT_TRUE(node.CloseSession("s1").IsOk());
+    closed.store(true, std::memory_order_release);
+  });
+  DestructionTrackedEngine::WaitEntered(control);
+  EXPECT_FALSE(closed.load(std::memory_order_acquire));
+  EXPECT_FALSE(resources->record.expired());
+  EXPECT_EQ(node.CloseSession("s1").Error(),
+            std::make_error_code(std::errc::operation_in_progress));
+  EXPECT_TRUE(node.ActiveSessions().empty());
+  DestructionTrackedEngine::Release(control);
+  closer.join();
+  EXPECT_TRUE(closed.load(std::memory_order_acquire));
+  EXPECT_TRUE(resources->record.expired());
+  EXPECT_TRUE(resources->snapshot.expired());
+  EXPECT_TRUE(resources->overlay.expired());
+  EXPECT_TRUE(weak.expired());
+}
+
+TEST(StorageNodeSessionLifecycleTest, StopWaitsForAdmittedCreate) {
+  auto engine = std::make_shared<StopOrderedSnapshotEngine>();
+  FakeTransport transport;
+  transport.clear_callbacks_on_reset = true;
+  StorageNode node(transport);
+  ASSERT_TRUE(node.Start(engine, transport, {.prefix = "sitos", .log_sink = nullptr}).IsOk());
+  Result<void> created = Result<void>::Err(Status::Error, "not started");
+  std::thread creator([&] { created = node.CreateSession("s1"); });
+  engine->WaitSetup();
+  const auto gate_observer =
+      storage_node_test_access::StorageNodeTestAccess::CaptureGateObserver(node);
+  ASSERT_TRUE(gate_observer.has_value());
+  std::atomic<bool> stopped{false};
+  std::thread stopper([&] {
+    node.Stop();
+    stopped.store(true, std::memory_order_release);
+  });
+  ASSERT_TRUE(gate_observer->WaitForClosed());
+  EXPECT_FALSE(stopped.load(std::memory_order_acquire));
+  engine->ReleaseSetup();
+  creator.join();
+  ASSERT_TRUE(created.IsOk());
+  engine->WaitDestruction();
+  EXPECT_FALSE(stopped.load(std::memory_order_acquire));
+  engine->ReleaseDestruction();
+  stopper.join();
+  EXPECT_TRUE(stopped.load(std::memory_order_acquire));
+  EXPECT_FALSE(node.IsStarted());
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Closes #140

This PR implements the frozen stage-2 StorageNode Session admission lifecycle. It replaces the
separate internal ownership tables with generation-safe `SessionRecord` state, admission leases,
rollback-safe creation, Close/Stop quiescence, and deterministic lifecycle coverage. It does not
implement buffers, routing, public factories, wire behavior, or the final #56 integration.

## Requirements

F05, F06, F07, F08, F10, and N07 from `docs/01_requirements.md`; ADR-0017, ADR-0025, and the
accepted lifecycle/ownership/lock-order constraints of ADR-0032. ADR-0025 weak State plus weak
overlay-owner generation identity is preserved. F10 Session resource release and stale-generation
rejection are directly exercised by the SessionView tests.

## Contract Registry

N/A. This stage changes no Contract Registry row; the mixed-buffer implementation remains Planned
under ADR-0032. No transition is made.

## Frozen Issue Checklist

The following is copied from the frozen Issue #140 body. Checked items are implemented or locally
verified; hosted-only sanitizer executions and one-time owner merge authorization remain unchecked.

## Summary

Replace StorageNode's separate Session ownership tables with one generation-safe SessionRecord
and admission lifecycle while preserving all existing parameter, snapshot, Session, stopped-node,
and Python behavior.

This is stage 2 of the owner-approved Issue #56 split in `DEC-56-SPLIT-001`. It provides the
concurrency and lifetime foundation required by mixed buffers but exposes no buffer capability or
wire behavior.

## Branch

`feat/140-session-admission-lifecycle`

## Dependencies and stage boundary

- #139 was merged by PR #142.
- Parent integration issue: #56.
- #141 depends on this issue and #139.
- Contract Registry change: none; the mixed-buffer implementation remains Planned.
- #143 considers future stopped-node result unification and does not block this issue.

## Normative references

- ADR-0017 atomic StorageNode lifecycle
- ADR-0025 SessionView lifetime and weak overlay-owner generation identity
- ADR-0032 lifecycle, lock-order, ownership, and re-entry constraints
- `docs/01_requirements.md` F05, F06, F07, F08, F10, and N07
- `docs/02_architecture.md` StorageNode State and Session lifecycle
- `docs/04_api_cpp.md` Session lifecycle and thread-safety contract
- `docs/06_build_test_packaging.md` §5.1.1 acceptance-name authority
- `DEC-133-LIFECYCLE-001`:
  https://github.com/tetsuh/sitos/issues/133#issuecomment-5129230080
- `DEC-133-REENTRANCY-001`:
  https://github.com/tetsuh/sitos/issues/133#issuecomment-5139427185
- `DEC-56-STOP-CREATE-001`:
  https://github.com/tetsuh/sitos/issues/56#issuecomment-5143758077
- `DEC-56-SETUP-FAILURE-001`:
  https://github.com/tetsuh/sitos/issues/56#issuecomment-5143845545
- `DEC-140-STOP-STATUS-002`:
  https://github.com/tetsuh/sitos/issues/140#issuecomment-5149241315
- `DEC-140-REENTRANCY-001`:
  https://github.com/tetsuh/sitos/issues/140#issuecomment-5149070665
- `DEC-140-SANITIZER-REPEAT-001`:
  https://github.com/tetsuh/sitos/issues/140#issuecomment-5149184376

## Compatibility and ADR boundary

- [x] Preserve the existing one-argument `CreateSession(std::string_view)` public signature.
- [x] Preserve the current C++ and Python stopped-node results listed below.
- [x] Retain public `SessionMeta`, `SnapshotTable`, `OverlayTable`, and `SessionTable` aliases for
  source compatibility; StorageNode must no longer use the three aliases as ownership tables.
- [x] Update only the comments in `include/sitos/session.hpp` so they describe those aliases as
  compatibility types rather than active StorageNode ownership or membership sources.
- [x] Add no public Session type, factory, capability, test hook, or wire behavior.
- [x] Require no new ADR because this issue changes no public API behavior, wire protocol, thread
  model selected by accepted ADRs, dependency invariant, build platform, or Contract Registry row.

## Lifecycle and result contract

- [x] Replace the separate snapshots, overlays, and Session metadata ownership tables with one
  `shared_ptr<SessionRecord>` map owned by callback-shared StorageNode State.
- [x] Keep `SessionRecord`, phase, admission, and all synchronization implementation private to
  StorageNode.
- [x] Each record owns its phase, immutable snapshot, mutable overlay, metadata, and admission gate.
- [x] Use the exact phases Creating, Active, and Closing.
- [x] Insert a Creating reservation before calling external snapshot code. A creator may commit only
  its same still-Creating record.
- [x] Only Active to Closing succeeds. Close admission atomically with that phase transition.
- [x] Atomically find an Active record and acquire its admission while holding the Session-state
  mutex before any callback or SessionView operation copies or uses Session resources.
- [x] Perform snapshot creation, engine/reader calls, admission waiting, resource destruction, and
  LogSink calls outside the Session-state mutex.
- [x] Preserve lock order: node callback gate, whole-subscriber mutex when applicable,
  Session-state mutex, then per-Session admission.
- [x] Keep active Session enumeration limited to Active records.

The exact public C++ results are:

| Condition | Status | Cause | Message |
|---|---|---|---|
| malformed SID passed to Create | `InvalidArgument` | `invalid_argument` | empty |
| malformed SID passed to Close on an active node | `Error` | `no_such_file_or_directory` | empty |
| stopped Create or Close | `InvalidArgument` | `invalid_argument` | empty |
| Create or Close against Creating/Closing | `Error` | `operation_in_progress` | empty |
| duplicate Create against Active | `Error` | `file_exists` | empty |
| Close of an absent SID on an active node | `Error` | `no_such_file_or_directory` | empty |
| stopped SessionView Open/read | existing `Disconnected` behavior | unchanged | unchanged |
| stale/non-Active View generation | existing `NotFound` behavior | unchanged | unchanged |

`ActiveSessions` returns an empty vector when stopped. Creating and Closing records are absent from
`ActiveSessions`, appear as NotFound to SessionView, produce zero Session/snapshot/meta query
replies, and admit no Session-scoped subscriber resource access or mutation.

## Creation and rollback

- [x] Prepare the snapshot, overlay, metadata, and other pre-factory resources outside the
  Session-state mutex while the same Creating record remains reserved.
- [x] `TakeSnapshot()` returning null yields `Status::Error`,
  `MakeErrorCode(Status::Error)`, and `base snapshot creation returned null`.
- [x] Any exception escaping `TakeSnapshot()`, including `std::bad_alloc`, yields `Status::Error`,
  `MakeErrorCode(Status::Error)`, and `base snapshot creation threw an exception`.
- [x] Both snapshot failures release all attempt-created resources, remove only the same Creating
  reservation, leave it externally non-Active, and allow a same-SID retry.
- [x] An unrecoverable node-internal allocation failure outside `TakeSnapshot()` may propagate. Once
  a reservation exists, an RAII rollback guard must remove only that reservation and release all
  attempt-created resources before propagation.

## Close destruction order

- [x] Close keeps strong local ownership of the same Closing record after atomically closing its
  admission and releasing the Session-state mutex.
- [x] Close waits for all admitted resource users, keeps admission permanently closed, destroys the
  record's snapshot, overlay, metadata, and other Session resources, then erases only that same map
  entry and releases the local record before returning.
- [x] Keep the SID reserved through resource destruction. Same-SID recreation starts only after the
  Closing record is erased and all prior-generation resources are destroyed.
- [x] Emit diagnostics only after releasing the whole-subscriber, Session-state, and Session
  admission locks. A node callback-gate lease may remain held as required by Stop quiescence.

## SessionView, Stop, and re-entry safety

- [x] Preserve ADR-0025: each SessionView retains weak State and the existing weak overlay-owner
  generation identity; it does not retain SessionRecord or Session resources strongly.
- [x] On each View operation, atomically match that overlay owner to the same Active SessionRecord
  and acquire admission before copying the reader pair.
- [x] A stale View must never read a replacement generation with the same SID.
- [x] Materialize and validate View results, then release copied readers, admission, and the node
  gate before invoking a caller sink so sink re-entry remains safe.
- [x] Replace the old captured-read behavior: Close waits for an already admitted View read and
  releases all prior-generation resources before returning.
- [x] Preserve the node callback gate as the Stop quiescence boundary.
- [x] A Create admitted before Stop closes the node gate retains completion rights. If setup
  succeeds, it commits and returns Ok before Stop releases that Session and returns.
- [x] A Create or Close that cannot enter the stopped node preserves the InvalidArgument contract in
  `DEC-140-STOP-STATUS-002`; no stop-request cancellation flag is added.
- [x] Apply `DEC-140-REENTRANCY-001`: host-provided StorageEngine/StorageReader calls must not
  synchronously invoke or wait for same-node Close, Stop, destruction, or another lifecycle
  operation that waits for callback/admission quiescence.
- [x] Preserve the corresponding unsupported synchronous waiting-lifecycle re-entry boundary for
  Transport callbacks, synchronous reply handlers, the future durable factory, and LogSink.
- [x] Add no runtime re-entry detection or thread-local status path. Non-blocking asynchronous
  requests and independent-thread operations remain allowed under the owner decision.

## TDD and fixed acceptance tests

Write every fixed test before production edits. For each test, record the failing test name, exact
command, expected failure reason, expected assertion, representative observed failure-message line,
and later GREEN command in the PR body. A fixed test must add at least one assertion that fails on
merged main; renaming or copying an already-green characterization is not RED evidence. Use
deterministic barriers or latches only. Fixed sleeps and polling loops are prohibited.

- [x] `StorageNodeSessionLifecycleTest.CreatingAndClosingCollisionsAreDeterministic`
  - Block creation after its Creating reservation exists and prove same-SID Create/Close return
    `operation_in_progress`, enumeration excludes the SID, View Open is NotFound, and wire queries
    return zero replies.
  - Hold an admitted operation while Close is Closing and prove the same collisions and visibility,
    then release it and prove destruction precedes successful same-SID recreation.
- [x] `StorageNodeSessionLifecycleTest.CreateRollbackAllowsSameSidRetry`
  - Cover null snapshot, ordinary throw, and `std::bad_alloc` escaping `TakeSnapshot()` with exact
    Status/cause/message, external invisibility, complete rollback, and successful same-SID retry.
- [x] `StorageNodeSessionLifecycleTest.CloseQuiescesAdmittedOperations`
  - Independently block an admitted Session-scoped query and subscriber write, prove Close cannot
    return or destroy resources before release, then prove both operations and Close complete.
- [x] `StorageNodeSessionLifecycleTest.DestroysResourcesBeforeCloseReturns`
  - Track snapshot, overlay, and record ownership; block destruction, prove the SID remains
    reserved, then prove all prior-generation ownership expires before Close returns.
- [x] `StorageNodeSessionLifecycleTest.StopWaitsForAdmittedCreate`
  - Hold snapshot setup after reservation, start Stop, prove neither operation returns prematurely,
    release setup, and prove Create commits before Stop destroys its resources and returns.
- [x] `SessionViewTest.CloseWaitsForCapturedRead`
  - Replace `CapturedReadCompletesAcrossClose`; prove an admitted blocked read prevents Close from
    returning, then completes successfully before resource destruction and Close return.
- [x] `SessionViewTest.StaleViewRejectsSameSidReplacement`
  - Block an old-generation read, prove recreation is rejected while Closing, then recreate and
    prove only the fresh View reads replacement data while the stale View remains NotFound.

A source-private friend test access header may install a blocking/tracked overlay in an Active
record and observe weak ownership for deterministic subscriber and destruction tests. It may also
capture a non-owning callback-gate observer while an admitted Create independently pins State, and
wait on an explicit notification that the gate is non-accepting and Stop has entered quiescence.
The production gate must notify its existing condition variable immediately after setting
`accepting = false` and before entering the quiescence wait. The seam must add no public Config/API
field, shipped test symbol, production behavior branch, owning State reference, or test-only
duplicate implementation.

## Sanitizer validation

- [x] Add `StorageNodeSessionLifecycleTest` to the existing ASan/UBSan and TSan lifecycle filters in
  both `.github/workflows/ci.yml` and the reproducible commands in
  `docs/06_build_test_packaging.md` §5.2; `SessionViewTest` is already selected.
- [ ] Run the selected lifecycle tests once in the existing common ASan/UBSan step.
- [ ] Preserve the existing TSan lifecycle `--repeat until-fail:10` plus common single run.
- [ ] Preserve the existing two-test TSan subscription `--repeat until-fail:100` regression.
- [x] Keep each CTest timeout at 60 seconds and the sanitizer job timeout at 15 minutes.
- [x] Add a GREEN characterization assertion to the existing Session operation test proving that
  malformed Close on an active node remains `Error` / `no_such_file_or_directory` / empty message;
  do not report that already-supported behavior as RED evidence.
- [x] Keep existing CreateSession, snapshot, overlay, enumeration, re-entrant sink, and Stop tests
  green except for the explicitly replaced captured-read expectation.

## Expected implementation files

- `include/sitos/storage_node.hpp`
- `include/sitos/session.hpp` (comment-only compatibility clarification)
- `src/storage_node.cpp`
- `src/session_view.cpp`
- `src/storage_node_test_access.hpp` (source-private deterministic test access only)
- `tests/unit/storage_node_test.cpp`
- `tests/unit/session_view_test.cpp`
- `.github/workflows/ci.yml` (existing sanitizer filters only)
- `docs/06_build_test_packaging.md` (§5.2 sanitizer regexes only)

No `tests/CMakeLists.txt`, Python binding/test, ADR, Contract Registry, package, or other
documentation change is expected. Any additional path requires a new owner decision and renewed
independent review before implementation.

## Out of scope

- stopped-node result unification tracked by #143
- removal or signature changes of existing public Session aliases and APIs
- `SessionOptions`, `DurableBufferEngineFactory`, or other #141 public API
- buffer routing, capability, bare-byte admission, or durable engine behavior
- RocksDB-specific behavior, raw Zenoh, package, relocation, or combined CI validation
- physical Session directory removal or restart recovery
- Issues #105-#108 behavior

## Governance

- [x] Independent pre-implementation review completed against this exact body.
- [x] Owner declares this exact checklist ready and frozen for implementation.
- [x] RED evidence is captured before production edits.
- [x] Independent exact-head review is completed.
- [ ] Separate one-time owner merge authorization is recorded.


## Acceptance Criteria Verification

### Build and tests

Exact commands and results:

```text
cmd //c C:/Users/tetet/AppData/Local/Temp/run-issue140-fix.bat
# MSVC 19.51.36248.0, Debug, SITOS_WITH_ZENOH=OFF; build and focused lifecycle CTest: 5/5 passed

build-issue140-fix/tests/sitos_storage_node_test.exe --gtest_color=no
# 63/63 tests passed

build-issue140-fix/tests/sitos_session_view_test.exe --gtest_color=no
# 23/23 tests passed

ctest --output-on-failure --timeout 60 --repeat until-fail:10 \
  -R 'StorageNodeSessionLifecycleTest|SessionViewTest\.(CloseWaitsForCapturedRead|StaleViewRejectsSameSidReplacement)'
# 7/7 selected tests passed across 10 repetitions
```

The final candidate fingerprint over the nine authorized paths is:
`59b7188daeb6ea2b2eab1892500bd262566db4a5444cd1f2fc8325e8f8b03511`.

### RED-phase chronology and evidence

Tests were written before production edits. The contemporaneous RED stopped at the unresolved
source-private test seam link, not at assertion-level production failures:

```text
Command: cmd //c C:/Users/tetet/AppData/Local/Temp/build-issue140-red4.bat
Failing stage: link of the test executable
Expected reason: the temporary source-private ReplaceSessionOverlay seam had no implementation
Representative line: error LNK2019: unresolved external symbol ...StorageNodeTestAccess::ReplaceSessionOverlay(...)
```

Per DEC-140-TDD-001, the following assertion-level evidence is explicitly retrospective, not
contemporaneous. It was reproduced against final test bytes on detached merged-main with only
baseline compatibility instrumentation:

```text
Command: cmd //c C:/Users/tetet/AppData/Local/Temp/build-issue140-baseline-final.bat
Storage: sitos_storage_node_test.exe --gtest_filter='StorageNodeSessionLifecycleTest.*' --gtest_color=no
SessionView: sitos_session_view_test.exe --gtest_filter='SessionViewTest.CloseWaitsForCapturedRead:SessionViewTest.StaleViewRejectsSameSidReplacement' --gtest_color=no
```

- `StorageNodeSessionLifecycleTest.CreatingAndClosingCollisionsAreDeterministic`: baseline lacked
  unified Creating/Closing lifecycle and external visibility; representative `storage_node_test.cpp(1657)`:
  `node.CreateSession("s1").Error()` was `generic:17` instead of `generic:112`, with additional
  ActiveSessions/meta and weak-lifetime assertion failures.
- `StorageNodeSessionLifecycleTest.CreateRollbackAllowsSameSidRetry`: baseline did not preserve
  exact failure messages; representative `storage_node_test.cpp(1720)` reported `baseline snapshot
  null` instead of `base snapshot creation returned null` (throw and bad_alloc similarly reported
  `baseline snapshot exception`).
- `StorageNodeSessionLifecycleTest.CloseQuiescesAdmittedOperations`: baseline released resources
  and returned Close immediately; representative `storage_node_test.cpp(1755)` reported
  `query_resources->record.expired()` Actual true / Expected false, with snapshot and close-return
  failures.
- `StorageNodeSessionLifecycleTest.DestroysResourcesBeforeCloseReturns`: baseline expired the
  record before Close quiescence; representative `storage_node_test.cpp(1825)` reported
  `resources->record.expired()` Actual true / Expected false.
- `StorageNodeSessionLifecycleTest.StopWaitsForAdmittedCreate`: baseline had no safe captured
  observer notification boundary; representative `storage_node_test.cpp(1855)` reported
  `gate_observer->WaitForClosed()` Actual false / Expected true.
- `SessionViewTest.CloseWaitsForCapturedRead`: baseline returned Close immediately; representative
  `session_view_test.cpp(504)` reported `close_returned` Actual true / Expected false.
- `SessionViewTest.StaleViewRejectsSameSidReplacement`: baseline returned Close immediately;
  representative `session_view_test.cpp(736)` reported `close_returned` Actual true / Expected false.

The malformed active-node Close assertion is a GREEN characterization only and was not reported as
RED evidence.

### Sanitizer and hosted residual gates

The sanitizer filters and reproducible documentation commands were synchronized, but this local
MSVC Zenoh-OFF run did not execute Linux, ASan/UBSan, TSan, Zenoh-ON, Python, package, relocation,
or hosted CI validation. These remain required hosted gates. No hosted check is claimed as passed.

## RED-phase Evidence

- Command: see the contemporaneous `build-issue140-red4.bat` link failure and the separate
  retrospective baseline commands above.
- Failing test names: all seven fixed names listed above for retrospective reproduction.
- Expected failure reason: merged-main lacked SessionRecord phases, admission quiescence, rollback,
  safe Stop gate observation, and generation-safe Close behavior.
- Representative failure-message lines: listed per test above.
- Complete CI-log link: N/A; hosted CI has not yet been run for this head.

## ADR Needed?

- [x] No — no new ADR is required. This implements already accepted lifecycle contracts and changes
  no wire protocol, public API, dependency, platform, or Contract Registry invariant.
- [ ] Yes — ADR PR: N/A

## Scope and exclusions

Exact authorized paths:

- `.github/workflows/ci.yml`
- `docs/06_build_test_packaging.md`
- `include/sitos/session.hpp`
- `include/sitos/storage_node.hpp`
- `src/session_view.cpp`
- `src/storage_node.cpp`
- `src/storage_node_test_access.hpp`
- `tests/unit/session_view_test.cpp`
- `tests/unit/storage_node_test.cpp`

Excluded: buffers and routing, #141 public API, `SessionOptions`, durable factories, RocksDB/raw
Zenoh/package/relocation integration, Python bindings, ADR files, Contract Registry transition,
#143 stopped-result unification, and Issues #105–#108 behavior.

## Independent review

Final independent Sol and Terra reviews at candidate fingerprint
`59b7188daeb6ea2b2eab1892500bd262566db4a5444cd1f2fc8325e8f8b03511` both returned
`MERGE — HANDOFF READY` with no Blocker, Major, or Minor findings. The source-private helper UAF
correction and reverse destruction ordering were included before this commit.

DEC-140-TDD-001: https://github.com/tetsuh/sitos/issues/140#issuecomment-5149771261

## Owner Merge Authorization

Complete this section only after the owner authorizes this exact PR head. Leave the status as
`Pending` when opening or updating the PR.

- Status: Authorized
- Authorized head SHA: `fa9049fc9cc2d509c7811a69c056e00e17059c3f`
- Owner instruction link: https://github.com/tetsuh/sitos/pull/144#issuecomment-5150509007

Authorization is one-time, expires after a new commit or new blocking finding, and never enables
auto-merge.

## Sonar remediation publication

This PR now includes commit `3f711c9` (`fix(node): satisfy Session lifecycle quality gate (#140)`).
It is limited to the four previously authorized paths and addresses the six reported findings:

- `AZ-79GHL_sm3M2mrZNRQ` / `cpp:S6045` — private C++20 transparent SessionKeyHash,
  `std::equal_to<>`, and heterogeneous session lookup.
- `AZ-79F_L_sm3M2mrZNRJ` / `cpp:S5350` — const-reference SessionRecord binding.
- `AZ-79GGE_sm3M2mrZNRM` / `cpp:S6030` — correct `try_emplace` Session insertion.
- `AZ-79GGE_sm3M2mrZNRN` / `cpp:S3624` — explicit non-copyable/non-movable
  SessionRollbackGuard with noexcept RAII destruction.
- `AZ-79GGE_sm3M2mrZNRK` / `cpp:S3646` — separate rollback-guard declaration and initialization.
- `AZ-79GGE_sm3M2mrZNRO` / `cpp:S3776` — one private AcquireSession helper deduplicates the
  OnSample Session and batch-Session lookup/admission paths, reducing duplication and complexity;
  OnQuery remains the previously reviewed structure.

The SessionAccess lifetime order is `AdmissionLease` first, then `shared_ptr<SessionRecord>`, so
reverse destruction releases admission before the prior-generation record/resource owner. SessionView
uses heterogeneous `find(sid)` without a lookup-only temporary string.

Validation for commit `3f711c9`:

- MSVC Zenoh-OFF build and focused lifecycle tests: 5/5 passed.
- Full StorageNode: 63/63 passed.
- Full SessionView: 23/23 passed.
- Fixed 7-test selection: 7/7 passed across 10 repetitions.
- `git diff --check`, changed-line length, authorized-path, forbidden-token, YAML, staging, and
  artifact checks passed before publication.
- Final independent Sol and Terra reviews for candidate fingerprint
  `e648e77e7a4bb558ed03e242487f0f000814584bbee3132330d785cc31d42621` returned HANDOFF READY with
  no findings.

Refreshed hosted SonarCloud Quality Gate and all hosted CI checks are pending. No hosted check is
claimed as passed. Exact-head owner merge authorization remains unchecked and pending; this PR has
not been merged and auto-merge is not enabled.

## Final CodeRabbit/Sonar remediation

This PR now includes commit `fa9049f` (`fix(node): synchronize Session lifecycle state (#140)`).
The six-path remediation is limited to the previously authorized scope:

- Session phase and `accepting` are owned exclusively by `admission_mutex`; `Activate`, `IsActive`,
  `TryAcquire`, and `BeginClose` publish/inspect state under that mutex, activation verifies
  Creating and notifies after the synchronized update, and direct phase reads were eliminated.
- `ObserveSession` retains `session_mutex` through Active admission and weak resource copies;
  `ReplaceSessionOverlay` holds an Active admission lease through replacement. Both preserve
  `session_mutex -> admission_mutex` ordering and exclude concurrent resource reset.
- Added the direct `<shared_mutex>` include, replaced POSIX `+=` lifecycle-filter fragments with
  `${lifecycle_filter}` concatenation, and bounded both tracked test destructor predicate waits to
  two seconds.
- Applied both `cpp:S6004` fixes with C++17 if-init statements in `AcquireSession` and OnSample.
- The transparent heterogeneous Session hash/`std::equal_to<>` remediation was already included in
  commit `3f711c9` and was not changed here.
- The review-summary nitpicks for bounded destructor waits and transparent hash are covered above;
  no separate aggregate comment is needed.

Validation for `fa9049f`:

- StorageNode: 63/63 passed.
- SessionView: 23/23 passed.
- Fixed lifecycle selection: 7/7 passed across 10 repetitions.
- Focused destructor/Stop ordering tests: 2/2 passed.
- Final exact-candidate Sol and Terra reviews returned HANDOFF READY with no findings.

Refreshed hosted SonarCloud Quality Gate and hosted CI remain pending. No refreshed hosted check is
claimed as passed. The frozen checklist, `Closes #140`, DEC-140-TDD-001 truthful RED evidence, and
unchecked exact-head owner merge authorization remain unchanged. This PR is not merged and
auto-merge is not enabled.

