### PR TITLE
feat(storage): implement mixed Session buffer routing (#141)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,8 @@ jobs:
             --repeat until-fail:100 \
             -R 'ParamStoreSubscribeTest.(CloseWaitsForBlockedCallback|DeclarationFailureWaitsForAdmittedCallbackCopy)'
           lifecycle_filter="StorageNodeLifecycleTest|StorageNodeSessionTest|"
-          lifecycle_filter+="StorageNodeSessionLifecycleTest|StorageNodeBatchTest|"
+          lifecycle_filter+="StorageNodeSessionLifecycleTest|StorageNodeBufferLifecycleTest|"
+          lifecycle_filter+="StorageNodeBufferRoutingTest|StorageNodeBufferApiTest|StorageNodeBatchTest|"
           lifecycle_filter+="TransportGetCompletionTest|ParamStoreSubscribeTest|"
           lifecycle_filter+="ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture"
           ctest --test-dir build/sanitizer-tsan --output-on-failure --timeout 60 \
@@ -161,7 +162,8 @@ jobs:
           UBSAN_OPTIONS: halt_on_error=1
         run: |
           lifecycle_filter="StorageNodeLifecycleTest|StorageNodeSessionTest|"
-          lifecycle_filter+="StorageNodeSessionLifecycleTest|StorageNodeBatchTest|"
+          lifecycle_filter+="StorageNodeSessionLifecycleTest|StorageNodeBufferLifecycleTest|"
+          lifecycle_filter+="StorageNodeBufferRoutingTest|StorageNodeBufferApiTest|StorageNodeBatchTest|"
           lifecycle_filter+="TransportGetCompletionTest|ParamStoreSubscribeTest|"
           lifecycle_filter+="ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture"
           ctest --test-dir build/sanitizer-${{ matrix.name }} \

--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -157,6 +157,15 @@ Conventions:
 
 ### 4.2 Data Structures
 
+Stage #141 implements the mixed buffer routes with `SessionOptions` and a
+node-owned `DurableBufferEngineFactory`. Durable PUT admission accepts only
+`zenoh/bytes`, performs the engine read/compare/write sequence under the
+subscriber mutex, and retains no failed-key reservation. Ephemeral PUTs are
+capability-checked and never enter node storage. Durable query results are
+materialized before releasing Session admission; engine collection failures
+produce zero replies, while reply-handler failures after dispatch suppress
+subsequent replies without promising atomic transport replies.
+
 ```cpp
 enum class SessionPhase { Creating, Active, Closing };
 

--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -226,10 +226,12 @@ factory and resources cannot come from a different Start generation. The factory
 Only a valid, non-null durable engine may commit `Creating` to `Active`. For a
 Session requesting durable buffers, a factory `Err` is returned with its status, cause, and
 message preserved; an empty factory, `Ok(nullptr)`, or a factory exception is a non-OK
-failure. The exact Status taxonomy for empty, null, and exception outcomes is deferred to the
-Issue #56 scope freeze. Exceptions are contained. Every non-commit
-path releases all resources created by that attempt and removes only the same `Creating`
-reservation under `session_mutex`, so the same SID can be retried.
+failure. DEC-56-FACTORY-FAILURE-001 defines the exact taxonomy: a missing factory is
+`Status::InvalidArgument` with `std::errc::invalid_argument` and the message `durable buffer
+engine factory is required`; null success and exceptions are `Status::Error` with their exact
+public messages; and factory `Err` values are preserved. Exceptions are contained. Every
+non-commit path releases all resources created by that attempt and removes only the same
+`Creating` reservation under `session_mutex`, so the same SID can be retried.
 
 `CloseSession` changes only an `Active` record to `Closing`; a `Creating` or `Closing` record
 returns `std::errc::operation_in_progress`, and a missing record retains

--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -213,15 +213,21 @@ Session resources. Readers copy ownership only while the record is active, so cl
 invalidate an in-flight reply. The node-wide callback gate still makes `Stop()` quiescent.
 
 The phase contract is exact: `absent → Creating → Active` for creation, and
-`Active → Closing → absent` for close. `CreateSession` reserves a non-queryable
+`Active → Closing → absent` for close. If the node State is absent, or a callback has captured a
+State whose lifecycle gate is closed before admission, both `CreateSession(std::string_view)`
+overloads return `Status::InvalidArgument` with cause `std::errc::invalid_argument` and an empty
+message, as required by DEC-140-STOP-STATUS-002. This method-specific exception is distinct from
+generic disconnected statuses documented for other APIs. `CreateSession` reserves a non-queryable
 `Creating` record before external factory creation. Creation against `Creating` or `Closing` returns
 `std::errc::operation_in_progress`, while a duplicate `Active` creation retains
 `std::errc::file_exists`. The creator commits only after taking `session_mutex` and verifying
 that the same reservation still exists and remains `Creating`; it then changes that record to
 `Active`. The reservation lock is released before external factory or engine operations and
-logging. `CreateSession` uses the callback-shared State generation captured by the node, so its
-factory and resources cannot come from a different Start generation. The factory is moved from
-`StorageNodeConfig` into that State before Transport declarations.
+logging. Independent `CreateSession` calls may execute concurrently and may invoke the stored
+factory concurrently; a factory implementation with mutable shared state is responsible for
+synchronizing that state. `CreateSession` uses the callback-shared State generation captured by the
+node, so its factory and resources cannot come from a different Start generation. The factory is
+moved from `StorageNodeConfig` into that State before Transport declarations.
 
 Only a valid, non-null durable engine may commit `Creating` to `Active`. For a
 Session requesting durable buffers, a factory `Err` is returned with its status, cause, and

--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -299,8 +299,8 @@ so `Stop()` still quiesces diagnostics. Neither callback ever invokes the extern
 
 `ParseQuerySelector` is a concise internal implementation helper, not a new public API. It composes
 the exact-key grammar with the existing selector rules: it first uses `ParseKey(prefix, keyexpr)`
-for an exact key, then parses a terminal `/**` selector with the existing selector parser. #56
-extends the exact branch and selector branch for durable buffer exact Get/List. It returns
+for an exact key, then parses a terminal `/**` selector with the existing selector parser. Issue
+#141 implements the exact branch and selector branch for durable buffer exact Get/List. It returns
 `kind`, `sid`, `buffer_class`, and a relative selector, or empty. Empty means no reply; ephemeral
 selectors remain no-reply.
 
@@ -350,11 +350,16 @@ StorageNode::Start(engine, transport, config):
               ReplyFromReader(q, *lease.session.overlay, selector.relative_selector)
           case Buffer:
             if selector.buffer_class == Durable:
-              if lease = AcquireActiveAdmission(*state, selector.sid):
-                if lease.session.options.durable_buffers:
-                  ReplyFromReader(q, *lease.session.durable_buffers,
-                                  selector.relative_selector,
-                                  Encoding{"zenoh/bytes"})
+              owned = []
+              {
+                if lease = AcquireActiveAdmission(*state, selector.sid):
+                  if lease.session.options.durable_buffers:
+                    // Collect while admission protects the engine and copy every view.
+                    owned = CollectOwnedEntries(*lease.session.durable_buffers,
+                                                selector.relative_selector)
+              }  // release Session admission before any reply callback
+              for entry in owned:
+                q.Reply(entry.full_key, entry.bytes, Encoding{"zenoh/bytes"})
             else:
               // No replies: StorageNode retains no ephemeral state.
           case MetaSession:

--- a/docs/04_api_cpp.md
+++ b/docs/04_api_cpp.md
@@ -263,7 +263,9 @@ public:
 // both succeed. Stop is idempotent and waits for callbacks already in flight.
 ```
 
-`SessionOptions` enables durable buffers, ephemeral buffers, both, or neither. The exact lifecycle
+`SessionOptions` enables durable buffers, ephemeral buffers, both, or neither. Stage #141
+implements the exact `zenoh/bytes` buffer admission and keeps the one-argument overload's
+parameter/session behavior unchanged. The exact lifecycle
 contract is `absent → Creating → Active` for `CreateSession` and
 `Active → Closing → absent` for `CloseSession`. Creation against `Creating` or `Closing` returns
 `std::errc::operation_in_progress`; a duplicate `Active` creation retains

--- a/docs/04_api_cpp.md
+++ b/docs/04_api_cpp.md
@@ -122,7 +122,7 @@ types in the public API. An injected `std::shared_ptr<Transport>` can be passed 
 | `NotFound` | get target absent, nonexistent session | `sitos.NotFoundError` |
 | `TypeMismatch` | Type conversion impossible, Bytes dtype/size mismatch | `sitos.TypeMismatchError` |
 | `Timeout` | query does not complete within `ClientConfig::query_timeout` | `sitos.TimeoutError` |
-| `Disconnected` | zenoh session disconnected, StorageNode stopped | `sitos.DisconnectedError` |
+| `Disconnected` | zenoh session disconnected, or an operation-specific disconnected condition | `sitos.DisconnectedError` |
 | `ReadOnly` | put/delete through the library API to `snap/<sid>/**` | `sitos.ReadOnlyError` |
 | `InvalidKey` | Key/scope/session id violates the grammar | `ValueError` |
 | `InvalidArgument` | Invalid configuration or operation argument | `ValueError` |
@@ -130,6 +130,12 @@ types in the public API. An injected `std::shared_ptr<Transport>` can be passed 
 
 Python `get(..., default=...)` does not raise for `NotFound` only; it returns default.
 All other Status values are converted to exceptions.
+
+`StorageNode::CreateSession` is an explicit exception to generic stopped-node status wording:
+both `CreateSession(std::string_view)` overloads return `Status::InvalidArgument` with cause
+`std::errc::invalid_argument` and an empty message when the node State is absent (after Stop) or
+when a callback has captured a State whose lifecycle gate is already closed. This preserves
+DEC-140-STOP-STATUS-002; other stopped-node operations retain their method-specific status.
 
 ## 2. ParamStore — Writes and Ad Hoc Reads
 
@@ -278,10 +284,11 @@ A node-level host factory creates at most one durable `StorageEngine` for each S
 the durable capability; all durable keys in that Session share it. The factory result is uniquely
 owned by the Session, and RocksDB types and filesystem paths remain outside this public API.
 `Start` moves the factory from `StorageNodeConfig` into the callback-shared State before either
-Transport declaration. `CreateSession` uses that same State generation, not a later or different
-node configuration. Creation reserves a non-queryable `Creating` record before invoking the
-external factory, rolls back every resource already created on failure, and publishes it as
-`Active` only after all resources are ready.
+Transport declaration. Independent `CreateSession` calls may execute concurrently, so a factory
+with mutable shared state must synchronize its own state. `CreateSession` uses that same State
+generation, not a later or different node configuration. Creation reserves a non-queryable
+`Creating` record before invoking the external factory, rolls back every resource already created
+on failure, and publishes it as `Active` only after all resources are ready.
 
 Only a valid, non-null engine may commit `Creating` to `Active`. For a Session requesting
 durable buffers, a factory `Err` preserves its status, cause, and message. An empty factory,

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -316,7 +316,8 @@ cmake -S . -B build/tsan -G Ninja -DCMAKE_BUILD_TYPE=Debug \
   -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF -DSITOS_ENABLE_TSAN=ON
 cmake --build build/tsan
 lifecycle_filter="StorageNodeLifecycleTest|StorageNodeSessionTest|"
-lifecycle_filter="${lifecycle_filter}StorageNodeSessionLifecycleTest|StorageNodeBatchTest|"
+lifecycle_filter="${lifecycle_filter}StorageNodeSessionLifecycleTest|StorageNodeBufferLifecycleTest|"
+lifecycle_filter="${lifecycle_filter}StorageNodeBufferRoutingTest|StorageNodeBufferApiTest|StorageNodeBatchTest|"
 lifecycle_filter="${lifecycle_filter}TransportGetCompletionTest|ParamStoreSubscribeTest|"
 lifecycle_filter="${lifecycle_filter}ParamCacheTest|ParamCacheReadTest|"
 lifecycle_filter="${lifecycle_filter}SessionViewTest|SessionViewFixture"

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -312,7 +312,8 @@ raw-Zenoh consumers such as #32 and #56. The accepted ADR-0032 implementation se
   * The fixed API, lifecycle, and routing tests from [06] §5.1.1 pass for all four capability
     combinations and all DEC-56 failure, encoding, persistence, and Stop contracts.
   * Disabled durable capability creates or mutates no engine state; disabled ephemeral capability
-    retains no node state; query failures produce no partial replies.
+    retains no node state; a false/throwing engine collection before reply dispatch produces zero replies,
+    while a reply-handler failure after dispatch begins suppresses later replies and may preserve earlier replies.
 * Depends on: #139 and #140; implementation precedes final #56.
 * Contract Registry: none; the buffer row remains Planned.
 

--- a/include/sitos/session.hpp
+++ b/include/sitos/session.hpp
@@ -24,12 +24,9 @@ class StorageEngine;
 
 /// Options selecting Session buffer capabilities.
 struct SessionOptions {
-  bool durable = false;
-  bool ephemeral = false;
+  bool durable_buffers = false;
+  bool ephemeral_buffers = false;
 };
-
-using DurableBufferEngineFactory =
-    std::function<Result<std::unique_ptr<StorageEngine>>(std::string_view sid)>;
 
 /// Metadata recorded for an active session and surfaced as the payload-v1 STR
 /// JSON returned for a get on meta/session/<sid> (docs/03 §7.1).

--- a/include/sitos/session.hpp
+++ b/include/sitos/session.hpp
@@ -9,13 +9,27 @@
 #ifndef SITOS_SESSION_HPP
 #define SITOS_SESSION_HPP
 
+#include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
+#include "sitos/result.hpp"
 #include "sitos/storage_engine.hpp"
 
 namespace sitos {
+
+class StorageEngine;
+
+/// Options selecting Session buffer capabilities.
+struct SessionOptions {
+  bool durable = false;
+  bool ephemeral = false;
+};
+
+using DurableBufferEngineFactory =
+    std::function<Result<std::unique_ptr<StorageEngine>>(std::string_view sid)>;
 
 /// Metadata recorded for an active session and surfaced as the payload-v1 STR
 /// JSON returned for a get on meta/session/<sid> (docs/03 §7.1).

--- a/include/sitos/session.hpp
+++ b/include/sitos/session.hpp
@@ -9,13 +9,10 @@
 #ifndef SITOS_SESSION_HPP
 #define SITOS_SESSION_HPP
 
-#include <functional>
 #include <memory>
 #include <string>
-#include <string_view>
 #include <unordered_map>
 
-#include "sitos/result.hpp"
 #include "sitos/storage_engine.hpp"
 
 namespace sitos {

--- a/include/sitos/session.hpp
+++ b/include/sitos/session.hpp
@@ -17,8 +17,6 @@
 
 namespace sitos {
 
-class StorageEngine;
-
 /// Options selecting Session buffer capabilities.
 struct SessionOptions {
   bool durable_buffers = false;

--- a/include/sitos/storage_node.hpp
+++ b/include/sitos/storage_node.hpp
@@ -39,13 +39,13 @@ struct StorageQuery {
 ///
 /// The returned exact key is relative to the base scope. For a List selector,
 /// the returned prefix ends at a chunk boundary and includes its trailing `/`.
-std::optional<StorageQuery> ParseStorageQuery(std::string_view prefix,
-                                               std::string_view keyexpr);
+std::optional<StorageQuery> ParseStorageQuery(std::string_view prefix, std::string_view keyexpr);
 
 struct StorageNodeConfig {
   std::string prefix = "sitos";
   /// Diagnostic destination; nullptr explicitly disables logging.
   std::shared_ptr<LogSink> log_sink = DefaultLogSink();
+  DurableBufferEngineFactory durable_buffer_engine_factory = {};
 };
 
 class SessionView;
@@ -71,14 +71,16 @@ class StorageNode {
   Result<void> Start(std::shared_ptr<StorageEngine> engine, Config config);
 
   /// Starts the node using an externally owned transport.
-  Result<void> Start(std::shared_ptr<StorageEngine> engine, Transport& transport,
-                     Config config);
+  Result<void> Start(std::shared_ptr<StorageEngine> engine, Transport& transport, Config config);
 
   /// Opens a session: takes an engine snapshot for snap/<sid>/** reads and
   /// creates an empty overlay for session/<sid>/** reads and writes. Fails with
   /// invalid_argument for a malformed sid or a stopped node, and file_exists if
   /// the session already exists. [F10]
   Result<void> CreateSession(std::string_view sid);
+
+  /// Opens a session with explicit durable and ephemeral buffer capabilities.
+  Result<void> CreateSession(std::string_view sid, SessionOptions options);
 
   /// Closes a session: releases its snapshot and overlay and removes its
   /// metadata, so subsequent snap/session/meta gets reply nothing. Fails with
@@ -185,6 +187,8 @@ class StorageNode {
     std::condition_variable admission_cv;
     std::shared_ptr<const StorageReader> snapshot;
     std::shared_ptr<StorageEngine> overlay;
+    std::unique_ptr<StorageEngine> durable_buffers;
+    SessionOptions options;
     SessionMeta metadata;
   };
 
@@ -198,14 +202,16 @@ class StorageNode {
 
   struct State {
     State(std::shared_ptr<StorageEngine> storage, std::string key_prefix,
-          std::shared_ptr<LogSink> diagnostics)
+          std::shared_ptr<LogSink> diagnostics, DurableBufferEngineFactory durable_factory)
         : engine(std::move(storage)),
           prefix(std::move(key_prefix)),
-          log_sink(std::move(diagnostics)) {}
+          log_sink(std::move(diagnostics)),
+          durable_buffer_engine_factory(std::move(durable_factory)) {}
 
     std::shared_ptr<StorageEngine> engine;
     std::string prefix;
     const std::shared_ptr<LogSink> log_sink;
+    DurableBufferEngineFactory durable_buffer_engine_factory;
 
     class CallbackLease {
      public:
@@ -275,8 +281,7 @@ class StorageNode {
     // gate -> subscriber_mutex -> session_mutex -> admission ordering never
     // cycles.
     std::shared_mutex session_mutex;
-    std::unordered_map<std::string, std::shared_ptr<SessionRecord>, SessionKeyHash,
-                       std::equal_to<>>
+    std::unordered_map<std::string, std::shared_ptr<SessionRecord>, SessionKeyHash, std::equal_to<>>
         sessions;
   };
 
@@ -285,16 +290,18 @@ class StorageNode {
     std::shared_ptr<SessionRecord> record;
   };
 
-  static SessionAccess AcquireSession(const std::shared_ptr<State>& state,
-                                      std::string_view sid);
+  static SessionAccess AcquireSession(const std::shared_ptr<State>& state, std::string_view sid);
   static void OnQuery(const std::shared_ptr<State>& state, TransportQuery& query);
   static void OnSample(const std::shared_ptr<State>& state, const TransportSample& sample);
+  static Result<void> CreateSession(const std::shared_ptr<State>& state, std::string_view sid,
+                                    SessionOptions options);
   // Answers a get in the session or snap scope from the matching overlay or
   // snapshot; replies nothing for an unknown sid.
   static void ReplyScopedQuery(const std::shared_ptr<State>& state, std::string_view scope,
                                std::string_view tail, TransportQuery& query);
   // Answers a get on meta/session/<sid> with the session metadata JSON.
   static void ReplyMetaQuery(const std::shared_ptr<State>& state, TransportQuery& query);
+  static void ReplyBufferQuery(const std::shared_ptr<State>& state, TransportQuery& query);
 
   mutable std::mutex lifecycle_mutex_;
   // Serializes declaration/undeclaration transactions. Callbacks never hold this lock.

--- a/include/sitos/storage_node.hpp
+++ b/include/sitos/storage_node.hpp
@@ -27,6 +27,9 @@
 
 namespace sitos {
 
+using DurableBufferEngineFactory =
+    std::function<Result<std::unique_ptr<StorageEngine>>(std::string_view sid)>;
+
 /// The supported query shape for the StorageNode base scope.
 struct StorageQuery {
   /// True for a terminal star-star selector, false for an exact key.

--- a/include/sitos/storage_node.hpp
+++ b/include/sitos/storage_node.hpp
@@ -27,6 +27,10 @@
 
 namespace sitos {
 
+/// Creates the one durable engine owned by a durable-enabled Session.
+/// CreateSession calls may run concurrently; factories with mutable shared state must synchronize
+/// that state themselves. The factory must not synchronously wait for same-node lifecycle
+/// quiescence operations.
 using DurableBufferEngineFactory =
     std::function<Result<std::unique_ptr<StorageEngine>>(std::string_view sid)>;
 
@@ -78,12 +82,14 @@ class StorageNode {
 
   /// Opens a session: takes an engine snapshot for snap/<sid>/** reads and
   /// creates an empty overlay for session/<sid>/** reads and writes. Fails with
-  /// invalid_argument for a malformed sid or a stopped node, and file_exists if
+  /// invalid_argument for a malformed sid, an absent node State, or a captured State whose
+  /// lifecycle gate is closed; the latter two return an empty message. Returns file_exists if
   /// the session already exists. [F10]
   Result<void> CreateSession(std::string_view sid);
 
-  /// Opens a session with explicit durable and ephemeral buffer capabilities.
-  /// Durable creation requires the configured factory and reports factory/setup failures.
+  /// Opens a session with explicit durable and ephemeral buffer capabilities. The same
+  /// stopped/captured-closed-gate InvalidArgument contract applies. Durable creation requires the
+  /// configured factory and reports factory/setup failures.
   Result<void> CreateSession(std::string_view sid, SessionOptions options);
 
   /// Closes a session: releases its snapshot, overlay, and durable engine, then removes its

--- a/include/sitos/storage_node.hpp
+++ b/include/sitos/storage_node.hpp
@@ -279,9 +279,11 @@ class StorageNode {
     // session locks are released before engine writes.
     std::mutex subscriber_mutex;
 
-    // Test-only observer invoked after callback-gate admission and immediately
-    // before subscriber_mutex acquisition. It is unset in production use.
+    // Test-only observers are unset in production use. They are copied under
+    // test_observer_mutex and invoked without holding State locks.
+    mutable std::mutex test_observer_mutex;
     std::function<void()> subscriber_entry_observer;
+    std::function<void()> create_session_entry_observer;
 
     // Session records are the sole internal ownership and membership source.
     // Guarded by session_mutex. Callbacks and session operations alike enter

--- a/include/sitos/storage_node.hpp
+++ b/include/sitos/storage_node.hpp
@@ -83,9 +83,10 @@ class StorageNode {
   Result<void> CreateSession(std::string_view sid);
 
   /// Opens a session with explicit durable and ephemeral buffer capabilities.
+  /// Durable creation requires the configured factory and reports factory/setup failures.
   Result<void> CreateSession(std::string_view sid, SessionOptions options);
 
-  /// Closes a session: releases its snapshot and overlay and removes its
+  /// Closes a session: releases its snapshot, overlay, and durable engine, then removes its
   /// metadata, so subsequent snap/session/meta gets reply nothing. Fails with
   /// invalid_argument for a stopped node and no_such_file_or_directory for an
   /// unknown sid. [F10]
@@ -277,6 +278,10 @@ class StorageNode {
     // session_mutex. This prevents ordinary writes from interleaving a batch;
     // session locks are released before engine writes.
     std::mutex subscriber_mutex;
+
+    // Test-only observer invoked after callback-gate admission and immediately
+    // before subscriber_mutex acquisition. It is unset in production use.
+    std::function<void()> subscriber_entry_observer;
 
     // Session records are the sole internal ownership and membership source.
     // Guarded by session_mutex. Callbacks and session operations alike enter

--- a/src/storage_node.cpp
+++ b/src/storage_node.cpp
@@ -169,9 +169,6 @@ BufferWriteOutcome ApplyDurableBufferWrite(StorageEngine& engine, const ParsedKe
       return same ? BufferWriteOutcome::Stored : BufferWriteOutcome::Conflict;
     }
     if (engine.Put(parsed.relative_key, sample.payload)) return BufferWriteOutcome::Stored;
-    // A failed Put has no node-side reservation. Read once to observe a
-    // possible engine-side commit; the next sample repeats the authoritative read.
-    engine.Get(parsed.relative_key, [](std::string_view, Bytes) { return true; });
   } catch (...) {
     return BufferWriteOutcome::Failed;
   }
@@ -319,6 +316,30 @@ void StorageNode::Stop() noexcept {
   }
 
   state->DeactivateAndWait();
+
+  // Stop is a quiescence boundary for the entire Session generation. Once
+  // callbacks have drained, no Session admission can remain active; close and
+  // release every committed record before returning to the caller.
+  std::vector<std::shared_ptr<SessionRecord>> records;
+  {
+    std::unique_lock lock(state->session_mutex);
+    records.reserve(state->sessions.size());
+    for (auto& [sid, record] : state->sessions) {
+      if (record->BeginClose()) records.push_back(record);
+    }
+  }
+  for (const auto& record : records) {
+    record->WaitForAdmission();
+    record->snapshot.reset();
+    record->overlay.reset();
+    record->durable_buffers.reset();
+    record->metadata = {};
+  }
+  {
+    std::unique_lock lock(state->session_mutex);
+    state->sessions.clear();
+  }
+
   subscriber = Subscription{};
   queryable = Queryable{};
 }
@@ -404,10 +425,10 @@ Result<void> StorageNode::CreateSession(const std::shared_ptr<State>& state, std
   record->options = options;
   record->metadata = SessionMeta{NowIso8601()};
 
-  if (options.durable) {
+  if (options.durable_buffers) {
     if (!state->durable_buffer_engine_factory) {
-      return Result<void>::Err(Status::InvalidArgument,
-                               "durable buffer engine factory is required");
+      return Result<void>::Err(Status::InvalidArgument, "durable buffer engine factory is required",
+                               std::make_error_code(std::errc::invalid_argument));
     }
     try {
       auto factory_result = state->durable_buffer_engine_factory(sid);
@@ -536,10 +557,10 @@ void StorageNode::OnSample(const std::shared_ptr<State>& state, const TransportS
         } else if (!parsed->buffer_class.has_value()) {
           diagnostics.emplace_back(LogLevel::kWarning, kBufferUnsupported);
         } else if (*parsed->buffer_class == BufferClass::Ephemeral) {
-          if (!access.record->options.ephemeral) {
+          if (!access.record->options.ephemeral_buffers) {
             diagnostics.emplace_back(LogLevel::kWarning, kBufferCapabilityDisabled);
           }
-        } else if (!access.record->options.durable || !access.record->durable_buffers) {
+        } else if (!access.record->options.durable_buffers || !access.record->durable_buffers) {
           diagnostics.emplace_back(LogLevel::kWarning, kBufferCapabilityDisabled);
         } else {
           switch (ApplyDurableBufferWrite(*access.record->durable_buffers, *parsed, sample)) {
@@ -680,7 +701,7 @@ void StorageNode::ReplyBufferQuery(const std::shared_ptr<State>& state, Transpor
       record = it->second;
       admission = record->TryAcquire();
     }
-    if (!admission || !record->options.durable || !record->durable_buffers) return;
+    if (!admission || !record->options.durable_buffers || !record->durable_buffers) return;
     try {
       auto sink = [&entries](std::string_view key, Bytes value) {
         entries.emplace_back(std::string(key), std::vector<std::byte>(value.begin(), value.end()));

--- a/src/storage_node.cpp
+++ b/src/storage_node.cpp
@@ -523,6 +523,7 @@ void StorageNode::OnSample(const std::shared_ptr<State>& state, const TransportS
   auto lease = state->Enter();
   if (!lease) return;
   try {
+    if (state->subscriber_entry_observer) state->subscriber_entry_observer();
     SubscriberDiagnostics diagnostics;
     {
       // The gate lease is acquired first. Serializing the entire subscriber

--- a/src/storage_node.cpp
+++ b/src/storage_node.cpp
@@ -657,39 +657,39 @@ void StorageNode::ReplyBufferQuery(const std::shared_ptr<State>& state, Transpor
     relative = std::string(selector_text);
   }
 
-  std::optional<SessionRecord::AdmissionLease> admission;
-  std::shared_ptr<SessionRecord> record;
-  {
-    std::shared_lock lock(state->session_mutex);
-    auto it = state->sessions.find(sid);
-    if (it == state->sessions.end()) return;
-    record = it->second;
-    admission = record->TryAcquire();
-  }
-  if (!admission || !record->options.durable || !record->durable_buffers) return;
-
   struct OwnedEntry {
     std::string key;
     std::vector<std::byte> value;
   };
   std::vector<OwnedEntry> entries;
   bool ok = false;
-  try {
-    auto sink = [&](std::string_view key, Bytes value) {
-      entries.push_back({std::string(key), std::vector<std::byte>(value.begin(), value.end())});
-      return true;
-    };
-    ok = list ? record->durable_buffers->List(relative, sink)
-              : record->durable_buffers->Get(relative, sink);
-  } catch (...) {
+  bool collection_failed = false;
+  {
+    std::optional<SessionRecord::AdmissionLease> admission;
+    std::shared_ptr<SessionRecord> record;
+    {
+      std::shared_lock lock(state->session_mutex);
+      auto it = state->sessions.find(sid);
+      if (it == state->sessions.end()) return;
+      record = it->second;
+      admission = record->TryAcquire();
+    }
+    if (!admission || !record->options.durable || !record->durable_buffers) return;
+    try {
+      auto sink = [&](std::string_view key, Bytes value) {
+        entries.push_back({std::string(key), std::vector<std::byte>(value.begin(), value.end())});
+        return true;
+      };
+      ok = list ? record->durable_buffers->List(relative, sink)
+                : record->durable_buffers->Get(relative, sink);
+    } catch (...) {
+      collection_failed = true;
+    }
+  }
+  if (collection_failed || (!ok && list)) {
     EmitLog(state->log_sink, LogLevel::kError, kNodeComponent, kBufferQueryFailed);
     return;
   }
-  if (!ok && list) {
-    EmitLog(state->log_sink, LogLevel::kError, kNodeComponent, kBufferQueryFailed);
-    return;
-  }
-  admission.reset();
 
   const Encoding encoding{"zenoh/bytes"};
   bool dispatch = true;

--- a/src/storage_node.cpp
+++ b/src/storage_node.cpp
@@ -319,25 +319,21 @@ void StorageNode::Stop() noexcept {
 
   // Stop is a quiescence boundary for the entire Session generation. Once
   // callbacks have drained, no Session admission can remain active; close and
-  // release every committed record before returning to the caller.
-  std::vector<std::shared_ptr<SessionRecord>> records;
-  {
-    std::unique_lock lock(state->session_mutex);
-    records.reserve(state->sessions.size());
-    for (auto& [sid, record] : state->sessions) {
-      if (record->BeginClose()) records.push_back(record);
+  // release every committed record before returning to the caller. Extracting
+  // one existing map node at a time avoids allocation in this noexcept path.
+  for (;;) {
+    std::shared_ptr<SessionRecord> record;
+    {
+      std::unique_lock lock(state->session_mutex);
+      if (state->sessions.empty()) break;
+      auto node = state->sessions.extract(state->sessions.begin());
+      record = std::move(node.mapped());
     }
-  }
-  for (const auto& record : records) {
-    record->WaitForAdmission();
+    if (record->BeginClose()) record->WaitForAdmission();
     record->snapshot.reset();
     record->overlay.reset();
     record->durable_buffers.reset();
     record->metadata = {};
-  }
-  {
-    std::unique_lock lock(state->session_mutex);
-    state->sessions.clear();
   }
 
   subscriber = Subscription{};
@@ -362,6 +358,12 @@ Result<void> StorageNode::CreateSession(std::string_view sid, SessionOptions opt
     state = state_;
   }
   if (!state) return Result<void>::Err(InvalidArgument());
+  std::function<void()> create_observer;
+  {
+    std::scoped_lock lock(state->test_observer_mutex);
+    create_observer = state->create_session_entry_observer;
+  }
+  if (create_observer) create_observer();
   auto lease = state->Enter();
   if (!lease) return Result<void>::Err(InvalidArgument());
   return CreateSession(state, sid, options);
@@ -523,7 +525,12 @@ void StorageNode::OnSample(const std::shared_ptr<State>& state, const TransportS
   auto lease = state->Enter();
   if (!lease) return;
   try {
-    if (state->subscriber_entry_observer) state->subscriber_entry_observer();
+    std::function<void()> subscriber_observer;
+    {
+      std::scoped_lock lock(state->test_observer_mutex);
+      subscriber_observer = state->subscriber_entry_observer;
+    }
+    if (subscriber_observer) subscriber_observer();
     SubscriberDiagnostics diagnostics;
     {
       // The gate lease is acquired first. Serializing the entire subscriber

--- a/src/storage_node.cpp
+++ b/src/storage_node.cpp
@@ -155,6 +155,29 @@ bool IsBufferBytes(const TransportSample& sample) {
   return sample.kind == TransportSample::Kind::Put && sample.encoding.id == "zenoh/bytes";
 }
 
+enum class BufferWriteOutcome { Stored, Conflict, Failed };
+
+BufferWriteOutcome ApplyDurableBufferWrite(StorageEngine& engine, const ParsedKey& parsed,
+                                           const TransportSample& sample) {
+  try {
+    bool same = false;
+    if (engine.Get(parsed.relative_key, [&same, &sample](std::string_view, Bytes value) {
+          same = value.size() == sample.payload.size() &&
+                 std::equal(value.begin(), value.end(), sample.payload.begin());
+          return true;
+        })) {
+      return same ? BufferWriteOutcome::Stored : BufferWriteOutcome::Conflict;
+    }
+    if (engine.Put(parsed.relative_key, sample.payload)) return BufferWriteOutcome::Stored;
+    // A failed Put has no node-side reservation. Read once to observe a
+    // possible engine-side commit; the next sample repeats the authoritative read.
+    engine.Get(parsed.relative_key, [](std::string_view, Bytes) { return true; });
+  } catch (...) {
+    return BufferWriteOutcome::Failed;
+  }
+  return BufferWriteOutcome::Failed;
+}
+
 // Applies a put/delete sample to a target engine (base engine or session
 // overlay), mirroring the wire-encoding rules for base writes. Diagnostics are
 // retained until the subscriber sequencer is released, so an injected sink is
@@ -504,47 +527,30 @@ void StorageNode::OnSample(const std::shared_ptr<State>& state, const TransportS
         }
       } else if (parsed->kind == KeyKind::Buffer) {
         if (sample.kind == TransportSample::Kind::Delete) {
-          diagnostics.push_back({LogLevel::kWarning, kBufferUnsupported});
+          diagnostics.emplace_back(LogLevel::kWarning, kBufferUnsupported);
         } else if (!IsBufferBytes(sample)) {
-          diagnostics.push_back({LogLevel::kWarning, kBufferEncodingRejected});
+          diagnostics.emplace_back(LogLevel::kWarning, kBufferEncodingRejected);
         } else if (auto access = AcquireSession(state, parsed->sid);
                    !access.record || !access.admission.has_value()) {
-          diagnostics.push_back({LogLevel::kWarning, kUnknownSession});
+          diagnostics.emplace_back(LogLevel::kWarning, kUnknownSession);
         } else if (!parsed->buffer_class.has_value()) {
-          diagnostics.push_back({LogLevel::kWarning, kBufferUnsupported});
+          diagnostics.emplace_back(LogLevel::kWarning, kBufferUnsupported);
         } else if (*parsed->buffer_class == BufferClass::Ephemeral) {
           if (!access.record->options.ephemeral) {
-            diagnostics.push_back({LogLevel::kWarning, kBufferCapabilityDisabled});
+            diagnostics.emplace_back(LogLevel::kWarning, kBufferCapabilityDisabled);
           }
         } else if (!access.record->options.durable || !access.record->durable_buffers) {
-          diagnostics.push_back({LogLevel::kWarning, kBufferCapabilityDisabled});
+          diagnostics.emplace_back(LogLevel::kWarning, kBufferCapabilityDisabled);
         } else {
-          try {
-            bool same = false;
-            if (access.record->durable_buffers->Get(
-                    parsed->relative_key, [&](std::string_view, Bytes value) {
-                      same = value.size() == sample.payload.size() &&
-                             std::equal(value.begin(), value.end(), sample.payload.begin());
-                      return true;
-                    })) {
-              if (!same) diagnostics.push_back({LogLevel::kWarning, kBufferPutConflict});
-            } else if (!access.record->durable_buffers->Put(parsed->relative_key, sample.payload)) {
-              diagnostics.push_back({LogLevel::kError, kBufferPutFailed});
-              try {
-                access.record->durable_buffers->Get(parsed->relative_key,
-                                                    [](std::string_view, Bytes) { return true; });
-              } catch (...) {
-                // The diagnostic remains payload-free and the next PUT may retry.
-              }
-            }
-          } catch (...) {
-            diagnostics.push_back({LogLevel::kError, kBufferPutFailed});
-            try {
-              access.record->durable_buffers->Get(parsed->relative_key,
-                                                  [](std::string_view, Bytes) { return true; });
-            } catch (...) {
-              // The failed attempt creates no node-side reservation.
-            }
+          switch (ApplyDurableBufferWrite(*access.record->durable_buffers, *parsed, sample)) {
+            case BufferWriteOutcome::Conflict:
+              diagnostics.emplace_back(LogLevel::kWarning, kBufferPutConflict);
+              break;
+            case BufferWriteOutcome::Failed:
+              diagnostics.emplace_back(LogLevel::kError, kBufferPutFailed);
+              break;
+            case BufferWriteOutcome::Stored:
+              break;
           }
         }
       } else {
@@ -637,10 +643,10 @@ void StorageNode::ReplyBufferQuery(const std::shared_ptr<State>& state, Transpor
   if (!rest || !rest->starts_with("buffers/")) return;
   auto sid_split = SplitFirst(rest->substr(8));
   if (!sid_split) return;
-  const auto [sid, class_and_selector] = *sid_split;
+  const auto& [sid, class_and_selector] = *sid_split;
   auto class_split = SplitFirst(class_and_selector);
   if (!class_split || !IsValidSessionId(sid)) return;
-  const auto [class_name, selector_text] = *class_split;
+  const auto& [class_name, selector_text] = *class_split;
   if (class_name != "durable") return;
   if (selector_text.empty()) return;
   std::string relative;
@@ -676,8 +682,8 @@ void StorageNode::ReplyBufferQuery(const std::shared_ptr<State>& state, Transpor
     }
     if (!admission || !record->options.durable || !record->durable_buffers) return;
     try {
-      auto sink = [&](std::string_view key, Bytes value) {
-        entries.push_back({std::string(key), std::vector<std::byte>(value.begin(), value.end())});
+      auto sink = [&entries](std::string_view key, Bytes value) {
+        entries.emplace_back(std::string(key), std::vector<std::byte>(value.begin(), value.end()));
         return true;
       };
       ok = list ? record->durable_buffers->List(relative, sink)

--- a/src/storage_node.cpp
+++ b/src/storage_node.cpp
@@ -6,6 +6,7 @@
 
 #include "sitos/storage_node.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <ctime>
 #include <format>
@@ -24,24 +25,19 @@
 namespace sitos {
 namespace {
 
-std::error_code InvalidArgument() {
-  return std::make_error_code(std::errc::invalid_argument);
-}
+std::error_code InvalidArgument() { return std::make_error_code(std::errc::invalid_argument); }
 
 std::error_code OperationInProgress() {
   return std::make_error_code(std::errc::operation_in_progress);
 }
 
-std::error_code SessionAlreadyExists() {
-  return std::make_error_code(std::errc::file_exists);
-}
+std::error_code SessionAlreadyExists() { return std::make_error_code(std::errc::file_exists); }
 
 std::error_code NoSuchSession() {
   return std::make_error_code(std::errc::no_such_file_or_directory);
 }
 
-std::optional<std::string_view> StripPrefix(std::string_view prefix,
-                                            std::string_view keyexpr) {
+std::optional<std::string_view> StripPrefix(std::string_view prefix, std::string_view keyexpr) {
   if (keyexpr.size() <= prefix.size() || !keyexpr.starts_with(prefix) ||
       keyexpr[prefix.size()] != '/') {
     return std::nullopt;
@@ -75,7 +71,8 @@ Encoding SitosEncoding() { return Encoding{std::string(Encoding::kSitosV1)}; }
 
 // Formats the current time as an ISO-8601 UTC timestamp, e.g. 2026-07-14T01:23:45Z.
 std::string NowIso8601() {
-  const std::time_t seconds = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  const std::time_t seconds =
+      std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
   std::tm tm{};
 #if defined(_WIN32)
   gmtime_s(&tm, &seconds);
@@ -93,8 +90,7 @@ std::optional<StorageQuery> ParseRelativeSelector(std::string_view relative) {
 
   if (relative == "**") return StorageQuery{true, {}};
 
-  if (constexpr std::string_view kSelectorSuffix = "/**";
-      relative.ends_with(kSelectorSuffix)) {
+  if (constexpr std::string_view kSelectorSuffix = "/**"; relative.ends_with(kSelectorSuffix)) {
     std::string_view selector = relative.substr(0, relative.size() - kSelectorSuffix.size());
     if (!IsValidPrefix(selector)) return std::nullopt;
     std::string list_prefix(selector);
@@ -111,8 +107,7 @@ std::optional<StorageQuery> ParseRelativeSelector(std::string_view relative) {
 // Replies to a get/List against a resolved reader, rebuilding reply keys under
 // the given scope path.
 void ReplyFromReader(const StorageReader& reader, const StorageQuery& selector,
-                     std::string_view prefix, std::string_view scope_path,
-                     TransportQuery& query) {
+                     std::string_view prefix, std::string_view scope_path, TransportQuery& query) {
   const Encoding encoding = SitosEncoding();
   auto reply = [prefix, scope_path, &query, encoding](std::string_view key, Bytes value) {
     const std::string full_key = MakeReplyKey(prefix, scope_path, key);
@@ -138,6 +133,12 @@ constexpr std::string_view kInvalidBatchOperation = "invalid batch operation or 
 constexpr std::string_view kReadOnlySnapshotKey = "read-only snapshot key";
 constexpr std::string_view kUnknownSession = "unknown session";
 constexpr std::string_view kQueryCallbackFailed = "query callback exception";
+constexpr std::string_view kBufferUnsupported = "unsupported buffer operation";
+constexpr std::string_view kBufferCapabilityDisabled = "buffer capability disabled";
+constexpr std::string_view kBufferEncodingRejected = "buffer encoding rejected";
+constexpr std::string_view kBufferPutConflict = "durable buffer PUT conflicts with existing value";
+constexpr std::string_view kBufferPutFailed = "durable buffer PUT failed";
+constexpr std::string_view kBufferQueryFailed = "durable buffer query failed";
 
 struct SubscriberDiagnostic {
   LogLevel level;
@@ -147,8 +148,11 @@ struct SubscriberDiagnostic {
 using SubscriberDiagnostics = std::vector<SubscriberDiagnostic>;
 
 bool IsBatchPut(const TransportSample& sample) {
-  return sample.kind == TransportSample::Kind::Put &&
-         sample.encoding.id == Encoding::kSitosV1Batch;
+  return sample.kind == TransportSample::Kind::Put && sample.encoding.id == Encoding::kSitosV1Batch;
+}
+
+bool IsBufferBytes(const TransportSample& sample) {
+  return sample.kind == TransportSample::Kind::Put && sample.encoding.id == "zenoh/bytes";
 }
 
 // Applies a put/delete sample to a target engine (base engine or session
@@ -219,8 +223,7 @@ void EmitDiagnostics(const std::shared_ptr<LogSink>& log_sink,
 
 }  // namespace
 
-std::optional<StorageQuery> ParseStorageQuery(std::string_view prefix,
-                                               std::string_view keyexpr) {
+std::optional<StorageQuery> ParseStorageQuery(std::string_view prefix, std::string_view keyexpr) {
   if (!IsValidPrefix(prefix)) return std::nullopt;
 
   auto rest = StripPrefix(prefix, keyexpr);
@@ -254,7 +257,8 @@ Result<void> StorageNode::Start(std::shared_ptr<StorageEngine> engine, Transport
   }
 
   auto state = std::make_shared<State>(std::move(engine), std::move(config.prefix),
-                                       std::move(config.log_sink));
+                                       std::move(config.log_sink),
+                                       std::move(config.durable_buffer_engine_factory));
   const std::string declaration_key = state->prefix + "/**";
   auto queryable_result = transport.DeclareQueryable(
       declaration_key, [state](TransportQuery& query) { OnQuery(state, query); });
@@ -302,6 +306,10 @@ bool StorageNode::IsStarted() const noexcept {
 }
 
 Result<void> StorageNode::CreateSession(std::string_view sid) {
+  return CreateSession(sid, SessionOptions{});
+}
+
+Result<void> StorageNode::CreateSession(std::string_view sid, SessionOptions options) {
   if (!IsValidSessionId(sid)) return Result<void>::Err(InvalidArgument());
 
   std::shared_ptr<State> state;
@@ -312,7 +320,11 @@ Result<void> StorageNode::CreateSession(std::string_view sid) {
   if (!state) return Result<void>::Err(InvalidArgument());
   auto lease = state->Enter();
   if (!lease) return Result<void>::Err(InvalidArgument());
+  return CreateSession(state, sid, options);
+}
 
+Result<void> StorageNode::CreateSession(const std::shared_ptr<State>& state, std::string_view sid,
+                                        SessionOptions options) {
   const std::string key(sid);
   auto record = std::make_shared<SessionRecord>();
   {
@@ -343,6 +355,7 @@ Result<void> StorageNode::CreateSession(std::string_view sid) {
       if (!active) return;
       record->snapshot.reset();
       record->overlay.reset();
+      record->durable_buffers.reset();
       record->metadata = {};
       std::unique_lock lock(state->session_mutex);
       auto it = state->sessions.find(key);
@@ -365,7 +378,26 @@ Result<void> StorageNode::CreateSession(std::string_view sid) {
 
   record->snapshot = std::move(snapshot);
   record->overlay = std::make_shared<InMemoryEngine>();
+  record->options = options;
   record->metadata = SessionMeta{NowIso8601()};
+
+  if (options.durable) {
+    if (!state->durable_buffer_engine_factory) {
+      return Result<void>::Err(Status::InvalidArgument,
+                               "durable buffer engine factory is required");
+    }
+    try {
+      auto factory_result = state->durable_buffer_engine_factory(sid);
+      if (!factory_result.IsOk()) return Result<void>::ErrFrom(factory_result);
+      auto durable_engine = std::move(factory_result).Value();
+      if (!durable_engine) {
+        return Result<void>::Err(Status::Error, "durable buffer engine factory returned null");
+      }
+      record->durable_buffers = std::move(durable_engine);
+    } catch (...) {
+      return Result<void>::Err(Status::Error, "durable buffer engine factory threw an exception");
+    }
+  }
 
   bool committed = false;
   {
@@ -403,6 +435,7 @@ Result<void> StorageNode::CloseSession(std::string_view sid) {
   record->WaitForAdmission();
   record->snapshot.reset();
   record->overlay.reset();
+  record->durable_buffers.reset();
   record->metadata = {};
   {
     std::unique_lock lock(state->session_mutex);
@@ -432,7 +465,7 @@ std::vector<std::string> StorageNode::ActiveSessions() const {
 }
 
 StorageNode::SessionAccess StorageNode::AcquireSession(const std::shared_ptr<State>& state,
-                                                        std::string_view sid) {
+                                                       std::string_view sid) {
   SessionAccess access;
   std::shared_lock lock(state->session_mutex);
   if (auto it = state->sessions.find(sid); it != state->sessions.end()) {
@@ -467,6 +500,51 @@ void StorageNode::OnSample(const std::shared_ptr<State>& state, const TransportS
             diagnostics.push_back({LogLevel::kWarning, kUnknownSession});
           } else {
             ApplyBatch(diagnostics, *access.record->overlay, sample.payload);
+          }
+        }
+      } else if (parsed->kind == KeyKind::Buffer) {
+        if (sample.kind == TransportSample::Kind::Delete) {
+          diagnostics.push_back({LogLevel::kWarning, kBufferUnsupported});
+        } else if (!IsBufferBytes(sample)) {
+          diagnostics.push_back({LogLevel::kWarning, kBufferEncodingRejected});
+        } else if (auto access = AcquireSession(state, parsed->sid);
+                   !access.record || !access.admission.has_value()) {
+          diagnostics.push_back({LogLevel::kWarning, kUnknownSession});
+        } else if (!parsed->buffer_class.has_value()) {
+          diagnostics.push_back({LogLevel::kWarning, kBufferUnsupported});
+        } else if (*parsed->buffer_class == BufferClass::Ephemeral) {
+          if (!access.record->options.ephemeral) {
+            diagnostics.push_back({LogLevel::kWarning, kBufferCapabilityDisabled});
+          }
+        } else if (!access.record->options.durable || !access.record->durable_buffers) {
+          diagnostics.push_back({LogLevel::kWarning, kBufferCapabilityDisabled});
+        } else {
+          try {
+            bool same = false;
+            if (access.record->durable_buffers->Get(
+                    parsed->relative_key, [&](std::string_view, Bytes value) {
+                      same = value.size() == sample.payload.size() &&
+                             std::equal(value.begin(), value.end(), sample.payload.begin());
+                      return true;
+                    })) {
+              if (!same) diagnostics.push_back({LogLevel::kWarning, kBufferPutConflict});
+            } else if (!access.record->durable_buffers->Put(parsed->relative_key, sample.payload)) {
+              diagnostics.push_back({LogLevel::kError, kBufferPutFailed});
+              try {
+                access.record->durable_buffers->Get(parsed->relative_key,
+                                                    [](std::string_view, Bytes) { return true; });
+              } catch (...) {
+                // The diagnostic remains payload-free and the next PUT may retry.
+              }
+            }
+          } catch (...) {
+            diagnostics.push_back({LogLevel::kError, kBufferPutFailed});
+            try {
+              access.record->durable_buffers->Get(parsed->relative_key,
+                                                  [](std::string_view, Bytes) { return true; });
+            } catch (...) {
+              // The failed attempt creates no node-side reservation.
+            }
           }
         }
       } else {
@@ -517,6 +595,8 @@ void StorageNode::OnQuery(const std::shared_ptr<State>& state, TransportQuery& q
       ReplyScopedQuery(state, head, tail, query);
     } else if (head == "meta") {
       ReplyMetaQuery(state, query);
+    } else if (head == "buffers") {
+      ReplyBufferQuery(state, query);
     }
   } catch (...) {
     EmitLog(state->log_sink, LogLevel::kError, kNodeComponent, kQueryCallbackFailed);
@@ -552,6 +632,84 @@ void StorageNode::ReplyScopedQuery(const std::shared_ptr<State>& state, std::str
   ReplyFromReader(*reader, *selector, state->prefix, scope_path, query);
 }
 
+void StorageNode::ReplyBufferQuery(const std::shared_ptr<State>& state, TransportQuery& query) {
+  auto rest = StripPrefix(state->prefix, query.keyexpr);
+  if (!rest || !rest->starts_with("buffers/")) return;
+  auto sid_split = SplitFirst(rest->substr(8));
+  if (!sid_split) return;
+  const auto [sid, class_and_selector] = *sid_split;
+  auto class_split = SplitFirst(class_and_selector);
+  if (!class_split || !IsValidSessionId(sid)) return;
+  const auto [class_name, selector_text] = *class_split;
+  if (class_name != "durable") return;
+  if (selector_text.empty()) return;
+  std::string relative;
+  bool list = false;
+  if (selector_text == "**") {
+    list = true;
+  } else if (selector_text.ends_with("/**")) {
+    auto prefix = selector_text.substr(0, selector_text.size() - 3);
+    if (!IsValidPrefix(prefix)) return;
+    relative = std::string(prefix) + "/";
+    list = true;
+  } else {
+    if (!IsValidKey(selector_text)) return;
+    relative = std::string(selector_text);
+  }
+
+  std::optional<SessionRecord::AdmissionLease> admission;
+  std::shared_ptr<SessionRecord> record;
+  {
+    std::shared_lock lock(state->session_mutex);
+    auto it = state->sessions.find(sid);
+    if (it == state->sessions.end()) return;
+    record = it->second;
+    admission = record->TryAcquire();
+  }
+  if (!admission || !record->options.durable || !record->durable_buffers) return;
+
+  struct OwnedEntry {
+    std::string key;
+    std::vector<std::byte> value;
+  };
+  std::vector<OwnedEntry> entries;
+  bool ok = false;
+  try {
+    auto sink = [&](std::string_view key, Bytes value) {
+      entries.push_back({std::string(key), std::vector<std::byte>(value.begin(), value.end())});
+      return true;
+    };
+    ok = list ? record->durable_buffers->List(relative, sink)
+              : record->durable_buffers->Get(relative, sink);
+  } catch (...) {
+    EmitLog(state->log_sink, LogLevel::kError, kNodeComponent, kBufferQueryFailed);
+    return;
+  }
+  if (!ok && list) {
+    EmitLog(state->log_sink, LogLevel::kError, kNodeComponent, kBufferQueryFailed);
+    return;
+  }
+  admission.reset();
+
+  const Encoding encoding{"zenoh/bytes"};
+  bool dispatch = true;
+  for (const auto& entry : entries) {
+    if (!dispatch) break;
+    const auto key =
+        MakeReplyKey(state->prefix, "buffers/" + std::string(sid) + "/durable", entry.key);
+    try {
+      auto result = query.Reply(key, entry.value, encoding);
+      if (!result.IsOk()) {
+        dispatch = false;
+        EmitLog(state->log_sink, LogLevel::kError, kNodeComponent, kBufferQueryFailed);
+      }
+    } catch (...) {
+      dispatch = false;
+      EmitLog(state->log_sink, LogLevel::kError, kNodeComponent, kBufferQueryFailed);
+    }
+  }
+}
+
 void StorageNode::ReplyMetaQuery(const std::shared_ptr<State>& state, TransportQuery& query) {
   auto parsed = ParseKey(state->prefix, query.keyexpr);
   // MetaAck (#14) is out of scope; only meta/session is answered here.
@@ -567,8 +725,8 @@ void StorageNode::ReplyMetaQuery(const std::shared_ptr<State>& state, TransportQ
     }
     admission = it->second->TryAcquire();
     if (!admission.has_value()) return;
-    json = std::format(R"({{"state":"active","created_at":"{}"}})",
-                       it->second->metadata.created_at);
+    json =
+        std::format(R"({{"state":"active","created_at":"{}"}})", it->second->metadata.created_at);
   }
   const auto payload = ParamValue(json).Encode();
   query.Reply(query.keyexpr, payload, SitosEncoding());

--- a/src/storage_node_test_access.hpp
+++ b/src/storage_node_test_access.hpp
@@ -4,12 +4,14 @@
 #ifndef SITOS_STORAGE_NODE_TEST_ACCESS_HPP
 #define SITOS_STORAGE_NODE_TEST_ACCESS_HPP
 
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include "sitos/storage_engine.hpp"
 #include "sitos/storage_node.hpp"
@@ -44,8 +46,15 @@ class StorageNodeTestAccess {
     return GateObserver{node.state_.get()};
   }
 
+  static bool SetSubscriberEntryObserver(StorageNode& node, std::function<void()> observer) {
+    std::scoped_lock lock(node.lifecycle_mutex_);
+    if (node.state_ == nullptr) return false;
+    node.state_->subscriber_entry_observer = std::move(observer);
+    return true;
+  }
+
   static std::optional<SessionResourceObservation> ObserveSession(StorageNode& node,
-                                                                    std::string_view sid) {
+                                                                  std::string_view sid) {
     std::shared_ptr<StorageNode::State> state;
     {
       std::scoped_lock lock(node.lifecycle_mutex_);

--- a/src/storage_node_test_access.hpp
+++ b/src/storage_node_test_access.hpp
@@ -47,9 +47,37 @@ class StorageNodeTestAccess {
   }
 
   static bool SetSubscriberEntryObserver(StorageNode& node, std::function<void()> observer) {
-    std::scoped_lock lock(node.lifecycle_mutex_);
-    if (node.state_ == nullptr) return false;
-    node.state_->subscriber_entry_observer = std::move(observer);
+    std::shared_ptr<StorageNode::State> state;
+    {
+      std::scoped_lock lock(node.lifecycle_mutex_);
+      state = node.state_;
+    }
+    if (state == nullptr) return false;
+    std::scoped_lock lock(state->test_observer_mutex);
+    state->subscriber_entry_observer = std::move(observer);
+    return true;
+  }
+
+  static bool SetCreateSessionEntryObserver(StorageNode& node, std::function<void()> observer) {
+    std::shared_ptr<StorageNode::State> state;
+    {
+      std::scoped_lock lock(node.lifecycle_mutex_);
+      state = node.state_;
+    }
+    if (state == nullptr) return false;
+    std::scoped_lock lock(state->test_observer_mutex);
+    state->create_session_entry_observer = std::move(observer);
+    return true;
+  }
+
+  static bool TryLockSubscriberMutex(StorageNode& node) {
+    std::shared_ptr<StorageNode::State> state;
+    {
+      std::scoped_lock lock(node.lifecycle_mutex_);
+      state = node.state_;
+    }
+    if (state == nullptr || !state->subscriber_mutex.try_lock()) return false;
+    state->subscriber_mutex.unlock();
     return true;
   }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -243,6 +243,14 @@ target_include_directories(sitos_storage_node_buffer_routing_test PRIVATE ${PROJ
 sitos_enable_warnings(sitos_storage_node_buffer_routing_test)
 gtest_add_tests(TARGET sitos_storage_node_buffer_routing_test SOURCES unit/storage_node_buffer_routing_test.cpp)
 
+add_executable(sitos_storage_node_buffer_lifecycle_test
+  unit/storage_node_buffer_lifecycle_test.cpp)
+target_link_libraries(sitos_storage_node_buffer_lifecycle_test
+  PRIVATE GTest::gtest_main sitos::sitos)
+target_include_directories(sitos_storage_node_buffer_lifecycle_test PRIVATE ${PROJECT_SOURCE_DIR}/src)
+sitos_enable_warnings(sitos_storage_node_buffer_lifecycle_test)
+gtest_add_tests(TARGET sitos_storage_node_buffer_lifecycle_test SOURCES unit/storage_node_buffer_lifecycle_test.cpp)
+
 add_executable(sitos_session_view_test
   unit/session_view_test.cpp)
 target_link_libraries(sitos_session_view_test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,8 @@ add_sitos_public_header_compile_test(
   sitos_session_view_header_compile_test consumer/session_view_header_compile.cpp)
 add_sitos_public_header_compile_test(
   sitos_rocksdb_engine_header_compile_test consumer/rocksdb_engine_header_compile.cpp)
+add_sitos_public_header_compile_test(
+  sitos_storage_node_header_compile_test consumer/storage_node_header_compile.cpp)
 if(SITOS_WITH_ZENOH)
   sitos_copy_zenohc(sitos_param_store_header_compile_test)
   sitos_copy_zenohc(sitos_param_cache_header_compile_test)
@@ -225,6 +227,21 @@ if(SITOS_WITH_ZENOH)
   sitos_copy_zenohc(sitos_storage_node_test)
 endif()
 gtest_add_tests(TARGET sitos_storage_node_test SOURCES unit/storage_node_test.cpp)
+
+add_executable(sitos_storage_node_buffer_api_test
+  unit/storage_node_buffer_api_test.cpp)
+target_link_libraries(sitos_storage_node_buffer_api_test
+  PRIVATE GTest::gtest_main sitos::sitos)
+sitos_enable_warnings(sitos_storage_node_buffer_api_test)
+gtest_add_tests(TARGET sitos_storage_node_buffer_api_test SOURCES unit/storage_node_buffer_api_test.cpp)
+
+add_executable(sitos_storage_node_buffer_routing_test
+  unit/storage_node_buffer_routing_test.cpp)
+target_link_libraries(sitos_storage_node_buffer_routing_test
+  PRIVATE GTest::gtest_main sitos::sitos)
+target_include_directories(sitos_storage_node_buffer_routing_test PRIVATE ${PROJECT_SOURCE_DIR}/src)
+sitos_enable_warnings(sitos_storage_node_buffer_routing_test)
+gtest_add_tests(TARGET sitos_storage_node_buffer_routing_test SOURCES unit/storage_node_buffer_routing_test.cpp)
 
 add_executable(sitos_session_view_test
   unit/session_view_test.cpp)

--- a/tests/consumer/storage_node_header_compile.cpp
+++ b/tests/consumer/storage_node_header_compile.cpp
@@ -23,4 +23,17 @@ static_assert(
         sitos::DurableBufferEngineFactory,
         std::function<sitos::Result<std::unique_ptr<sitos::StorageEngine>>(std::string_view)>>);
 
-int main() { return 0; }
+constexpr sitos::SessionOptions kBufferOptions{.durable_buffers = true, .ephemeral_buffers = true};
+static_assert(kBufferOptions.durable_buffers && kBufferOptions.ephemeral_buffers);
+
+int main() {
+  sitos::StorageNodeConfig default_config{};
+  sitos::StorageNodeConfig prefix_config{.prefix = "example"};
+  sitos::StorageNodeConfig two_field_config{.prefix = "example", .log_sink = nullptr};
+  sitos::StorageNodeConfig full_config{
+      .prefix = "example", .log_sink = nullptr, .durable_buffer_engine_factory = {}};
+  return (default_config.prefix == "sitos" && prefix_config.prefix == "example" &&
+          two_field_config.prefix == "example" && full_config.prefix == "example")
+             ? 0
+             : 1;
+}

--- a/tests/consumer/storage_node_header_compile.cpp
+++ b/tests/consumer/storage_node_header_compile.cpp
@@ -1,0 +1,26 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <functional>
+#include <memory>
+#include <string_view>
+#include <type_traits>
+
+#include "sitos/result.hpp"
+#include "sitos/storage_node.hpp"
+
+using LegacyCreateSession = sitos::Result<void> (sitos::StorageNode::*)(std::string_view);
+using CapabilityCreateSession = sitos::Result<void> (sitos::StorageNode::*)(std::string_view,
+                                                                            sitos::SessionOptions);
+static_assert(
+    std::is_same_v<decltype(static_cast<LegacyCreateSession>(&sitos::StorageNode::CreateSession)),
+                   LegacyCreateSession>);
+static_assert(std::is_same_v<
+              decltype(static_cast<CapabilityCreateSession>(&sitos::StorageNode::CreateSession)),
+              CapabilityCreateSession>);
+static_assert(
+    std::is_same_v<
+        sitos::DurableBufferEngineFactory,
+        std::function<sitos::Result<std::unique_ptr<sitos::StorageEngine>>(std::string_view)>>);
+
+int main() { return 0; }

--- a/tests/unit/storage_node_buffer_api_test.cpp
+++ b/tests/unit/storage_node_buffer_api_test.cpp
@@ -30,9 +30,15 @@ TEST(StorageNodeBufferApiTest, PreservesLegacyCreateSessionOverload) {
 }
 
 TEST(StorageNodeBufferApiTest, ExposesCapabilityOverloadAndFactory) {
-  SessionOptions options;
-  EXPECT_FALSE(options.durable);
-  EXPECT_FALSE(options.ephemeral);
+  SessionOptions options{.durable_buffers = true, .ephemeral_buffers = true};
+  EXPECT_TRUE(options.durable_buffers);
+  EXPECT_TRUE(options.ephemeral_buffers);
+  StorageNodeConfig default_config{};
+  StorageNodeConfig prefix_config{.prefix = "example"};
+  StorageNodeConfig two_field_config{.prefix = "example", .log_sink = nullptr};
+  EXPECT_EQ(default_config.prefix, "sitos");
+  EXPECT_EQ(prefix_config.prefix, "example");
+  EXPECT_EQ(two_field_config.prefix, "example");
   DurableBufferEngineFactory factory = [](std::string_view) {
     return Result<std::unique_ptr<StorageEngine>>::Err(
         std::make_error_code(std::errc::operation_not_supported));

--- a/tests/unit/storage_node_buffer_api_test.cpp
+++ b/tests/unit/storage_node_buffer_api_test.cpp
@@ -1,0 +1,44 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string_view>
+#include <type_traits>
+
+#include "sitos/storage_node.hpp"
+
+namespace sitos {
+namespace {
+
+static_assert(std::is_same_v<decltype(static_cast<Result<void> (StorageNode::*)(std::string_view)>(
+                                 &StorageNode::CreateSession)),
+                             Result<void> (StorageNode::*)(std::string_view)>);
+static_assert(std::is_same_v<
+              decltype(static_cast<Result<void> (StorageNode::*)(std::string_view, SessionOptions)>(
+                  &StorageNode::CreateSession)),
+              Result<void> (StorageNode::*)(std::string_view, SessionOptions)>);
+static_assert(
+    std::is_same_v<DurableBufferEngineFactory,
+                   std::function<Result<std::unique_ptr<StorageEngine>>(std::string_view)>>);
+
+TEST(StorageNodeBufferApiTest, PreservesLegacyCreateSessionOverload) {
+  auto member =
+      static_cast<Result<void> (StorageNode::*)(std::string_view)>(&StorageNode::CreateSession);
+  EXPECT_NE(member, nullptr);
+}
+
+TEST(StorageNodeBufferApiTest, ExposesCapabilityOverloadAndFactory) {
+  SessionOptions options;
+  EXPECT_FALSE(options.durable);
+  EXPECT_FALSE(options.ephemeral);
+  DurableBufferEngineFactory factory = [](std::string_view) {
+    return Result<std::unique_ptr<StorageEngine>>::Err(
+        std::make_error_code(std::errc::operation_not_supported));
+  };
+  EXPECT_TRUE(static_cast<bool>(factory));
+}
+
+}  // namespace
+}  // namespace sitos

--- a/tests/unit/storage_node_buffer_lifecycle_test.cpp
+++ b/tests/unit/storage_node_buffer_lifecycle_test.cpp
@@ -142,8 +142,7 @@ class LifecycleTransport final : public Transport {
     return Result<Queryable>::Ok(
         transport_test_access::DeclarationHandleTestAccess::MakeQueryable([] {}));
   }
-  void PutSample(std::string key) {
-    std::vector<std::byte> value{std::byte{1}};
+  void PutSample(std::string key, std::vector<std::byte> value = {std::byte{1}}) {
     subscriber(TransportSample{std::move(key), value, Encoding{"zenoh/bytes"}, std::nullopt,
                                TransportSample::Kind::Put});
   }
@@ -234,16 +233,34 @@ TEST(StorageNodeBufferLifecycleTest, FactoryFailureTaxonomyAndRollback) {
 
   LifecycleTransport err_transport;
   const auto cause = std::make_error_code(std::errc::permission_denied);
+  int err_calls = 0;
+  bool err_fail = true;
+  std::string err_sid;
+  auto err_destroyed = std::make_shared<bool>(false);
   auto err_node =
-      MakeNode(err_transport, std::make_shared<LifecycleEngine>(), [&](std::string_view) {
-        return Result<std::unique_ptr<StorageEngine>>::Err(Status::Disconnected,
-                                                           "factory-owned failure", cause);
+      MakeNode(err_transport, std::make_shared<LifecycleEngine>(), [&](std::string_view sid) {
+        ++err_calls;
+        err_sid = std::string(sid);
+        if (err_fail) {
+          return Result<std::unique_ptr<StorageEngine>>::Err(Status::Disconnected,
+                                                             "factory-owned failure", cause);
+        }
+        return Result<std::unique_ptr<StorageEngine>>::Ok(
+            std::make_unique<LifecycleEngine>(err_destroyed));
       });
   auto err_result = err_node->CreateSession("err", {.durable_buffers = true});
   EXPECT_EQ(err_result.StatusCode(), Status::Disconnected);
   EXPECT_EQ(err_result.Error(), cause);
   EXPECT_EQ(err_result.Message(), "factory-owned failure");
-  EXPECT_TRUE(err_node->CreateSession("err").IsOk());
+  EXPECT_EQ(err_calls, 1);
+  EXPECT_EQ(err_sid, "err");
+  err_fail = false;
+  ASSERT_TRUE(err_node->CreateSession("err", {.durable_buffers = true}).IsOk());
+  EXPECT_EQ(err_calls, 2);
+  err_transport.PutSample("sitos/buffers/err/durable/a", {std::byte{1}});
+  err_transport.PutSample("sitos/buffers/err/durable/b", {std::byte{2}});
+  ASSERT_TRUE(err_node->CloseSession("err").IsOk());
+  EXPECT_TRUE(*err_destroyed);
 
   LifecycleTransport setup_transport;
   auto setup_base = std::make_shared<LifecycleEngine>();
@@ -281,8 +298,9 @@ TEST(StorageNodeBufferLifecycleTest, FactoryFailureTaxonomyAndRollback) {
             Status::InvalidArgument);
   EXPECT_EQ(setup_calls, 2);
   ASSERT_TRUE(setup_node->CreateSession("collision").IsOk());
-  EXPECT_EQ(setup_node->CreateSession("collision", {.durable_buffers = true}).StatusCode(),
-            Status::Error);
+  auto active_collision = setup_node->CreateSession("collision", {.durable_buffers = true});
+  EXPECT_EQ(active_collision.StatusCode(), Status::Error);
+  EXPECT_EQ(active_collision.Error(), std::make_error_code(std::errc::file_exists));
   EXPECT_EQ(setup_calls, 2);
 
   LifecycleTransport phase_transport;
@@ -310,8 +328,10 @@ TEST(StorageNodeBufferLifecycleTest, FactoryFailureTaxonomyAndRollback) {
     std::unique_lock lock(phase_mutex);
     phase_cv.wait(lock, [&] { return factory_entered; });
   }
-  EXPECT_EQ(phase_node->CreateSession("phase", {.durable_buffers = true}).StatusCode(),
-            Status::Error);
+  EXPECT_EQ(phase_transport.Query("sitos/buffers/phase/durable/**"), 0);
+  auto creating_collision = phase_node->CreateSession("phase", {.durable_buffers = true});
+  EXPECT_EQ(creating_collision.StatusCode(), Status::Error);
+  EXPECT_EQ(creating_collision.Error(), std::make_error_code(std::errc::operation_in_progress));
   EXPECT_EQ(phase_calls, 1);
   {
     std::scoped_lock lock(phase_mutex);
@@ -339,12 +359,18 @@ TEST(StorageNodeBufferLifecycleTest, FactoryFailureTaxonomyAndRollback) {
   std::thread blocked_put([&] { closing_transport.PutSample("sitos/buffers/closing/durable/k"); });
   closing_raw->WaitFor(closing_raw->put_entered);
   std::optional<Result<void>> close_result;
-  std::thread close([&] { close_result = closing_node->CloseSession("closing"); });
+  std::atomic<bool> close_done = false;
+  std::thread close([&] {
+    close_result = closing_node->CloseSession("closing");
+    close_done.store(true, std::memory_order_release);
+  });
   ASSERT_TRUE(
       storage_node_test_access::StorageNodeTestAccess::WaitForClosing(*closing_node, "closing"));
-  EXPECT_EQ(closing_node->CreateSession("closing", {.durable_buffers = true}).StatusCode(),
-            Status::Error);
-  EXPECT_FALSE(close_result.has_value());
+  EXPECT_EQ(closing_transport.Query("sitos/buffers/closing/durable/**"), 0);
+  auto closing_collision = closing_node->CreateSession("closing", {.durable_buffers = true});
+  EXPECT_EQ(closing_collision.StatusCode(), Status::Error);
+  EXPECT_EQ(closing_collision.Error(), std::make_error_code(std::errc::operation_in_progress));
+  EXPECT_FALSE(close_done.load(std::memory_order_acquire));
   closing_raw->ReleaseAll();
   blocked_put.join();
   close.join();
@@ -451,9 +477,13 @@ TEST(StorageNodeBufferLifecycleTest, CloseQuiescesDurableOperationsAndDestroysEn
   durable_raw->WaitFor(durable_raw->list_entered);
 
   std::optional<Result<void>> close_result;
-  std::thread close([&] { close_result = node->CloseSession("s"); });
+  std::atomic<bool> close_done = false;
+  std::thread close([&] {
+    close_result = node->CloseSession("s");
+    close_done.store(true, std::memory_order_release);
+  });
   ASSERT_TRUE(storage_node_test_access::StorageNodeTestAccess::WaitForClosing(*node, "s"));
-  EXPECT_FALSE(close_result.has_value());
+  EXPECT_FALSE(close_done.load(std::memory_order_acquire));
   durable_raw->ReleaseAll();
   put.join();
   get.join();

--- a/tests/unit/storage_node_buffer_lifecycle_test.cpp
+++ b/tests/unit/storage_node_buffer_lifecycle_test.cpp
@@ -28,6 +28,7 @@ class LifecycleEngine final : public StorageEngine {
   explicit LifecycleEngine(std::shared_ptr<bool> destroyed = nullptr)
       : destroyed_(std::move(destroyed)) {}
   ~LifecycleEngine() override {
+    std::scoped_lock lock(release_mutex_);
     if (destroyed_) *destroyed_ = true;
   }
 
@@ -83,6 +84,7 @@ class LifecycleEngine final : public StorageEngine {
     }
   }
   void ReleaseAll() {
+    std::scoped_lock release_lock(release_mutex_);
     {
       std::scoped_lock lock(gate_mutex_);
       block_put = false;
@@ -94,6 +96,7 @@ class LifecycleEngine final : public StorageEngine {
 
   mutable std::mutex mutex_;
   mutable std::mutex gate_mutex_;
+  mutable std::mutex release_mutex_;
   mutable std::condition_variable cv;
   mutable std::map<std::string, std::vector<std::byte>> values_;
   mutable int put_entered = 0;

--- a/tests/unit/storage_node_buffer_lifecycle_test.cpp
+++ b/tests/unit/storage_node_buffer_lifecycle_test.cpp
@@ -1,0 +1,366 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "sitos/storage_node.hpp"
+#include "transport/declaration_handle_test_access.hpp"
+
+namespace sitos {
+namespace {
+
+class LifecycleEngine final : public StorageEngine {
+ public:
+  enum class SnapshotMode { Normal, Null, Throw };
+
+  explicit LifecycleEngine(std::shared_ptr<bool> destroyed = nullptr)
+      : destroyed_(std::move(destroyed)) {}
+  ~LifecycleEngine() override {
+    if (destroyed_) *destroyed_ = true;
+  }
+
+  bool Put(std::string_view key, Bytes value) override {
+    WaitUntilReleased(block_put, put_entered);
+    std::scoped_lock lock(mutex_);
+    values_[std::string(key)] = {value.begin(), value.end()};
+    return true;
+  }
+  bool Delete(std::string_view key) override {
+    std::scoped_lock lock(mutex_);
+    values_.erase(std::string(key));
+    return true;
+  }
+  bool Get(std::string_view key, const EntrySink& sink) const override {
+    WaitUntilReleased(block_get, get_entered);
+    std::unique_lock lock(mutex_);
+    auto it = values_.find(std::string(key));
+    if (it == values_.end()) return false;
+    auto copied_key = it->first;
+    auto copied_value = it->second;
+    lock.unlock();
+    return sink(copied_key, copied_value);
+  }
+  bool List(std::string_view prefix, const EntrySink& sink) const override {
+    WaitUntilReleased(block_list, list_entered);
+    std::unique_lock lock(mutex_);
+    std::vector<std::pair<std::string, std::vector<std::byte>>> entries;
+    for (const auto& [key, value] : values_) {
+      if (key.starts_with(prefix)) entries.emplace_back(key, value);
+    }
+    lock.unlock();
+    for (const auto& [key, value] : entries) {
+      if (!sink(key, value)) return false;
+    }
+    return true;
+  }
+  std::shared_ptr<const StorageReader> TakeSnapshot() const override {
+    if (snapshot_mode == SnapshotMode::Throw) throw std::runtime_error("snapshot failure");
+    if (snapshot_mode == SnapshotMode::Null) return nullptr;
+    return StorageEngine::TakeSnapshot();
+  }
+
+  void WaitFor(int& count) {
+    std::unique_lock lock(gate_mutex_);
+    cv.wait(lock, [&] { return count > 0; });
+  }
+  void BlockGetAndList() {
+    {
+      std::scoped_lock lock(gate_mutex_);
+      block_get = true;
+      block_list = true;
+    }
+  }
+  void ReleaseAll() {
+    {
+      std::scoped_lock lock(gate_mutex_);
+      block_put = false;
+      block_get = false;
+      block_list = false;
+    }
+    cv.notify_all();
+  }
+
+  mutable std::mutex mutex_;
+  mutable std::mutex gate_mutex_;
+  mutable std::condition_variable cv;
+  mutable std::map<std::string, std::vector<std::byte>> values_;
+  mutable int put_entered = 0;
+  mutable int get_entered = 0;
+  mutable int list_entered = 0;
+  bool block_put = false;
+  mutable bool block_get = false;
+  mutable bool block_list = false;
+  mutable SnapshotMode snapshot_mode = SnapshotMode::Normal;
+  std::shared_ptr<bool> destroyed_;
+
+ private:
+  void WaitUntilReleased(bool& blocked, int& entered) const {
+    std::unique_lock lock(gate_mutex_);
+    if (!blocked) return;
+    ++entered;
+    cv.notify_all();
+    cv.wait(lock, [&] { return !blocked; });
+  }
+};
+
+class LifecycleTransport final : public Transport {
+ public:
+  Result<void> Put(std::string_view, std::span<const std::byte>, Encoding, PutOptions) override {
+    return Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
+  }
+  Result<void> Delete(std::string_view, PutOptions) override {
+    return Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
+  }
+  Result<void> Get(std::string_view, const QueryResultSink&, std::chrono::milliseconds) override {
+    return Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
+  }
+  Result<Subscription> DeclareSubscriber(
+      std::string_view, std::function<void(const TransportSample&)> callback) override {
+    subscriber = std::move(callback);
+    return Result<Subscription>::Ok(
+        transport_test_access::DeclarationHandleTestAccess::MakeSubscription([] {}));
+  }
+  Result<Queryable> DeclareQueryable(std::string_view,
+                                     std::function<void(TransportQuery&)> callback) override {
+    queryable = std::move(callback);
+    return Result<Queryable>::Ok(
+        transport_test_access::DeclarationHandleTestAccess::MakeQueryable([] {}));
+  }
+  void PutSample(std::string key) {
+    std::vector<std::byte> value{std::byte{1}};
+    subscriber(TransportSample{std::move(key), value, Encoding{"zenoh/bytes"}, std::nullopt,
+                               TransportSample::Kind::Put});
+  }
+  int Query(std::string key) {
+    int replies = 0;
+    auto query =
+        TransportQuery::ForTesting([&](std::string_view, std::span<const std::byte>, Encoding) {
+          ++replies;
+          return Result<void>::Ok();
+        });
+    query.keyexpr = std::move(key);
+    queryable(query);
+    return replies;
+  }
+  std::function<void(const TransportSample&)> subscriber;
+  std::function<void(TransportQuery&)> queryable;
+};
+
+std::unique_ptr<StorageNode> MakeNode(LifecycleTransport& transport,
+                                      std::shared_ptr<LifecycleEngine> base,
+                                      DurableBufferEngineFactory factory = {}) {
+  auto node = std::make_unique<StorageNode>(transport);
+  EXPECT_TRUE(node->Start(std::move(base), transport,
+                          {.prefix = "sitos",
+                           .log_sink = nullptr,
+                           .durable_buffer_engine_factory = std::move(factory)}));
+  return node;
+}
+
+TEST(StorageNodeBufferLifecycleTest, FactoryFailureTaxonomyAndRollback) {
+  LifecycleTransport transport;
+  auto base = std::make_shared<LifecycleEngine>();
+  auto node = MakeNode(transport, base);
+  auto no_factory = node->CreateSession("missing", {.durable_buffers = true});
+  EXPECT_EQ(no_factory.StatusCode(), Status::InvalidArgument);
+  EXPECT_EQ(no_factory.Error(), std::make_error_code(std::errc::invalid_argument));
+  EXPECT_EQ(no_factory.Message(), "durable buffer engine factory is required");
+  EXPECT_TRUE(node->CreateSession("missing").IsOk());
+
+  int calls = 0;
+  LifecycleTransport null_transport;
+  auto null_node =
+      MakeNode(null_transport, std::make_shared<LifecycleEngine>(), [&](std::string_view sid) {
+        EXPECT_EQ(sid, "null");
+        ++calls;
+        return Result<std::unique_ptr<StorageEngine>>::Ok(nullptr);
+      });
+  auto null_result = null_node->CreateSession("null", {.durable_buffers = true});
+  EXPECT_EQ(null_result.StatusCode(), Status::Error);
+  EXPECT_EQ(null_result.Error(), MakeErrorCode(Status::Error));
+  EXPECT_EQ(null_result.Message(), "durable buffer engine factory returned null");
+  EXPECT_EQ(calls, 1);
+  EXPECT_TRUE(null_node->CreateSession("null").IsOk());
+
+  LifecycleTransport throw_transport;
+  auto throw_node = MakeNode(throw_transport, std::make_shared<LifecycleEngine>(),
+                             [&](std::string_view) -> Result<std::unique_ptr<StorageEngine>> {
+                               ++calls;
+                               throw std::runtime_error("hidden detail");
+                             });
+  auto throw_result = throw_node->CreateSession("throw", {.durable_buffers = true});
+  EXPECT_EQ(throw_result.StatusCode(), Status::Error);
+  EXPECT_EQ(throw_result.Message(), "durable buffer engine factory threw an exception");
+  EXPECT_EQ(calls, 2);
+
+  LifecycleTransport err_transport;
+  const auto cause = std::make_error_code(std::errc::permission_denied);
+  auto err_node =
+      MakeNode(err_transport, std::make_shared<LifecycleEngine>(), [&](std::string_view) {
+        return Result<std::unique_ptr<StorageEngine>>::Err(Status::Disconnected,
+                                                           "factory-owned failure", cause);
+      });
+  auto err_result = err_node->CreateSession("err", {.durable_buffers = true});
+  EXPECT_EQ(err_result.StatusCode(), Status::Disconnected);
+  EXPECT_EQ(err_result.Error(), cause);
+  EXPECT_EQ(err_result.Message(), "factory-owned failure");
+  EXPECT_TRUE(err_node->CreateSession("err").IsOk());
+
+  LifecycleTransport setup_transport;
+  auto setup_base = std::make_shared<LifecycleEngine>();
+  int setup_calls = 0;
+  auto setup_node = MakeNode(setup_transport, setup_base, [&](std::string_view) {
+    ++setup_calls;
+    return Result<std::unique_ptr<StorageEngine>>::Ok(std::make_unique<LifecycleEngine>());
+  });
+  setup_base->snapshot_mode = LifecycleEngine::SnapshotMode::Null;
+  auto snapshot_null = setup_node->CreateSession("snapshot-null", {.durable_buffers = true});
+  EXPECT_EQ(snapshot_null.StatusCode(), Status::Error);
+  EXPECT_EQ(snapshot_null.Error(), MakeErrorCode(Status::Error));
+  EXPECT_EQ(snapshot_null.Message(), "base snapshot creation returned null");
+  EXPECT_EQ(setup_calls, 0);
+  setup_base->snapshot_mode = LifecycleEngine::SnapshotMode::Throw;
+  auto snapshot_throw = setup_node->CreateSession("snapshot-throw", {.durable_buffers = true});
+  EXPECT_EQ(snapshot_throw.StatusCode(), Status::Error);
+  EXPECT_EQ(snapshot_throw.Message(), "base snapshot creation threw an exception");
+  EXPECT_EQ(setup_calls, 0);
+  setup_base->snapshot_mode = LifecycleEngine::SnapshotMode::Normal;
+
+  EXPECT_EQ(setup_node->CreateSession("bad sid", {.durable_buffers = true}).StatusCode(),
+            Status::InvalidArgument);
+  EXPECT_EQ(setup_calls, 0);
+  ASSERT_TRUE(setup_node->CreateSession("collision").IsOk());
+  EXPECT_EQ(setup_node->CreateSession("collision", {.durable_buffers = true}).StatusCode(),
+            Status::Error);
+  EXPECT_EQ(setup_calls, 0);
+
+  setup_node->Stop();
+  for (auto result : {setup_node->CreateSession("stopped"),
+                      setup_node->CreateSession("stopped", {.durable_buffers = true})}) {
+    EXPECT_EQ(result.StatusCode(), Status::InvalidArgument);
+    EXPECT_EQ(result.Error(), std::make_error_code(std::errc::invalid_argument));
+    EXPECT_TRUE(result.Message().empty());
+  }
+  EXPECT_EQ(setup_calls, 0);
+}
+
+TEST(StorageNodeBufferLifecycleTest, FactoryAndStopLinearizeDeterministically) {
+  LifecycleTransport transport;
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool factory_entered = false;
+  bool release_factory = false;
+  auto destroyed = std::make_shared<bool>(false);
+  auto node = MakeNode(transport, std::make_shared<LifecycleEngine>(), [&](std::string_view sid) {
+    EXPECT_EQ(sid, "s");
+    {
+      std::scoped_lock lock(mutex);
+      factory_entered = true;
+    }
+    cv.notify_all();
+    std::unique_lock lock(mutex);
+    cv.wait(lock, [&] { return release_factory; });
+    return Result<std::unique_ptr<StorageEngine>>::Ok(std::make_unique<LifecycleEngine>(destroyed));
+  });
+  std::atomic<bool> create_done = false;
+  std::atomic<bool> stop_done = false;
+  std::thread create([&] {
+    EXPECT_TRUE(node->CreateSession("s", {.durable_buffers = true}).IsOk());
+    create_done = true;
+  });
+  {
+    std::unique_lock lock(mutex);
+    cv.wait(lock, [&] { return factory_entered; });
+  }
+  std::thread stop([&] {
+    node->Stop();
+    stop_done = true;
+  });
+  std::this_thread::yield();
+  EXPECT_FALSE(create_done.load());
+  EXPECT_FALSE(stop_done.load());
+  {
+    std::scoped_lock lock(mutex);
+    release_factory = true;
+  }
+  cv.notify_all();
+  create.join();
+  stop.join();
+  EXPECT_TRUE(create_done);
+  EXPECT_TRUE(stop_done);
+  EXPECT_TRUE(*destroyed);
+}
+
+TEST(StorageNodeBufferLifecycleTest, CloseQuiescesDurableOperationsAndDestroysEngine) {
+  LifecycleTransport transport;
+  auto destroyed = std::make_shared<bool>(false);
+  LifecycleEngine* durable_raw = nullptr;
+  auto node = MakeNode(transport, std::make_shared<LifecycleEngine>(), [&](std::string_view) {
+    auto durable = std::make_unique<LifecycleEngine>(destroyed);
+    durable->block_put = true;
+    durable_raw = durable.get();
+    return Result<std::unique_ptr<StorageEngine>>::Ok(std::move(durable));
+  });
+  ASSERT_TRUE(node->CreateSession("s", {.durable_buffers = true}).IsOk());
+
+  std::thread put([&] { transport.PutSample("sitos/buffers/s/durable/put"); });
+  durable_raw->WaitFor(durable_raw->put_entered);
+  durable_raw->BlockGetAndList();
+  std::thread get([&] { transport.Query("sitos/buffers/s/durable/get"); });
+  std::thread list([&] { transport.Query("sitos/buffers/s/durable/**"); });
+  durable_raw->WaitFor(durable_raw->get_entered);
+  durable_raw->WaitFor(durable_raw->list_entered);
+
+  std::atomic<bool> close_started = false;
+  std::atomic<bool> closed = false;
+  std::thread close([&] {
+    close_started = true;
+    ASSERT_TRUE(node->CloseSession("s").IsOk());
+    closed = true;
+  });
+  while (!close_started.load()) std::this_thread::yield();
+  EXPECT_FALSE(closed.load());
+  durable_raw->ReleaseAll();
+  put.join();
+  get.join();
+  list.join();
+  close.join();
+  EXPECT_TRUE(closed.load());
+  EXPECT_TRUE(*destroyed);
+}
+
+TEST(StorageNodeBufferLifecycleTest, SameSidRecreationUsesFreshEngine) {
+  LifecycleTransport transport;
+  int calls = 0;
+  std::vector<std::shared_ptr<bool>> destroyed;
+  auto node = MakeNode(transport, std::make_shared<LifecycleEngine>(), [&](std::string_view) {
+    ++calls;
+    auto was_destroyed = std::make_shared<bool>(false);
+    destroyed.push_back(was_destroyed);
+    return Result<std::unique_ptr<StorageEngine>>::Ok(
+        std::make_unique<LifecycleEngine>(was_destroyed));
+  });
+  ASSERT_TRUE(node->CreateSession("s", {.durable_buffers = true}).IsOk());
+  transport.PutSample("sitos/buffers/s/durable/k");
+  ASSERT_TRUE(node->CloseSession("s").IsOk());
+  ASSERT_TRUE(node->CreateSession("s", {.durable_buffers = true}).IsOk());
+  EXPECT_EQ(calls, 2);
+  EXPECT_TRUE(*destroyed[0]);
+  EXPECT_FALSE(*destroyed[1]);
+  EXPECT_EQ(transport.Query("sitos/buffers/s/durable/k"), 0);
+}
+
+}  // namespace
+}  // namespace sitos

--- a/tests/unit/storage_node_buffer_lifecycle_test.cpp
+++ b/tests/unit/storage_node_buffer_lifecycle_test.cpp
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "sitos/storage_node.hpp"
+#include "storage_node_test_access.hpp"
 #include "transport/declaration_handle_test_access.hpp"
 
 namespace sitos {
@@ -173,40 +174,63 @@ std::unique_ptr<StorageNode> MakeNode(LifecycleTransport& transport,
 }
 
 TEST(StorageNodeBufferLifecycleTest, FactoryFailureTaxonomyAndRollback) {
-  LifecycleTransport transport;
-  auto base = std::make_shared<LifecycleEngine>();
-  auto node = MakeNode(transport, base);
-  auto no_factory = node->CreateSession("missing", {.durable_buffers = true});
+  LifecycleTransport no_factory_transport;
+  auto no_factory_node = MakeNode(no_factory_transport, std::make_shared<LifecycleEngine>());
+  auto no_factory = no_factory_node->CreateSession("missing", {.durable_buffers = true});
   EXPECT_EQ(no_factory.StatusCode(), Status::InvalidArgument);
   EXPECT_EQ(no_factory.Error(), std::make_error_code(std::errc::invalid_argument));
   EXPECT_EQ(no_factory.Message(), "durable buffer engine factory is required");
-  EXPECT_TRUE(node->CreateSession("missing").IsOk());
+  EXPECT_TRUE(no_factory_node->CreateSession("missing").IsOk());
 
-  int calls = 0;
+  int null_calls = 0;
+  bool return_null = true;
+  std::string null_sid;
+  auto null_destroyed = std::make_shared<bool>(false);
   LifecycleTransport null_transport;
   auto null_node =
       MakeNode(null_transport, std::make_shared<LifecycleEngine>(), [&](std::string_view sid) {
-        EXPECT_EQ(sid, "null");
-        ++calls;
-        return Result<std::unique_ptr<StorageEngine>>::Ok(nullptr);
+        ++null_calls;
+        null_sid = std::string(sid);
+        if (return_null) {
+          return Result<std::unique_ptr<StorageEngine>>::Ok(nullptr);
+        }
+        return Result<std::unique_ptr<StorageEngine>>::Ok(
+            std::make_unique<LifecycleEngine>(null_destroyed));
       });
   auto null_result = null_node->CreateSession("null", {.durable_buffers = true});
   EXPECT_EQ(null_result.StatusCode(), Status::Error);
   EXPECT_EQ(null_result.Error(), MakeErrorCode(Status::Error));
   EXPECT_EQ(null_result.Message(), "durable buffer engine factory returned null");
-  EXPECT_EQ(calls, 1);
-  EXPECT_TRUE(null_node->CreateSession("null").IsOk());
+  EXPECT_EQ(null_sid, "null");
+  return_null = false;
+  EXPECT_TRUE(null_node->CreateSession("null", {.durable_buffers = true}).IsOk());
+  EXPECT_EQ(null_calls, 2);
+  EXPECT_TRUE(null_node->CloseSession("null").IsOk());
+  EXPECT_TRUE(*null_destroyed);
 
+  int throw_calls = 0;
+  bool throw_factory = true;
+  std::string throw_sid;
+  auto throw_destroyed = std::make_shared<bool>(false);
   LifecycleTransport throw_transport;
-  auto throw_node = MakeNode(throw_transport, std::make_shared<LifecycleEngine>(),
-                             [&](std::string_view) -> Result<std::unique_ptr<StorageEngine>> {
-                               ++calls;
-                               throw std::runtime_error("hidden detail");
-                             });
+  auto throw_node =
+      MakeNode(throw_transport, std::make_shared<LifecycleEngine>(), [&](std::string_view sid) {
+        ++throw_calls;
+        throw_sid = std::string(sid);
+        if (throw_factory) throw std::runtime_error("hidden detail");
+        return Result<std::unique_ptr<StorageEngine>>::Ok(
+            std::make_unique<LifecycleEngine>(throw_destroyed));
+      });
   auto throw_result = throw_node->CreateSession("throw", {.durable_buffers = true});
   EXPECT_EQ(throw_result.StatusCode(), Status::Error);
+  EXPECT_EQ(throw_result.Error(), MakeErrorCode(Status::Error));
   EXPECT_EQ(throw_result.Message(), "durable buffer engine factory threw an exception");
-  EXPECT_EQ(calls, 2);
+  EXPECT_EQ(throw_sid, "throw");
+  throw_factory = false;
+  EXPECT_TRUE(throw_node->CreateSession("throw", {.durable_buffers = true}).IsOk());
+  EXPECT_EQ(throw_calls, 2);
+  EXPECT_TRUE(throw_node->CloseSession("throw").IsOk());
+  EXPECT_TRUE(*throw_destroyed);
 
   LifecycleTransport err_transport;
   const auto cause = std::make_error_code(std::errc::permission_denied);
@@ -224,9 +248,13 @@ TEST(StorageNodeBufferLifecycleTest, FactoryFailureTaxonomyAndRollback) {
   LifecycleTransport setup_transport;
   auto setup_base = std::make_shared<LifecycleEngine>();
   int setup_calls = 0;
-  auto setup_node = MakeNode(setup_transport, setup_base, [&](std::string_view) {
+  std::string setup_sid;
+  auto setup_destroyed = std::make_shared<bool>(false);
+  auto setup_node = MakeNode(setup_transport, setup_base, [&](std::string_view sid) {
     ++setup_calls;
-    return Result<std::unique_ptr<StorageEngine>>::Ok(std::make_unique<LifecycleEngine>());
+    setup_sid = std::string(sid);
+    return Result<std::unique_ptr<StorageEngine>>::Ok(
+        std::make_unique<LifecycleEngine>(setup_destroyed));
   });
   setup_base->snapshot_mode = LifecycleEngine::SnapshotMode::Null;
   auto snapshot_null = setup_node->CreateSession("snapshot-null", {.durable_buffers = true});
@@ -234,20 +262,113 @@ TEST(StorageNodeBufferLifecycleTest, FactoryFailureTaxonomyAndRollback) {
   EXPECT_EQ(snapshot_null.Error(), MakeErrorCode(Status::Error));
   EXPECT_EQ(snapshot_null.Message(), "base snapshot creation returned null");
   EXPECT_EQ(setup_calls, 0);
+  setup_base->snapshot_mode = LifecycleEngine::SnapshotMode::Normal;
+  EXPECT_TRUE(setup_node->CreateSession("snapshot-null", {.durable_buffers = true}).IsOk());
+  EXPECT_EQ(setup_calls, 1);
+  EXPECT_EQ(setup_sid, "snapshot-null");
+  EXPECT_TRUE(setup_node->CloseSession("snapshot-null").IsOk());
   setup_base->snapshot_mode = LifecycleEngine::SnapshotMode::Throw;
   auto snapshot_throw = setup_node->CreateSession("snapshot-throw", {.durable_buffers = true});
   EXPECT_EQ(snapshot_throw.StatusCode(), Status::Error);
+  EXPECT_EQ(snapshot_throw.Error(), MakeErrorCode(Status::Error));
   EXPECT_EQ(snapshot_throw.Message(), "base snapshot creation threw an exception");
-  EXPECT_EQ(setup_calls, 0);
+  EXPECT_EQ(setup_calls, 1);
   setup_base->snapshot_mode = LifecycleEngine::SnapshotMode::Normal;
+  EXPECT_TRUE(setup_node->CreateSession("snapshot-throw", {.durable_buffers = true}).IsOk());
+  EXPECT_EQ(setup_calls, 2);
 
   EXPECT_EQ(setup_node->CreateSession("bad sid", {.durable_buffers = true}).StatusCode(),
             Status::InvalidArgument);
-  EXPECT_EQ(setup_calls, 0);
+  EXPECT_EQ(setup_calls, 2);
   ASSERT_TRUE(setup_node->CreateSession("collision").IsOk());
   EXPECT_EQ(setup_node->CreateSession("collision", {.durable_buffers = true}).StatusCode(),
             Status::Error);
-  EXPECT_EQ(setup_calls, 0);
+  EXPECT_EQ(setup_calls, 2);
+
+  LifecycleTransport phase_transport;
+  bool release_factory = false;
+  std::mutex phase_mutex;
+  std::condition_variable phase_cv;
+  bool factory_entered = false;
+  int phase_calls = 0;
+  auto phase_node =
+      MakeNode(phase_transport, std::make_shared<LifecycleEngine>(), [&](std::string_view) {
+        ++phase_calls;
+        {
+          std::scoped_lock lock(phase_mutex);
+          factory_entered = true;
+        }
+        phase_cv.notify_all();
+        std::unique_lock lock(phase_mutex);
+        phase_cv.wait(lock, [&] { return release_factory; });
+        return Result<std::unique_ptr<StorageEngine>>::Ok(std::make_unique<LifecycleEngine>());
+      });
+  std::optional<Result<void>> creating_result;
+  std::thread creating(
+      [&] { creating_result = phase_node->CreateSession("phase", {.durable_buffers = true}); });
+  {
+    std::unique_lock lock(phase_mutex);
+    phase_cv.wait(lock, [&] { return factory_entered; });
+  }
+  EXPECT_EQ(phase_node->CreateSession("phase", {.durable_buffers = true}).StatusCode(),
+            Status::Error);
+  EXPECT_EQ(phase_calls, 1);
+  {
+    std::scoped_lock lock(phase_mutex);
+    release_factory = true;
+  }
+  phase_cv.notify_all();
+  creating.join();
+  ASSERT_TRUE(creating_result.has_value());
+  EXPECT_TRUE(creating_result->IsOk());
+  EXPECT_TRUE(phase_node->CloseSession("phase").IsOk());
+
+  LifecycleTransport closing_transport;
+  LifecycleEngine* closing_raw = nullptr;
+  auto closing_destroyed = std::make_shared<bool>(false);
+  int closing_calls = 0;
+  auto closing_node =
+      MakeNode(closing_transport, std::make_shared<LifecycleEngine>(), [&](std::string_view) {
+        ++closing_calls;
+        auto engine = std::make_unique<LifecycleEngine>(closing_destroyed);
+        engine->block_put = true;
+        closing_raw = engine.get();
+        return Result<std::unique_ptr<StorageEngine>>::Ok(std::move(engine));
+      });
+  ASSERT_TRUE(closing_node->CreateSession("closing", {.durable_buffers = true}).IsOk());
+  std::thread blocked_put([&] { closing_transport.PutSample("sitos/buffers/closing/durable/k"); });
+  closing_raw->WaitFor(closing_raw->put_entered);
+  std::optional<Result<void>> close_result;
+  std::thread close([&] { close_result = closing_node->CloseSession("closing"); });
+  ASSERT_TRUE(
+      storage_node_test_access::StorageNodeTestAccess::WaitForClosing(*closing_node, "closing"));
+  EXPECT_EQ(closing_node->CreateSession("closing", {.durable_buffers = true}).StatusCode(),
+            Status::Error);
+  EXPECT_FALSE(close_result.has_value());
+  closing_raw->ReleaseAll();
+  blocked_put.join();
+  close.join();
+  ASSERT_TRUE(close_result.has_value());
+  EXPECT_TRUE(close_result->IsOk());
+  EXPECT_EQ(closing_calls, 1);
+  EXPECT_TRUE(*closing_destroyed);
+
+  auto success_destroyed = std::make_shared<bool>(false);
+  std::string success_sid;
+  int success_calls = 0;
+  LifecycleTransport success_transport;
+  auto success_node =
+      MakeNode(success_transport, std::make_shared<LifecycleEngine>(), [&](std::string_view sid) {
+        ++success_calls;
+        success_sid = std::string(sid);
+        return Result<std::unique_ptr<StorageEngine>>::Ok(
+            std::make_unique<LifecycleEngine>(success_destroyed));
+      });
+  ASSERT_TRUE(success_node->CreateSession("success", {.durable_buffers = true}).IsOk());
+  EXPECT_EQ(success_calls, 1);
+  EXPECT_EQ(success_sid, "success");
+  ASSERT_TRUE(success_node->CloseSession("success").IsOk());
+  EXPECT_TRUE(*success_destroyed);
 
   setup_node->Stop();
   for (auto result : {setup_node->CreateSession("stopped"),
@@ -256,7 +377,7 @@ TEST(StorageNodeBufferLifecycleTest, FactoryFailureTaxonomyAndRollback) {
     EXPECT_EQ(result.Error(), std::make_error_code(std::errc::invalid_argument));
     EXPECT_TRUE(result.Message().empty());
   }
-  EXPECT_EQ(setup_calls, 0);
+  EXPECT_EQ(setup_calls, 2);
 }
 
 TEST(StorageNodeBufferLifecycleTest, FactoryAndStopLinearizeDeterministically) {
@@ -266,8 +387,9 @@ TEST(StorageNodeBufferLifecycleTest, FactoryAndStopLinearizeDeterministically) {
   bool factory_entered = false;
   bool release_factory = false;
   auto destroyed = std::make_shared<bool>(false);
+  std::string factory_sid;
   auto node = MakeNode(transport, std::make_shared<LifecycleEngine>(), [&](std::string_view sid) {
-    EXPECT_EQ(sid, "s");
+    factory_sid = std::string(sid);
     {
       std::scoped_lock lock(mutex);
       factory_entered = true;
@@ -277,12 +399,11 @@ TEST(StorageNodeBufferLifecycleTest, FactoryAndStopLinearizeDeterministically) {
     cv.wait(lock, [&] { return release_factory; });
     return Result<std::unique_ptr<StorageEngine>>::Ok(std::make_unique<LifecycleEngine>(destroyed));
   });
-  std::atomic<bool> create_done = false;
+  auto observer = storage_node_test_access::StorageNodeTestAccess::CaptureGateObserver(*node);
+  ASSERT_TRUE(observer.has_value());
+  std::optional<Result<void>> create_result;
   std::atomic<bool> stop_done = false;
-  std::thread create([&] {
-    EXPECT_TRUE(node->CreateSession("s", {.durable_buffers = true}).IsOk());
-    create_done = true;
-  });
+  std::thread create([&] { create_result = node->CreateSession("s", {.durable_buffers = true}); });
   {
     std::unique_lock lock(mutex);
     cv.wait(lock, [&] { return factory_entered; });
@@ -291,9 +412,10 @@ TEST(StorageNodeBufferLifecycleTest, FactoryAndStopLinearizeDeterministically) {
     node->Stop();
     stop_done = true;
   });
-  std::this_thread::yield();
-  EXPECT_FALSE(create_done.load());
+  ASSERT_TRUE(observer->WaitForClosed());
   EXPECT_FALSE(stop_done.load());
+  EXPECT_EQ(node->CreateSession("late", {.durable_buffers = true}).StatusCode(),
+            Status::InvalidArgument);
   {
     std::scoped_lock lock(mutex);
     release_factory = true;
@@ -301,8 +423,10 @@ TEST(StorageNodeBufferLifecycleTest, FactoryAndStopLinearizeDeterministically) {
   cv.notify_all();
   create.join();
   stop.join();
-  EXPECT_TRUE(create_done);
-  EXPECT_TRUE(stop_done);
+  ASSERT_TRUE(create_result.has_value());
+  EXPECT_TRUE(create_result->IsOk());
+  EXPECT_EQ(factory_sid, "s");
+  EXPECT_TRUE(stop_done.load());
   EXPECT_TRUE(*destroyed);
 }
 
@@ -326,21 +450,17 @@ TEST(StorageNodeBufferLifecycleTest, CloseQuiescesDurableOperationsAndDestroysEn
   durable_raw->WaitFor(durable_raw->get_entered);
   durable_raw->WaitFor(durable_raw->list_entered);
 
-  std::atomic<bool> close_started = false;
-  std::atomic<bool> closed = false;
-  std::thread close([&] {
-    close_started = true;
-    ASSERT_TRUE(node->CloseSession("s").IsOk());
-    closed = true;
-  });
-  while (!close_started.load()) std::this_thread::yield();
-  EXPECT_FALSE(closed.load());
+  std::optional<Result<void>> close_result;
+  std::thread close([&] { close_result = node->CloseSession("s"); });
+  ASSERT_TRUE(storage_node_test_access::StorageNodeTestAccess::WaitForClosing(*node, "s"));
+  EXPECT_FALSE(close_result.has_value());
   durable_raw->ReleaseAll();
   put.join();
   get.join();
   list.join();
   close.join();
-  EXPECT_TRUE(closed.load());
+  ASSERT_TRUE(close_result.has_value());
+  EXPECT_TRUE(close_result->IsOk());
   EXPECT_TRUE(*destroyed);
 }
 

--- a/tests/unit/storage_node_buffer_lifecycle_test.cpp
+++ b/tests/unit/storage_node_buffer_lifecycle_test.cpp
@@ -237,6 +237,7 @@ TEST(StorageNodeBufferLifecycleTest, FactoryFailureTaxonomyAndRollback) {
   bool err_fail = true;
   std::string err_sid;
   auto err_destroyed = std::make_shared<bool>(false);
+  LifecycleEngine* err_engine = nullptr;
   auto err_node =
       MakeNode(err_transport, std::make_shared<LifecycleEngine>(), [&](std::string_view sid) {
         ++err_calls;
@@ -245,8 +246,9 @@ TEST(StorageNodeBufferLifecycleTest, FactoryFailureTaxonomyAndRollback) {
           return Result<std::unique_ptr<StorageEngine>>::Err(Status::Disconnected,
                                                              "factory-owned failure", cause);
         }
-        return Result<std::unique_ptr<StorageEngine>>::Ok(
-            std::make_unique<LifecycleEngine>(err_destroyed));
+        auto engine = std::make_unique<LifecycleEngine>(err_destroyed);
+        err_engine = engine.get();
+        return Result<std::unique_ptr<StorageEngine>>::Ok(std::move(engine));
       });
   auto err_result = err_node->CreateSession("err", {.durable_buffers = true});
   EXPECT_EQ(err_result.StatusCode(), Status::Disconnected);
@@ -259,6 +261,11 @@ TEST(StorageNodeBufferLifecycleTest, FactoryFailureTaxonomyAndRollback) {
   EXPECT_EQ(err_calls, 2);
   err_transport.PutSample("sitos/buffers/err/durable/a", {std::byte{1}});
   err_transport.PutSample("sitos/buffers/err/durable/b", {std::byte{2}});
+  ASSERT_NE(err_engine, nullptr);
+  EXPECT_EQ(err_engine->values_.at("a"), (std::vector<std::byte>{std::byte{1}}));
+  EXPECT_EQ(err_engine->values_.at("b"), (std::vector<std::byte>{std::byte{2}}));
+  EXPECT_EQ(err_calls, 2);
+  EXPECT_EQ(err_sid, "err");
   ASSERT_TRUE(err_node->CloseSession("err").IsOk());
   EXPECT_TRUE(*err_destroyed);
 
@@ -342,6 +349,48 @@ TEST(StorageNodeBufferLifecycleTest, FactoryFailureTaxonomyAndRollback) {
   ASSERT_TRUE(creating_result.has_value());
   EXPECT_TRUE(creating_result->IsOk());
   EXPECT_TRUE(phase_node->CloseSession("phase").IsOk());
+
+  LifecycleTransport closed_gate_transport;
+  std::mutex closed_gate_mutex;
+  std::condition_variable closed_gate_cv;
+  bool state_captured = false;
+  bool release_closed_gate_create = false;
+  std::atomic<int> closed_gate_factory_calls = 0;
+  auto closed_gate_node =
+      MakeNode(closed_gate_transport, std::make_shared<LifecycleEngine>(), [&](std::string_view) {
+        closed_gate_factory_calls.fetch_add(1, std::memory_order_relaxed);
+        return Result<std::unique_ptr<StorageEngine>>::Ok(std::make_unique<LifecycleEngine>());
+      });
+  ASSERT_TRUE(storage_node_test_access::StorageNodeTestAccess::SetCreateSessionEntryObserver(
+      *closed_gate_node, [&] {
+        {
+          std::scoped_lock lock(closed_gate_mutex);
+          state_captured = true;
+        }
+        closed_gate_cv.notify_all();
+        std::unique_lock lock(closed_gate_mutex);
+        closed_gate_cv.wait(lock, [&] { return release_closed_gate_create; });
+      }));
+  std::optional<Result<void>> closed_gate_result;
+  std::thread closed_gate_create([&] {
+    closed_gate_result = closed_gate_node->CreateSession("closed-gate", {.durable_buffers = true});
+  });
+  {
+    std::unique_lock lock(closed_gate_mutex);
+    closed_gate_cv.wait(lock, [&] { return state_captured; });
+  }
+  closed_gate_node->Stop();
+  {
+    std::scoped_lock lock(closed_gate_mutex);
+    release_closed_gate_create = true;
+  }
+  closed_gate_cv.notify_all();
+  closed_gate_create.join();
+  ASSERT_TRUE(closed_gate_result.has_value());
+  EXPECT_EQ(closed_gate_result->StatusCode(), Status::InvalidArgument);
+  EXPECT_EQ(closed_gate_result->Error(), std::make_error_code(std::errc::invalid_argument));
+  EXPECT_TRUE(closed_gate_result->Message().empty());
+  EXPECT_EQ(closed_gate_factory_calls.load(std::memory_order_relaxed), 0);
 
   LifecycleTransport closing_transport;
   LifecycleEngine* closing_raw = nullptr;

--- a/tests/unit/storage_node_buffer_routing_test.cpp
+++ b/tests/unit/storage_node_buffer_routing_test.cpp
@@ -1,0 +1,246 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <functional>
+#include <map>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "sitos/storage_node.hpp"
+#include "transport/declaration_handle_test_access.hpp"
+
+namespace sitos {
+namespace {
+
+class CountingEngine final : public StorageEngine {
+ public:
+  explicit CountingEngine(std::shared_ptr<bool> destroyed = nullptr)
+      : destroyed_(std::move(destroyed)) {}
+  ~CountingEngine() override {
+    if (destroyed_) *destroyed_ = true;
+  }
+  bool Put(std::string_view key, Bytes value) override {
+    std::lock_guard lock(mutex_);
+    values_[std::string(key)] = std::vector<std::byte>(value.begin(), value.end());
+    ++puts;
+    return true;
+  }
+  bool Delete(std::string_view key) override {
+    std::lock_guard lock(mutex_);
+    values_.erase(std::string(key));
+    return true;
+  }
+  bool Get(std::string_view key, const EntrySink& sink) const override {
+    std::lock_guard lock(mutex_);
+    auto it = values_.find(std::string(key));
+    if (it == values_.end()) return false;
+    return sink(it->first, it->second);
+  }
+  bool List(std::string_view prefix, const EntrySink& sink) const override {
+    std::lock_guard lock(mutex_);
+    for (const auto& [key, value] : values_) {
+      if (key.starts_with(prefix) && !sink(key, value)) return false;
+    }
+    return true;
+  }
+  mutable std::mutex mutex_;
+  mutable int puts = 0;
+  std::map<std::string, std::vector<std::byte>> values_;
+  std::shared_ptr<bool> destroyed_;
+};
+
+class BufferTransport final : public Transport {
+ public:
+  Result<void> Put(std::string_view, std::span<const std::byte>, Encoding, PutOptions) override {
+    return Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
+  }
+  Result<void> Delete(std::string_view, PutOptions) override {
+    return Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
+  }
+  Result<void> Get(std::string_view, const QueryResultSink&, std::chrono::milliseconds) override {
+    return Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
+  }
+  Result<Subscription> DeclareSubscriber(
+      std::string_view, std::function<void(const TransportSample&)> callback) override {
+    subscriber = std::move(callback);
+    return Result<Subscription>::Ok(
+        transport_test_access::DeclarationHandleTestAccess::MakeSubscription([] {}));
+  }
+  Result<Queryable> DeclareQueryable(std::string_view,
+                                     std::function<void(TransportQuery&)> callback) override {
+    queryable = std::move(callback);
+    return Result<Queryable>::Ok(
+        transport_test_access::DeclarationHandleTestAccess::MakeQueryable([] {}));
+  }
+  void PutSample(std::string key, std::vector<std::byte> payload,
+                 std::string encoding = "zenoh/bytes") {
+    TransportSample sample{std::move(key), payload, Encoding{std::move(encoding)}, std::nullopt,
+                           TransportSample::Kind::Put};
+    subscriber(sample);
+  }
+  std::vector<TransportSample> Samples() const { return {}; }
+  std::vector<std::pair<std::string, std::vector<std::byte>>> Query(std::string key) {
+    std::vector<std::pair<std::string, std::vector<std::byte>>> result;
+    auto query = TransportQuery::ForTesting(
+        [&](std::string_view reply_key, std::span<const std::byte> bytes, Encoding) {
+          result.emplace_back(std::string(reply_key),
+                              std::vector<std::byte>(bytes.begin(), bytes.end()));
+          return Result<void>::Ok();
+        });
+    query.keyexpr = std::move(key);
+    queryable(query);
+    return result;
+  }
+  std::function<void(const TransportSample&)> subscriber;
+  std::function<void(TransportQuery&)> queryable;
+};
+
+struct BufferFixture : testing::Test {
+  void SetUp() override {
+    ASSERT_TRUE(node.Start(base, transport,
+                           {.prefix = "sitos",
+                            .log_sink = nullptr,
+                            .durable_buffer_engine_factory = [&](std::string_view sid) {
+                              factory_sid = std::string(sid);
+                              durable = std::make_unique<CountingEngine>();
+                              durable_ptr = durable.get();
+                              return Result<std::unique_ptr<StorageEngine>>::Ok(std::move(durable));
+                            }}));
+  }
+  std::shared_ptr<CountingEngine> base = std::make_shared<CountingEngine>();
+  BufferTransport transport;
+  StorageNode node{transport};
+  std::string factory_sid;
+  std::unique_ptr<CountingEngine> durable;
+  CountingEngine* durable_ptr = nullptr;
+};
+using StorageNodeBufferRoutingTest = BufferFixture;
+
+TEST_F(StorageNodeBufferRoutingTest, CapabilityMatrix) {
+  ASSERT_TRUE(node.CreateSession("none").IsOk());
+  ASSERT_TRUE(node.CreateSession("dur", {.durable = true}).IsOk());
+  ASSERT_TRUE(node.CreateSession("eph", {.ephemeral = true}).IsOk());
+  EXPECT_EQ(factory_sid, "dur");
+}
+TEST_F(StorageNodeBufferRoutingTest, DurablePutIsByteExactAndWriteOnce) {
+  ASSERT_TRUE(node.CreateSession("s", {.durable = true}).IsOk());
+  std::vector<std::byte> value{std::byte{1}, std::byte{2}};
+  transport.PutSample("sitos/buffers/s/durable/k", value);
+  transport.PutSample("sitos/buffers/s/durable/k", value);
+  EXPECT_EQ(durable_ptr->puts, 1);
+  EXPECT_EQ(transport.Query("sitos/buffers/s/durable/k").size(), 1u);
+}
+TEST_F(StorageNodeBufferRoutingTest, PutFailureRereadsAuthoritativeEngineState) {
+  ASSERT_TRUE(node.CreateSession("s", {.durable = true}).IsOk());
+  transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}});
+  EXPECT_EQ(durable_ptr->puts, 1);
+}
+TEST_F(StorageNodeBufferRoutingTest, WholeSubscriberSerializationPreventsConflictingPuts) {
+  ASSERT_TRUE(node.CreateSession("s", {.durable = true}).IsOk());
+  transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}});
+  transport.PutSample("sitos/buffers/s/durable/k", {std::byte{2}});
+  EXPECT_EQ(durable_ptr->puts, 1);
+}
+TEST_F(StorageNodeBufferRoutingTest, EphemeralPutNeverTouchesEngine) {
+  ASSERT_TRUE(node.CreateSession("s", {.ephemeral = true}).IsOk());
+  transport.PutSample("sitos/buffers/s/ephemeral/k", {std::byte{1}});
+  EXPECT_EQ(durable_ptr, nullptr);
+}
+TEST_F(StorageNodeBufferRoutingTest, NonBytesEncodingIsRejected) {
+  ASSERT_TRUE(node.CreateSession("s", {.durable = true}).IsOk());
+  transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}}, "sitos.v1");
+  EXPECT_EQ(durable_ptr->puts, 0);
+}
+TEST_F(StorageNodeBufferRoutingTest, DurableQuerySelectorsAndFailures) {
+  ASSERT_TRUE(node.CreateSession("s", {.durable = true}).IsOk());
+  transport.PutSample("sitos/buffers/s/durable/a/k", {std::byte{1}});
+  EXPECT_EQ(transport.Query("sitos/buffers/s/durable/**").size(), 1u);
+  EXPECT_EQ(transport.Query("sitos/buffers/s/ephemeral/**").size(), 0u);
+}
+TEST_F(StorageNodeBufferRoutingTest, EngineFailuresAndExceptionsAreContained) {
+  ASSERT_TRUE(node.CreateSession("s", {.durable = true}).IsOk());
+  EXPECT_NO_THROW(transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}}));
+}
+TEST_F(StorageNodeBufferRoutingTest, BufferRoutesDoNotEnterParameterSurfaces) {
+  ASSERT_TRUE(node.CreateSession("s", {.durable = true}).IsOk());
+  transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}});
+  EXPECT_TRUE(transport.Query("sitos/session/s/k").empty());
+}
+TEST_F(StorageNodeBufferRoutingTest, BufferDeleteAndControlRoutesAreRejected) {
+  ASSERT_TRUE(node.CreateSession("s", {.durable = true}).IsOk());
+  TransportSample sample{"sitos/buffers/s/durable/k",
+                         {},
+                         Encoding{"zenoh/bytes"},
+                         std::nullopt,
+                         TransportSample::Kind::Delete};
+  EXPECT_NO_THROW(transport.subscriber(sample));
+  EXPECT_EQ(durable_ptr->puts, 0);
+}
+
+TEST(StorageNodeBufferLifecycleTest, FactoryFailureTaxonomyAndRollback) {
+  BufferTransport transport;
+  StorageNode node(transport);
+  auto base = std::make_shared<CountingEngine>();
+  int calls = 0;
+  ASSERT_TRUE(node.Start(base, transport,
+                         {.prefix = "sitos",
+                          .log_sink = nullptr,
+                          .durable_buffer_engine_factory = [&](std::string_view) {
+                            ++calls;
+                            return Result<std::unique_ptr<StorageEngine>>::Ok(nullptr);
+                          }}));
+  auto result = node.CreateSession("s", {.durable = true});
+  EXPECT_FALSE(result.IsOk());
+  EXPECT_EQ(result.StatusCode(), Status::Error);
+  EXPECT_EQ(result.Message(), "durable buffer engine factory returned null");
+  EXPECT_EQ(calls, 1);
+  EXPECT_TRUE(node.CreateSession("s").IsOk());
+}
+TEST(StorageNodeBufferLifecycleTest, FactoryAndStopLinearizeDeterministically) {
+  BufferTransport transport;
+  StorageNode node(transport);
+  ASSERT_TRUE(node.Start(std::make_shared<CountingEngine>(), transport,
+                         {.prefix = "sitos", .log_sink = nullptr}));
+  EXPECT_TRUE(node.CreateSession("s").IsOk());
+  node.Stop();
+  EXPECT_EQ(node.CreateSession("after").StatusCode(), Status::InvalidArgument);
+}
+TEST(StorageNodeBufferLifecycleTest, CloseQuiescesDurableOperationsAndDestroysEngine) {
+  BufferTransport transport;
+  StorageNode node(transport);
+  auto destroyed = std::make_shared<bool>(false);
+  auto engine = std::make_unique<CountingEngine>(destroyed);
+  ASSERT_TRUE(node.Start(std::make_shared<CountingEngine>(), transport,
+                         {.prefix = "sitos",
+                          .log_sink = nullptr,
+                          .durable_buffer_engine_factory = [&](std::string_view) {
+                            return Result<std::unique_ptr<StorageEngine>>::Ok(std::move(engine));
+                          }}));
+  ASSERT_TRUE(node.CreateSession("s", {.durable = true}));
+  ASSERT_TRUE(node.CloseSession("s"));
+  EXPECT_TRUE(*destroyed);
+}
+TEST(StorageNodeBufferLifecycleTest, SameSidRecreationUsesFreshEngine) {
+  BufferTransport transport;
+  StorageNode node(transport);
+  int calls = 0;
+  ASSERT_TRUE(node.Start(std::make_shared<CountingEngine>(), transport,
+                         {.prefix = "sitos",
+                          .log_sink = nullptr,
+                          .durable_buffer_engine_factory = [&](std::string_view) {
+                            ++calls;
+                            return Result<std::unique_ptr<StorageEngine>>::Ok(
+                                std::make_unique<CountingEngine>());
+                          }}));
+  ASSERT_TRUE(node.CreateSession("s", {.durable = true}));
+  ASSERT_TRUE(node.CloseSession("s"));
+  ASSERT_TRUE(node.CreateSession("s", {.durable = true}));
+  EXPECT_EQ(calls, 2);
+}
+
+}  // namespace
+}  // namespace sitos

--- a/tests/unit/storage_node_buffer_routing_test.cpp
+++ b/tests/unit/storage_node_buffer_routing_test.cpp
@@ -463,10 +463,18 @@ TEST_F(StorageNodeBufferRoutingTest, DurableQuerySelectorsAndFailures) {
   EXPECT_EQ(partial.replies.size(), 1u);
   EXPECT_EQ(partial.reply_calls, 1);
   EXPECT_EQ(partial.reply_attempts, 2);
+  const int throwing_handler_before = diagnostic_count("durable buffer query failed");
+  const int throwing_handler_attempts = log_sink->write_attempts;
   auto throwing = transport.Query("sitos/buffers/s/durable/**", 1, true);
   EXPECT_EQ(throwing.replies.size(), 1u);
   EXPECT_EQ(throwing.reply_calls, 1);
   EXPECT_EQ(throwing.reply_attempts, 2);
+  EXPECT_EQ(diagnostic_count("durable buffer query failed"), throwing_handler_before + 1);
+  EXPECT_EQ(log_sink->write_attempts, throwing_handler_attempts + 1);
+  const auto throwing_handler_messages = log_sink->Messages();
+  ASSERT_EQ(throwing_handler_messages.size(), throwing_handler_before + 1);
+  EXPECT_EQ(throwing_handler_messages.back(), "durable buffer query failed");
+  EXPECT_EQ(throwing_handler_messages.back().find("sentinel"), std::string::npos);
   const int returned_reply_before = diagnostic_count("durable buffer query failed");
   const int returned_reply_attempts = log_sink->write_attempts;
   auto returned_failure = transport.Query("sitos/buffers/s/durable/**", 1);
@@ -476,7 +484,7 @@ TEST_F(StorageNodeBufferRoutingTest, DurableQuerySelectorsAndFailures) {
   EXPECT_EQ(log_sink->write_attempts, returned_reply_attempts + 1);
   const int throwing_reply_attempts = log_sink->write_attempts;
   log_sink->throwing = true;
-  EXPECT_NO_THROW(transport.Query("sitos/buffers/s/durable/**", 1));
+  EXPECT_NO_THROW(transport.Query("sitos/buffers/s/durable/**", 1, true));
   EXPECT_EQ(log_sink->write_attempts, throwing_reply_attempts + 1);
   log_sink->throwing = false;
 }

--- a/tests/unit/storage_node_buffer_routing_test.cpp
+++ b/tests/unit/storage_node_buffer_routing_test.cpp
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "sitos/storage_node.hpp"
+#include "storage_node_test_access.hpp"
 #include "transport/declaration_handle_test_access.hpp"
 
 namespace sitos {
@@ -45,6 +46,7 @@ class ProgrammableEngine final : public StorageEngine {
 
   bool Delete(std::string_view key) override {
     std::scoped_lock lock(mutex_);
+    ++delete_calls;
     values_.erase(std::string(key));
     return true;
   }
@@ -93,6 +95,7 @@ class ProgrammableEngine final : public StorageEngine {
   mutable int put_calls = 0;
   mutable int get_calls = 0;
   mutable int list_calls = 0;
+  mutable int delete_calls = 0;
   mutable int put_entered = 0;
   mutable int get_entered = 0;
   mutable int list_entered = 0;
@@ -131,6 +134,7 @@ class BufferTransport final : public Transport {
     std::vector<std::pair<std::string, std::vector<std::byte>>> replies;
     std::vector<Encoding> encodings;
     int reply_calls = 0;
+    int reply_attempts = 0;
   };
 
   Result<void> Put(std::string_view, std::span<const std::byte>, Encoding, PutOptions) override {
@@ -179,7 +183,8 @@ class BufferTransport final : public Transport {
     QueryResult result;
     auto query = TransportQuery::ForTesting(
         [&](std::string_view reply_key, std::span<const std::byte> bytes, Encoding encoding) {
-          if (fail_after >= 0 && result.reply_calls >= fail_after) {
+          ++result.reply_attempts;
+          if (fail_after >= 0 && result.reply_attempts > fail_after) {
             if (throw_reply) throw std::runtime_error("reply failure");
             return Result<void>::Err(std::make_error_code(std::errc::broken_pipe));
           }
@@ -247,13 +252,20 @@ TEST_F(StorageNodeBufferRoutingTest, CapabilityMatrix) {
   EXPECT_EQ(factory_sids, (std::vector<std::string>{"dur", "both"}));
 
   transport.PutSample("sitos/buffers/none/durable/k", {std::byte{1}});
+  transport.PutSample("sitos/buffers/none/ephemeral/k", {std::byte{1}});
   transport.PutSample("sitos/buffers/dur/durable/k", {std::byte{1}});
+  transport.PutSample("sitos/buffers/dur/ephemeral/k", {std::byte{1}});
+  transport.PutSample("sitos/buffers/eph/durable/k", {std::byte{1}});
   transport.PutSample("sitos/buffers/eph/ephemeral/k", {std::byte{1}});
   transport.PutSample("sitos/buffers/both/durable/k", {std::byte{1}});
   transport.PutSample("sitos/buffers/both/ephemeral/k", {std::byte{1}});
   EXPECT_EQ(engines.at("dur")->put_calls, 1);
   EXPECT_EQ(engines.at("both")->put_calls, 1);
-  EXPECT_EQ(transport.Query("sitos/buffers/eph/ephemeral/**").replies.size(), 0u);
+  EXPECT_FALSE(engines.contains("eph"));
+  EXPECT_EQ(transport.Query("sitos/buffers/none/ephemeral/**").replies.size(), 0u);
+  EXPECT_EQ(transport.Query("sitos/buffers/dur/ephemeral/**").replies.size(), 0u);
+  EXPECT_EQ(transport.Query("sitos/buffers/eph/durable/**").replies.size(), 0u);
+  EXPECT_EQ(transport.Query("sitos/buffers/both/ephemeral/**").replies.size(), 0u);
 }
 
 TEST_F(StorageNodeBufferRoutingTest, DurablePutIsByteExactAndWriteOnce) {
@@ -273,7 +285,11 @@ TEST_F(StorageNodeBufferRoutingTest, PutFailureRereadsAuthoritativeEngineState) 
   ASSERT_TRUE(node.CreateSession("s", {.durable_buffers = true}).IsOk());
   auto* engine = engines.at("s");
   engine->false_puts = 1;
+  const auto put_failure_before = log_sink->Messages().size();
   transport.PutSample("sitos/buffers/s/durable/unmodified", {std::byte{1}});
+  auto put_failure_messages = log_sink->Messages();
+  ASSERT_EQ(put_failure_messages.size(), put_failure_before + 1);
+  EXPECT_EQ(put_failure_messages.back(), "durable buffer PUT failed");
   EXPECT_EQ(engine->put_calls, 1);
   transport.PutSample("sitos/buffers/s/durable/unmodified", {std::byte{1}});
   EXPECT_EQ(engine->put_calls, 2);
@@ -285,6 +301,8 @@ TEST_F(StorageNodeBufferRoutingTest, PutFailureRereadsAuthoritativeEngineState) 
   EXPECT_EQ(engine->put_calls, 3);
   transport.PutSample("sitos/buffers/s/durable/partial", {std::byte{3}});
   EXPECT_EQ(engine->put_calls, 3);
+  put_failure_messages = log_sink->Messages();
+  EXPECT_EQ(put_failure_messages.back(), "durable buffer PUT conflicts with existing value");
   auto result = transport.Query("sitos/buffers/s/durable/partial");
   ASSERT_EQ(result.replies.size(), 1u);
   EXPECT_EQ(result.replies[0].first, "sitos/buffers/s/durable/partial");
@@ -295,15 +313,36 @@ TEST_F(StorageNodeBufferRoutingTest, WholeSubscriberSerializationPreventsConflic
   ASSERT_TRUE(node.CreateSession("s", {.durable_buffers = true}).IsOk());
   auto* engine = engines.at("s");
   engine->block_get = true;
+  std::mutex observer_mutex;
+  std::condition_variable observer_cv;
+  int boundary_entries = 0;
+  bool release_second = false;
+  ASSERT_TRUE(
+      storage_node_test_access::StorageNodeTestAccess::SetSubscriberEntryObserver(node, [&] {
+        std::unique_lock lock(observer_mutex);
+        ++boundary_entries;
+        observer_cv.notify_all();
+        if (boundary_entries >= 2) {
+          observer_cv.wait(lock, [&] { return release_second; });
+        }
+      }));
   std::thread first([&] { transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}}); });
   engine->WaitFor(engine->get_entered);
   std::thread second([&] { transport.PutSample("sitos/buffers/s/durable/k", {std::byte{2}}); });
-  transport.WaitForSamples(2);
+  {
+    std::unique_lock lock(observer_mutex);
+    observer_cv.wait(lock, [&] { return boundary_entries >= 2; });
+  }
   {
     std::scoped_lock lock(engine->gate_mutex_);
     EXPECT_EQ(engine->get_entered, 1);
   }
   engine->ReleaseGet();
+  {
+    std::scoped_lock lock(observer_mutex);
+    release_second = true;
+  }
+  observer_cv.notify_all();
   first.join();
   second.join();
   EXPECT_EQ(engine->put_calls, 1);
@@ -326,11 +365,20 @@ TEST_F(StorageNodeBufferRoutingTest, NonBytesEncodingIsRejected) {
   const std::vector<std::string> rejected = {"sitos.v1", "sitos.v1.batch", "zenoh/bytes;schema=x",
                                              "", "application/octet-stream"};
   const auto diagnostics_before = log_sink->Messages().size();
+  const std::string sentinel_payload = "sentinel-payload";
   for (const auto& encoding : rejected) {
-    transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}}, encoding);
+    transport.PutSample("sitos/buffers/s/durable/sentinel-key",
+                        {std::byte{'s'}, std::byte{'e'}, std::byte{'n'}, std::byte{'t'},
+                         std::byte{'i'}, std::byte{'n'}, std::byte{'e'}, std::byte{'l'}},
+                        encoding);
   }
   const auto diagnostics_after = log_sink->Messages();
-  EXPECT_GE(diagnostics_after.size(), diagnostics_before + rejected.size());
+  ASSERT_GE(diagnostics_after.size(), diagnostics_before + rejected.size());
+  for (std::size_t i = diagnostics_before; i < diagnostics_after.size(); ++i) {
+    EXPECT_EQ(diagnostics_after[i], "buffer encoding rejected");
+    EXPECT_EQ(diagnostics_after[i].find("sentinel"), std::string::npos);
+    EXPECT_EQ(diagnostics_after[i].find(sentinel_payload), std::string::npos);
+  }
   EXPECT_EQ(engine->get_calls, 0);
   EXPECT_EQ(engine->put_calls, 0);
   log_sink->throwing = true;
@@ -357,73 +405,124 @@ TEST_F(StorageNodeBufferRoutingTest, DurableQuerySelectorsAndFailures) {
   EXPECT_EQ(root.replies[0].first, "sitos/buffers/s/durable/a/k");
   EXPECT_EQ(root.replies[1].first, "sitos/buffers/s/durable/a/l");
   EXPECT_EQ(root.replies[2].first, "sitos/buffers/s/durable/b");
+  EXPECT_EQ(root.replies[0].second, (std::vector<std::byte>{std::byte{1}}));
+  EXPECT_EQ(root.replies[1].second, (std::vector<std::byte>{std::byte{2}}));
+  EXPECT_EQ(root.replies[2].second, (std::vector<std::byte>{std::byte{3}}));
   for (const auto& encoding : root.encodings) EXPECT_EQ(encoding.id, "zenoh/bytes");
   auto subtree = transport.Query("sitos/buffers/s/durable/a/**");
   ASSERT_EQ(subtree.replies.size(), 2u);
   EXPECT_EQ(subtree.replies[0].first, "sitos/buffers/s/durable/a/k");
   EXPECT_EQ(subtree.replies[1].first, "sitos/buffers/s/durable/a/l");
+  EXPECT_EQ(subtree.replies[0].second, (std::vector<std::byte>{std::byte{1}}));
+  EXPECT_EQ(subtree.replies[1].second, (std::vector<std::byte>{std::byte{2}}));
+  ASSERT_EQ(subtree.encodings.size(), 2u);
+  EXPECT_EQ(subtree.encodings[0].id, "zenoh/bytes");
+  EXPECT_EQ(subtree.encodings[1].id, "zenoh/bytes");
+  const auto diagnostics_before_miss = log_sink->Messages().size();
   EXPECT_EQ(transport.Query("sitos/buffers/s/durable/missing").replies.size(), 0u);
+  EXPECT_EQ(log_sink->Messages().size(), diagnostics_before_miss);
   EXPECT_EQ(transport.Query("sitos/buffers/s/ephemeral/**").replies.size(), 0u);
   ASSERT_TRUE(node.CreateSession("eph", {.ephemeral_buffers = true}).IsOk());
   EXPECT_TRUE(transport.Query("sitos/buffers/eph/durable/**").replies.empty());
   EXPECT_TRUE(transport.Query("sitos/buffers/unknown/durable/**").replies.empty());
   EXPECT_TRUE(transport.Query("sitos/buffers/s/durable/a/*").replies.empty());
+  EXPECT_TRUE(transport.Query("sitos/buffers/s/durable/:batch").replies.empty());
+  EXPECT_TRUE(transport.Query("sitos/buffers/s/durable/:fence").replies.empty());
+  EXPECT_TRUE(transport.Query("sitos/snap/s/**").replies.empty());
   ASSERT_TRUE(node.CloseSession("eph").IsOk());
   EXPECT_TRUE(transport.Query("sitos/buffers/eph/durable/**").replies.empty());
 
   auto* engine = engines.at("s");
+  auto diagnostic_count = [&](std::string_view message) {
+    const auto messages = log_sink->Messages();
+    return static_cast<int>(std::count(messages.begin(), messages.end(), message));
+  };
   engine->false_list = true;
+  const int false_list_before = diagnostic_count("durable buffer query failed");
   EXPECT_TRUE(transport.Query("sitos/buffers/s/durable/**").replies.empty());
+  EXPECT_EQ(diagnostic_count("durable buffer query failed"), false_list_before + 1);
   engine->false_list = false;
   engine->throw_list = true;
+  const int throw_list_before = diagnostic_count("durable buffer query failed");
   EXPECT_TRUE(transport.Query("sitos/buffers/s/durable/**").replies.empty());
+  EXPECT_EQ(diagnostic_count("durable buffer query failed"), throw_list_before + 1);
   engine->throw_list = false;
   engine->throw_get = true;
+  const int throw_get_before = diagnostic_count("durable buffer query failed");
   EXPECT_TRUE(transport.Query("sitos/buffers/s/durable/a/k").replies.empty());
+  EXPECT_EQ(diagnostic_count("durable buffer query failed"), throw_get_before + 1);
   engine->throw_get = false;
   auto partial = transport.Query("sitos/buffers/s/durable/**", 1);
   EXPECT_EQ(partial.replies.size(), 1u);
   EXPECT_EQ(partial.reply_calls, 1);
+  EXPECT_EQ(partial.reply_attempts, 2);
   auto throwing = transport.Query("sitos/buffers/s/durable/**", 1, true);
   EXPECT_EQ(throwing.replies.size(), 1u);
   EXPECT_EQ(throwing.reply_calls, 1);
+  EXPECT_EQ(throwing.reply_attempts, 2);
+  log_sink->throwing = true;
+  EXPECT_NO_THROW(transport.Query("sitos/buffers/s/durable/**", 1));
+  log_sink->throwing = false;
 }
 
 TEST_F(StorageNodeBufferRoutingTest, EngineFailuresAndExceptionsAreContained) {
   ASSERT_TRUE(node.CreateSession("s", {.durable_buffers = true}).IsOk());
   auto* engine = engines.at("s");
   engine->throw_put = true;
+  const auto put_throw_before = log_sink->Messages().size();
   EXPECT_NO_THROW(transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}}));
   EXPECT_EQ(engine->put_calls, 1);
+  ASSERT_EQ(log_sink->Messages().size(), put_throw_before + 1);
+  EXPECT_EQ(log_sink->Messages().back(), "durable buffer PUT failed");
   engine->throw_put = false;
   EXPECT_NO_THROW(transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}}));
   EXPECT_EQ(engine->put_calls, 2);
   engine->throw_get = true;
+  const auto read_throw_before = log_sink->Messages().size();
   EXPECT_NO_THROW(transport.Query("sitos/buffers/s/durable/k"));
+  EXPECT_NO_THROW(transport.PutSample("sitos/buffers/s/durable/read-throw", {std::byte{2}}));
+  EXPECT_EQ(log_sink->Messages().size(), read_throw_before + 2);
+  EXPECT_EQ(log_sink->Messages()[read_throw_before], "durable buffer query failed");
+  EXPECT_EQ(log_sink->Messages()[read_throw_before + 1], "durable buffer PUT failed");
   engine->throw_get = false;
 }
 
 TEST_F(StorageNodeBufferRoutingTest, BufferRoutesDoNotEnterParameterSurfaces) {
   ASSERT_TRUE(node.CreateSession("s", {.durable_buffers = true}).IsOk());
   auto metadata_before = transport.Query("sitos/meta/session/s");
+  auto snapshot_before = transport.Query("sitos/snap/s/**");
+  const auto base_values_before = base->values_;
+  const int base_gets_before = base->get_calls;
+  const int base_lists_before = base->list_calls;
   transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}});
   EXPECT_TRUE(transport.Query("sitos/session/s/k").replies.empty());
   auto metadata_after = transport.Query("sitos/meta/session/s");
+  auto snapshot_after = transport.Query("sitos/snap/s/**");
   ASSERT_EQ(metadata_before.replies.size(), 1u);
   ASSERT_EQ(metadata_after.replies.size(), 1u);
   EXPECT_EQ(metadata_before.replies[0].second, metadata_after.replies[0].second);
+  EXPECT_EQ(snapshot_before.replies, snapshot_after.replies);
+  EXPECT_EQ(base->values_, base_values_before);
+  EXPECT_EQ(base->get_calls, base_gets_before);
+  EXPECT_EQ(base->list_calls, base_lists_before);
 }
 
 TEST_F(StorageNodeBufferRoutingTest, BufferDeleteAndControlRoutesAreRejected) {
   ASSERT_TRUE(node.CreateSession("s", {.durable_buffers = true}).IsOk());
   auto* engine = engines.at("s");
+  transport.PutSample("sitos/buffers/s/durable/k", {std::byte{9}});
+  const int deletes_before = engine->delete_calls;
   EXPECT_NO_THROW(transport.DeleteSample("sitos/buffers/s/durable/k"));
+  EXPECT_EQ(engine->delete_calls, deletes_before);
+  auto retained = transport.Query("sitos/buffers/s/durable/k");
+  ASSERT_EQ(retained.replies.size(), 1u);
+  EXPECT_EQ(retained.replies[0].second, (std::vector<std::byte>{std::byte{9}}));
   transport.PutSample("sitos/buffers/s/durable/k/*", {std::byte{1}});
   transport.PutSample("sitos/buffers/s/durable", {std::byte{1}});
   transport.PutSample("sitos/buffers/s/durable/:batch", {std::byte{1}});
   transport.PutSample("sitos/buffers/s/durable/:fence", {std::byte{1}});
   transport.PutSample("sitos/snap/s/k", {std::byte{1}});
-  EXPECT_EQ(engine->put_calls, 0);
+  EXPECT_EQ(engine->put_calls, 1);
 }
 
 }  // namespace

--- a/tests/unit/storage_node_buffer_routing_test.cpp
+++ b/tests/unit/storage_node_buffer_routing_test.cpp
@@ -3,11 +3,16 @@
 
 #include <gtest/gtest.h>
 
-#include <algorithm>
+#include <condition_variable>
+#include <cstddef>
 #include <functional>
 #include <map>
 #include <mutex>
+#include <optional>
+#include <stdexcept>
 #include <string>
+#include <thread>
+#include <utility>
 #include <vector>
 
 #include "sitos/storage_node.hpp"
@@ -16,45 +21,122 @@
 namespace sitos {
 namespace {
 
-class CountingEngine final : public StorageEngine {
+class ProgrammableEngine final : public StorageEngine {
  public:
-  explicit CountingEngine(std::shared_ptr<bool> destroyed = nullptr)
+  explicit ProgrammableEngine(std::shared_ptr<bool> destroyed = nullptr)
       : destroyed_(std::move(destroyed)) {}
-  ~CountingEngine() override {
+  ~ProgrammableEngine() override {
     if (destroyed_) *destroyed_ = true;
   }
+
   bool Put(std::string_view key, Bytes value) override {
-    std::lock_guard lock(mutex_);
-    values_[std::string(key)] = std::vector<std::byte>(value.begin(), value.end());
-    ++puts;
+    std::unique_lock lock(mutex_);
+    ++put_calls;
+    if (block_put) {
+      ++put_entered;
+      cv.notify_all();
+      cv.wait(lock, [this] { return !block_put; });
+    }
+    if (throw_put) throw std::runtime_error("put failure");
+    if (false_puts > 0) {
+      --false_puts;
+      if (partial_false_put) values_[std::string(key)] = Copy(value);
+      return false;
+    }
+    values_[std::string(key)] = Copy(value);
     return true;
   }
+
   bool Delete(std::string_view key) override {
-    std::lock_guard lock(mutex_);
+    std::scoped_lock lock(mutex_);
     values_.erase(std::string(key));
     return true;
   }
+
   bool Get(std::string_view key, const EntrySink& sink) const override {
-    std::lock_guard lock(mutex_);
+    std::unique_lock lock(mutex_);
+    ++get_calls;
+    if (block_get) {
+      ++get_entered;
+      cv.notify_all();
+      cv.wait(lock, [this] { return !block_get; });
+    }
+    if (throw_get) throw std::runtime_error("get failure");
     auto it = values_.find(std::string(key));
     if (it == values_.end()) return false;
-    return sink(it->first, it->second);
+    auto copied_key = it->first;
+    auto copied_value = it->second;
+    lock.unlock();
+    return sink(copied_key, copied_value);
   }
+
   bool List(std::string_view prefix, const EntrySink& sink) const override {
-    std::lock_guard lock(mutex_);
-    for (const auto& [key, value] : values_) {
-      if (key.starts_with(prefix) && !sink(key, value)) return false;
+    std::unique_lock lock(mutex_);
+    ++list_calls;
+    if (block_list) {
+      ++list_entered;
+      cv.notify_all();
+      cv.wait(lock, [this] { return !block_list; });
     }
-    return true;
+    if (throw_list) throw std::runtime_error("list failure");
+    std::vector<std::pair<std::string, std::vector<std::byte>>> entries;
+    for (const auto& [key, value] : values_) {
+      if (key.starts_with(prefix)) entries.emplace_back(key, value);
+    }
+    lock.unlock();
+    for (const auto& [key, value] : entries) {
+      if (!sink(key, value)) return false;
+    }
+    return !false_list;
   }
+
+  void WaitFor(std::condition_variable& condition, int& count) {
+    std::unique_lock lock(mutex_);
+    condition.wait(lock, [&] { return count > 0; });
+  }
+  void ReleasePut() { SetBlocked(block_put, false); }
+  void ReleaseGet() { SetBlocked(block_get, false); }
+  void ReleaseList() { SetBlocked(block_list, false); }
+
   mutable std::mutex mutex_;
-  mutable int puts = 0;
-  std::map<std::string, std::vector<std::byte>> values_;
+  mutable std::condition_variable cv;
+  mutable std::map<std::string, std::vector<std::byte>> values_;
+  mutable int put_calls = 0;
+  mutable int get_calls = 0;
+  mutable int list_calls = 0;
+  mutable int put_entered = 0;
+  mutable int get_entered = 0;
+  mutable int list_entered = 0;
+  bool block_put = false;
+  bool block_get = false;
+  bool block_list = false;
+  bool throw_put = false;
+  mutable bool throw_get = false;
+  mutable bool throw_list = false;
+  mutable bool false_list = false;
+  int false_puts = 0;
+  bool partial_false_put = false;
   std::shared_ptr<bool> destroyed_;
+
+ private:
+  static std::vector<std::byte> Copy(Bytes value) { return {value.begin(), value.end()}; }
+  void SetBlocked(bool& blocked, bool value) {
+    {
+      std::scoped_lock lock(mutex_);
+      blocked = value;
+    }
+    cv.notify_all();
+  }
 };
 
 class BufferTransport final : public Transport {
  public:
+  struct QueryResult {
+    std::vector<std::pair<std::string, std::vector<std::byte>>> replies;
+    std::vector<Encoding> encodings;
+    int reply_calls = 0;
+  };
+
   Result<void> Put(std::string_view, std::span<const std::byte>, Encoding, PutOptions) override {
     return Result<void>::Err(std::make_error_code(std::errc::operation_not_supported));
   }
@@ -76,170 +158,192 @@ class BufferTransport final : public Transport {
     return Result<Queryable>::Ok(
         transport_test_access::DeclarationHandleTestAccess::MakeQueryable([] {}));
   }
+
   void PutSample(std::string key, std::vector<std::byte> payload,
                  std::string encoding = "zenoh/bytes") {
     TransportSample sample{std::move(key), payload, Encoding{std::move(encoding)}, std::nullopt,
                            TransportSample::Kind::Put};
     subscriber(sample);
   }
-  std::vector<TransportSample> Samples() const { return {}; }
-  std::vector<std::pair<std::string, std::vector<std::byte>>> Query(std::string key) {
-    std::vector<std::pair<std::string, std::vector<std::byte>>> result;
+  void DeleteSample(std::string key) {
+    TransportSample sample{
+        std::move(key), {}, Encoding{"zenoh/bytes"}, std::nullopt, TransportSample::Kind::Delete};
+    subscriber(sample);
+  }
+  QueryResult Query(std::string key, int fail_after = -1, bool throw_reply = false) {
+    QueryResult result;
     auto query = TransportQuery::ForTesting(
-        [&](std::string_view reply_key, std::span<const std::byte> bytes, Encoding) {
-          result.emplace_back(std::string(reply_key),
-                              std::vector<std::byte>(bytes.begin(), bytes.end()));
+        [&](std::string_view reply_key, std::span<const std::byte> bytes, Encoding encoding) {
+          if (fail_after >= 0 && result.reply_calls >= fail_after) {
+            if (throw_reply) throw std::runtime_error("reply failure");
+            return Result<void>::Err(std::make_error_code(std::errc::broken_pipe));
+          }
+          ++result.reply_calls;
+          result.replies.emplace_back(std::string(reply_key),
+                                      std::vector<std::byte>(bytes.begin(), bytes.end()));
+          result.encodings.push_back(std::move(encoding));
           return Result<void>::Ok();
         });
     query.keyexpr = std::move(key);
     queryable(query);
     return result;
   }
+
   std::function<void(const TransportSample&)> subscriber;
   std::function<void(TransportQuery&)> queryable;
 };
 
-struct BufferFixture : testing::Test {
+struct StorageNodeBufferRoutingTest : testing::Test {
   void SetUp() override {
     ASSERT_TRUE(node.Start(base, transport,
                            {.prefix = "sitos",
                             .log_sink = nullptr,
                             .durable_buffer_engine_factory = [&](std::string_view sid) {
-                              factory_sid = std::string(sid);
-                              durable = std::make_unique<CountingEngine>();
-                              durable_ptr = durable.get();
-                              return Result<std::unique_ptr<StorageEngine>>::Ok(std::move(durable));
+                              factory_sids.emplace_back(sid);
+                              auto engine = std::make_unique<ProgrammableEngine>();
+                              auto* pointer = engine.get();
+                              engines.emplace(std::string(sid), pointer);
+                              return Result<std::unique_ptr<StorageEngine>>::Ok(std::move(engine));
                             }}));
   }
-  std::shared_ptr<CountingEngine> base = std::make_shared<CountingEngine>();
+  std::shared_ptr<ProgrammableEngine> base = std::make_shared<ProgrammableEngine>();
   BufferTransport transport;
   StorageNode node{transport};
-  std::string factory_sid;
-  std::unique_ptr<CountingEngine> durable;
-  CountingEngine* durable_ptr = nullptr;
+  std::vector<std::string> factory_sids;
+  std::map<std::string, ProgrammableEngine*> engines;
 };
-using StorageNodeBufferRoutingTest = BufferFixture;
 
 TEST_F(StorageNodeBufferRoutingTest, CapabilityMatrix) {
   ASSERT_TRUE(node.CreateSession("none").IsOk());
-  ASSERT_TRUE(node.CreateSession("dur", {.durable = true}).IsOk());
-  ASSERT_TRUE(node.CreateSession("eph", {.ephemeral = true}).IsOk());
-  EXPECT_EQ(factory_sid, "dur");
-}
-TEST_F(StorageNodeBufferRoutingTest, DurablePutIsByteExactAndWriteOnce) {
-  ASSERT_TRUE(node.CreateSession("s", {.durable = true}).IsOk());
-  std::vector<std::byte> value{std::byte{1}, std::byte{2}};
-  transport.PutSample("sitos/buffers/s/durable/k", value);
-  transport.PutSample("sitos/buffers/s/durable/k", value);
-  EXPECT_EQ(durable_ptr->puts, 1);
-  EXPECT_EQ(transport.Query("sitos/buffers/s/durable/k").size(), 1u);
-}
-TEST_F(StorageNodeBufferRoutingTest, PutFailureRereadsAuthoritativeEngineState) {
-  ASSERT_TRUE(node.CreateSession("s", {.durable = true}).IsOk());
-  transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}});
-  EXPECT_EQ(durable_ptr->puts, 1);
-}
-TEST_F(StorageNodeBufferRoutingTest, WholeSubscriberSerializationPreventsConflictingPuts) {
-  ASSERT_TRUE(node.CreateSession("s", {.durable = true}).IsOk());
-  transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}});
-  transport.PutSample("sitos/buffers/s/durable/k", {std::byte{2}});
-  EXPECT_EQ(durable_ptr->puts, 1);
-}
-TEST_F(StorageNodeBufferRoutingTest, EphemeralPutNeverTouchesEngine) {
-  ASSERT_TRUE(node.CreateSession("s", {.ephemeral = true}).IsOk());
-  transport.PutSample("sitos/buffers/s/ephemeral/k", {std::byte{1}});
-  EXPECT_EQ(durable_ptr, nullptr);
-}
-TEST_F(StorageNodeBufferRoutingTest, NonBytesEncodingIsRejected) {
-  ASSERT_TRUE(node.CreateSession("s", {.durable = true}).IsOk());
-  transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}}, "sitos.v1");
-  EXPECT_EQ(durable_ptr->puts, 0);
-}
-TEST_F(StorageNodeBufferRoutingTest, DurableQuerySelectorsAndFailures) {
-  ASSERT_TRUE(node.CreateSession("s", {.durable = true}).IsOk());
-  transport.PutSample("sitos/buffers/s/durable/a/k", {std::byte{1}});
-  EXPECT_EQ(transport.Query("sitos/buffers/s/durable/**").size(), 1u);
-  EXPECT_EQ(transport.Query("sitos/buffers/s/ephemeral/**").size(), 0u);
-}
-TEST_F(StorageNodeBufferRoutingTest, EngineFailuresAndExceptionsAreContained) {
-  ASSERT_TRUE(node.CreateSession("s", {.durable = true}).IsOk());
-  EXPECT_NO_THROW(transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}}));
-}
-TEST_F(StorageNodeBufferRoutingTest, BufferRoutesDoNotEnterParameterSurfaces) {
-  ASSERT_TRUE(node.CreateSession("s", {.durable = true}).IsOk());
-  transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}});
-  EXPECT_TRUE(transport.Query("sitos/session/s/k").empty());
-}
-TEST_F(StorageNodeBufferRoutingTest, BufferDeleteAndControlRoutesAreRejected) {
-  ASSERT_TRUE(node.CreateSession("s", {.durable = true}).IsOk());
-  TransportSample sample{"sitos/buffers/s/durable/k",
-                         {},
-                         Encoding{"zenoh/bytes"},
-                         std::nullopt,
-                         TransportSample::Kind::Delete};
-  EXPECT_NO_THROW(transport.subscriber(sample));
-  EXPECT_EQ(durable_ptr->puts, 0);
+  ASSERT_TRUE(node.CreateSession("dur", {.durable_buffers = true}).IsOk());
+  ASSERT_TRUE(node.CreateSession("eph", {.ephemeral_buffers = true}).IsOk());
+  ASSERT_TRUE(
+      node.CreateSession("both", {.durable_buffers = true, .ephemeral_buffers = true}).IsOk());
+  EXPECT_EQ(factory_sids, (std::vector<std::string>{"dur", "both"}));
+
+  transport.PutSample("sitos/buffers/none/durable/k", {std::byte{1}});
+  transport.PutSample("sitos/buffers/dur/durable/k", {std::byte{1}});
+  transport.PutSample("sitos/buffers/eph/ephemeral/k", {std::byte{1}});
+  transport.PutSample("sitos/buffers/both/durable/k", {std::byte{1}});
+  transport.PutSample("sitos/buffers/both/ephemeral/k", {std::byte{1}});
+  EXPECT_EQ(engines.at("dur")->put_calls, 1);
+  EXPECT_EQ(engines.at("both")->put_calls, 1);
+  EXPECT_EQ(transport.Query("sitos/buffers/eph/ephemeral/**").replies.size(), 0u);
 }
 
-TEST(StorageNodeBufferLifecycleTest, FactoryFailureTaxonomyAndRollback) {
-  BufferTransport transport;
-  StorageNode node(transport);
-  auto base = std::make_shared<CountingEngine>();
-  int calls = 0;
-  ASSERT_TRUE(node.Start(base, transport,
-                         {.prefix = "sitos",
-                          .log_sink = nullptr,
-                          .durable_buffer_engine_factory = [&](std::string_view) {
-                            ++calls;
-                            return Result<std::unique_ptr<StorageEngine>>::Ok(nullptr);
-                          }}));
-  auto result = node.CreateSession("s", {.durable = true});
-  EXPECT_FALSE(result.IsOk());
-  EXPECT_EQ(result.StatusCode(), Status::Error);
-  EXPECT_EQ(result.Message(), "durable buffer engine factory returned null");
-  EXPECT_EQ(calls, 1);
-  EXPECT_TRUE(node.CreateSession("s").IsOk());
+TEST_F(StorageNodeBufferRoutingTest, DurablePutIsByteExactAndWriteOnce) {
+  ASSERT_TRUE(node.CreateSession("s", {.durable_buffers = true}).IsOk());
+  const std::vector<std::byte> value{std::byte{1}, std::byte{2}, std::byte{0}};
+  transport.PutSample("sitos/buffers/s/durable/k", value);
+  transport.PutSample("sitos/buffers/s/durable/k", value);
+  auto result = transport.Query("sitos/buffers/s/durable/k");
+  ASSERT_EQ(result.replies.size(), 1u);
+  EXPECT_EQ(result.replies[0].second, value);
+  ASSERT_EQ(result.encodings.size(), 1u);
+  EXPECT_EQ(result.encodings[0].id, "zenoh/bytes");
+  EXPECT_EQ(engines.at("s")->put_calls, 1);
 }
-TEST(StorageNodeBufferLifecycleTest, FactoryAndStopLinearizeDeterministically) {
-  BufferTransport transport;
-  StorageNode node(transport);
-  ASSERT_TRUE(node.Start(std::make_shared<CountingEngine>(), transport,
-                         {.prefix = "sitos", .log_sink = nullptr}));
-  EXPECT_TRUE(node.CreateSession("s").IsOk());
-  node.Stop();
-  EXPECT_EQ(node.CreateSession("after").StatusCode(), Status::InvalidArgument);
+
+TEST_F(StorageNodeBufferRoutingTest, PutFailureRereadsAuthoritativeEngineState) {
+  ASSERT_TRUE(node.CreateSession("s", {.durable_buffers = true}).IsOk());
+  auto* engine = engines.at("s");
+  engine->false_puts = 1;
+  engine->partial_false_put = true;
+  transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}});
+  EXPECT_EQ(engine->put_calls, 1);
+  transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}});
+  EXPECT_EQ(engine->put_calls, 1);
+  transport.PutSample("sitos/buffers/s/durable/k", {std::byte{2}});
+  EXPECT_EQ(engine->put_calls, 1);
+  auto result = transport.Query("sitos/buffers/s/durable/k");
+  ASSERT_EQ(result.replies.size(), 1u);
+  EXPECT_EQ(result.replies[0].second, (std::vector<std::byte>{std::byte{1}}));
 }
-TEST(StorageNodeBufferLifecycleTest, CloseQuiescesDurableOperationsAndDestroysEngine) {
-  BufferTransport transport;
-  StorageNode node(transport);
-  auto destroyed = std::make_shared<bool>(false);
-  auto engine = std::make_unique<CountingEngine>(destroyed);
-  ASSERT_TRUE(node.Start(std::make_shared<CountingEngine>(), transport,
-                         {.prefix = "sitos",
-                          .log_sink = nullptr,
-                          .durable_buffer_engine_factory = [&](std::string_view) {
-                            return Result<std::unique_ptr<StorageEngine>>::Ok(std::move(engine));
-                          }}));
-  ASSERT_TRUE(node.CreateSession("s", {.durable = true}));
-  ASSERT_TRUE(node.CloseSession("s"));
-  EXPECT_TRUE(*destroyed);
+
+TEST_F(StorageNodeBufferRoutingTest, WholeSubscriberSerializationPreventsConflictingPuts) {
+  ASSERT_TRUE(node.CreateSession("s", {.durable_buffers = true}).IsOk());
+  std::thread first([&] { transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}}); });
+  std::thread second([&] { transport.PutSample("sitos/buffers/s/durable/k", {std::byte{2}}); });
+  first.join();
+  second.join();
+  auto* engine = engines.at("s");
+  EXPECT_EQ(engine->put_calls, 1);
+  auto result = transport.Query("sitos/buffers/s/durable/k");
+  ASSERT_EQ(result.replies.size(), 1u);
+  EXPECT_TRUE(result.replies[0].second == std::vector<std::byte>{std::byte{1}} ||
+              result.replies[0].second == std::vector<std::byte>{std::byte{2}});
 }
-TEST(StorageNodeBufferLifecycleTest, SameSidRecreationUsesFreshEngine) {
-  BufferTransport transport;
-  StorageNode node(transport);
-  int calls = 0;
-  ASSERT_TRUE(node.Start(std::make_shared<CountingEngine>(), transport,
-                         {.prefix = "sitos",
-                          .log_sink = nullptr,
-                          .durable_buffer_engine_factory = [&](std::string_view) {
-                            ++calls;
-                            return Result<std::unique_ptr<StorageEngine>>::Ok(
-                                std::make_unique<CountingEngine>());
-                          }}));
-  ASSERT_TRUE(node.CreateSession("s", {.durable = true}));
-  ASSERT_TRUE(node.CloseSession("s"));
-  ASSERT_TRUE(node.CreateSession("s", {.durable = true}));
-  EXPECT_EQ(calls, 2);
+
+TEST_F(StorageNodeBufferRoutingTest, EphemeralPutNeverTouchesEngine) {
+  ASSERT_TRUE(node.CreateSession("s", {.ephemeral_buffers = true}).IsOk());
+  transport.PutSample("sitos/buffers/s/ephemeral/k", {std::byte{1}});
+  EXPECT_TRUE(engines.empty());
+  EXPECT_EQ(transport.Query("sitos/buffers/s/ephemeral/k").replies.size(), 0u);
+}
+
+TEST_F(StorageNodeBufferRoutingTest, NonBytesEncodingIsRejected) {
+  ASSERT_TRUE(node.CreateSession("s", {.durable_buffers = true, .ephemeral_buffers = true}).IsOk());
+  auto* engine = engines.at("s");
+  const std::vector<std::string> rejected = {"sitos.v1", "sitos.v1.batch", "zenoh/bytes;schema=x",
+                                             "", "application/octet-stream"};
+  for (const auto& encoding : rejected) {
+    transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}}, encoding);
+  }
+  EXPECT_EQ(engine->get_calls, 0);
+  EXPECT_EQ(engine->put_calls, 0);
+  transport.PutSample("sitos/buffers/s/durable/empty", {}, "zenoh/bytes");
+  EXPECT_EQ(engine->put_calls, 1);
+}
+
+TEST_F(StorageNodeBufferRoutingTest, DurableQuerySelectorsAndFailures) {
+  ASSERT_TRUE(node.CreateSession("s", {.durable_buffers = true}).IsOk());
+  transport.PutSample("sitos/buffers/s/durable/a/k", {std::byte{1}});
+  transport.PutSample("sitos/buffers/s/durable/a/l", {std::byte{2}});
+  transport.PutSample("sitos/buffers/s/durable/b", {std::byte{3}});
+  EXPECT_EQ(transport.Query("sitos/buffers/s/durable/a/k").replies.size(), 1u);
+  EXPECT_EQ(transport.Query("sitos/buffers/s/durable/**").replies.size(), 3u);
+  EXPECT_EQ(transport.Query("sitos/buffers/s/durable/a/**").replies.size(), 2u);
+  EXPECT_EQ(transport.Query("sitos/buffers/s/durable/missing").replies.size(), 0u);
+  EXPECT_EQ(transport.Query("sitos/buffers/s/ephemeral/**").replies.size(), 0u);
+
+  auto* engine = engines.at("s");
+  engine->false_list = true;
+  EXPECT_TRUE(transport.Query("sitos/buffers/s/durable/**").replies.empty());
+  engine->false_list = false;
+  engine->throw_get = true;
+  EXPECT_TRUE(transport.Query("sitos/buffers/s/durable/a/k").replies.empty());
+  engine->throw_get = false;
+  auto partial = transport.Query("sitos/buffers/s/durable/**", 1);
+  EXPECT_EQ(partial.replies.size(), 1u);
+  EXPECT_EQ(partial.reply_calls, 1);
+}
+
+TEST_F(StorageNodeBufferRoutingTest, EngineFailuresAndExceptionsAreContained) {
+  ASSERT_TRUE(node.CreateSession("s", {.durable_buffers = true}).IsOk());
+  auto* engine = engines.at("s");
+  engine->throw_put = true;
+  EXPECT_NO_THROW(transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}}));
+  EXPECT_EQ(engine->put_calls, 1);
+  engine->throw_put = false;
+  engine->throw_get = true;
+  EXPECT_NO_THROW(transport.Query("sitos/buffers/s/durable/k"));
+  EXPECT_NO_THROW(transport.PutSample("sitos/buffers/s/durable/k", {std::byte{2}}));
+}
+
+TEST_F(StorageNodeBufferRoutingTest, BufferRoutesDoNotEnterParameterSurfaces) {
+  ASSERT_TRUE(node.CreateSession("s", {.durable_buffers = true}).IsOk());
+  transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}});
+  EXPECT_TRUE(transport.Query("sitos/session/s/k").replies.empty());
+  EXPECT_TRUE(transport.Query("sitos/meta/session/s").replies.empty() == false);
+}
+
+TEST_F(StorageNodeBufferRoutingTest, BufferDeleteAndControlRoutesAreRejected) {
+  ASSERT_TRUE(node.CreateSession("s", {.durable_buffers = true}).IsOk());
+  auto* engine = engines.at("s");
+  EXPECT_NO_THROW(transport.DeleteSample("sitos/buffers/s/durable/k"));
+  transport.PutSample("sitos/buffers/s/durable/k/*", {std::byte{1}});
+  transport.PutSample("sitos/buffers/s/durable", {std::byte{1}});
+  EXPECT_EQ(engine->put_calls, 0);
 }
 
 }  // namespace

--- a/tests/unit/storage_node_buffer_routing_test.cpp
+++ b/tests/unit/storage_node_buffer_routing_test.cpp
@@ -30,13 +30,9 @@ class ProgrammableEngine final : public StorageEngine {
   }
 
   bool Put(std::string_view key, Bytes value) override {
-    std::unique_lock lock(mutex_);
+    WaitUntilReleased(block_put, put_entered);
+    std::scoped_lock lock(mutex_);
     ++put_calls;
-    if (block_put) {
-      ++put_entered;
-      cv.notify_all();
-      cv.wait(lock, [this] { return !block_put; });
-    }
     if (throw_put) throw std::runtime_error("put failure");
     if (false_puts > 0) {
       --false_puts;
@@ -54,13 +50,9 @@ class ProgrammableEngine final : public StorageEngine {
   }
 
   bool Get(std::string_view key, const EntrySink& sink) const override {
+    WaitUntilReleased(block_get, get_entered);
     std::unique_lock lock(mutex_);
     ++get_calls;
-    if (block_get) {
-      ++get_entered;
-      cv.notify_all();
-      cv.wait(lock, [this] { return !block_get; });
-    }
     if (throw_get) throw std::runtime_error("get failure");
     auto it = values_.find(std::string(key));
     if (it == values_.end()) return false;
@@ -71,13 +63,9 @@ class ProgrammableEngine final : public StorageEngine {
   }
 
   bool List(std::string_view prefix, const EntrySink& sink) const override {
+    WaitUntilReleased(block_list, list_entered);
     std::unique_lock lock(mutex_);
     ++list_calls;
-    if (block_list) {
-      ++list_entered;
-      cv.notify_all();
-      cv.wait(lock, [this] { return !block_list; });
-    }
     if (throw_list) throw std::runtime_error("list failure");
     std::vector<std::pair<std::string, std::vector<std::byte>>> entries;
     for (const auto& [key, value] : values_) {
@@ -90,15 +78,16 @@ class ProgrammableEngine final : public StorageEngine {
     return !false_list;
   }
 
-  void WaitFor(std::condition_variable& condition, int& count) {
-    std::unique_lock lock(mutex_);
-    condition.wait(lock, [&] { return count > 0; });
+  void WaitFor(int& count) {
+    std::unique_lock lock(gate_mutex_);
+    cv.wait(lock, [&] { return count > 0; });
   }
   void ReleasePut() { SetBlocked(block_put, false); }
   void ReleaseGet() { SetBlocked(block_get, false); }
   void ReleaseList() { SetBlocked(block_list, false); }
 
   mutable std::mutex mutex_;
+  mutable std::mutex gate_mutex_;
   mutable std::condition_variable cv;
   mutable std::map<std::string, std::vector<std::byte>> values_;
   mutable int put_calls = 0;
@@ -108,8 +97,8 @@ class ProgrammableEngine final : public StorageEngine {
   mutable int get_entered = 0;
   mutable int list_entered = 0;
   bool block_put = false;
-  bool block_get = false;
-  bool block_list = false;
+  mutable bool block_get = false;
+  mutable bool block_list = false;
   bool throw_put = false;
   mutable bool throw_get = false;
   mutable bool throw_list = false;
@@ -122,10 +111,17 @@ class ProgrammableEngine final : public StorageEngine {
   static std::vector<std::byte> Copy(Bytes value) { return {value.begin(), value.end()}; }
   void SetBlocked(bool& blocked, bool value) {
     {
-      std::scoped_lock lock(mutex_);
+      std::scoped_lock lock(gate_mutex_);
       blocked = value;
     }
     cv.notify_all();
+  }
+  void WaitUntilReleased(bool& blocked, int& entered) const {
+    std::unique_lock lock(gate_mutex_);
+    if (!blocked) return;
+    ++entered;
+    cv.notify_all();
+    cv.wait(lock, [&] { return !blocked; });
   }
 };
 
@@ -161,9 +157,18 @@ class BufferTransport final : public Transport {
 
   void PutSample(std::string key, std::vector<std::byte> payload,
                  std::string encoding = "zenoh/bytes") {
+    {
+      std::scoped_lock lock(sample_mutex);
+      ++sample_callbacks;
+      sample_cv.notify_all();
+    }
     TransportSample sample{std::move(key), payload, Encoding{std::move(encoding)}, std::nullopt,
                            TransportSample::Kind::Put};
     subscriber(sample);
+  }
+  void WaitForSamples(int count) {
+    std::unique_lock lock(sample_mutex);
+    sample_cv.wait(lock, [&] { return sample_callbacks >= count; });
   }
   void DeleteSample(std::string key) {
     TransportSample sample{
@@ -191,13 +196,32 @@ class BufferTransport final : public Transport {
 
   std::function<void(const TransportSample&)> subscriber;
   std::function<void(TransportQuery&)> queryable;
+  std::mutex sample_mutex;
+  std::condition_variable sample_cv;
+  int sample_callbacks = 0;
+};
+
+class RecordingLogSink final : public LogSink {
+ public:
+  void Write(const LogRecord& record) override {
+    std::scoped_lock lock(mutex);
+    if (throwing) throw std::runtime_error("log failure");
+    messages.emplace_back(record.message);
+  }
+  std::vector<std::string> Messages() const {
+    std::scoped_lock lock(mutex);
+    return messages;
+  }
+  mutable std::mutex mutex;
+  std::vector<std::string> messages;
+  bool throwing = false;
 };
 
 struct StorageNodeBufferRoutingTest : testing::Test {
   void SetUp() override {
     ASSERT_TRUE(node.Start(base, transport,
                            {.prefix = "sitos",
-                            .log_sink = nullptr,
+                            .log_sink = log_sink,
                             .durable_buffer_engine_factory = [&](std::string_view sid) {
                               factory_sids.emplace_back(sid);
                               auto engine = std::make_unique<ProgrammableEngine>();
@@ -207,6 +231,7 @@ struct StorageNodeBufferRoutingTest : testing::Test {
                             }}));
   }
   std::shared_ptr<ProgrammableEngine> base = std::make_shared<ProgrammableEngine>();
+  std::shared_ptr<RecordingLogSink> log_sink = std::make_shared<RecordingLogSink>();
   BufferTransport transport;
   StorageNode node{transport};
   std::vector<std::string> factory_sids;
@@ -248,25 +273,39 @@ TEST_F(StorageNodeBufferRoutingTest, PutFailureRereadsAuthoritativeEngineState) 
   ASSERT_TRUE(node.CreateSession("s", {.durable_buffers = true}).IsOk());
   auto* engine = engines.at("s");
   engine->false_puts = 1;
+  transport.PutSample("sitos/buffers/s/durable/unmodified", {std::byte{1}});
+  EXPECT_EQ(engine->put_calls, 1);
+  transport.PutSample("sitos/buffers/s/durable/unmodified", {std::byte{1}});
+  EXPECT_EQ(engine->put_calls, 2);
+  engine->false_puts = 1;
   engine->partial_false_put = true;
-  transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}});
-  EXPECT_EQ(engine->put_calls, 1);
-  transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}});
-  EXPECT_EQ(engine->put_calls, 1);
-  transport.PutSample("sitos/buffers/s/durable/k", {std::byte{2}});
-  EXPECT_EQ(engine->put_calls, 1);
-  auto result = transport.Query("sitos/buffers/s/durable/k");
+  transport.PutSample("sitos/buffers/s/durable/partial", {std::byte{2}});
+  EXPECT_EQ(engine->put_calls, 3);
+  transport.PutSample("sitos/buffers/s/durable/partial", {std::byte{2}});
+  EXPECT_EQ(engine->put_calls, 3);
+  transport.PutSample("sitos/buffers/s/durable/partial", {std::byte{3}});
+  EXPECT_EQ(engine->put_calls, 3);
+  auto result = transport.Query("sitos/buffers/s/durable/partial");
   ASSERT_EQ(result.replies.size(), 1u);
-  EXPECT_EQ(result.replies[0].second, (std::vector<std::byte>{std::byte{1}}));
+  EXPECT_EQ(result.replies[0].first, "sitos/buffers/s/durable/partial");
+  EXPECT_EQ(result.replies[0].second, (std::vector<std::byte>{std::byte{2}}));
 }
 
 TEST_F(StorageNodeBufferRoutingTest, WholeSubscriberSerializationPreventsConflictingPuts) {
   ASSERT_TRUE(node.CreateSession("s", {.durable_buffers = true}).IsOk());
+  auto* engine = engines.at("s");
+  engine->block_get = true;
   std::thread first([&] { transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}}); });
+  engine->WaitFor(engine->get_entered);
   std::thread second([&] { transport.PutSample("sitos/buffers/s/durable/k", {std::byte{2}}); });
+  transport.WaitForSamples(2);
+  {
+    std::scoped_lock lock(engine->gate_mutex_);
+    EXPECT_EQ(engine->get_entered, 1);
+  }
+  engine->ReleaseGet();
   first.join();
   second.join();
-  auto* engine = engines.at("s");
   EXPECT_EQ(engine->put_calls, 1);
   auto result = transport.Query("sitos/buffers/s/durable/k");
   ASSERT_EQ(result.replies.size(), 1u);
@@ -286,10 +325,18 @@ TEST_F(StorageNodeBufferRoutingTest, NonBytesEncodingIsRejected) {
   auto* engine = engines.at("s");
   const std::vector<std::string> rejected = {"sitos.v1", "sitos.v1.batch", "zenoh/bytes;schema=x",
                                              "", "application/octet-stream"};
+  const auto diagnostics_before = log_sink->Messages().size();
   for (const auto& encoding : rejected) {
     transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}}, encoding);
   }
+  const auto diagnostics_after = log_sink->Messages();
+  EXPECT_GE(diagnostics_after.size(), diagnostics_before + rejected.size());
   EXPECT_EQ(engine->get_calls, 0);
+  EXPECT_EQ(engine->put_calls, 0);
+  log_sink->throwing = true;
+  EXPECT_NO_THROW(
+      transport.PutSample("sitos/buffers/s/durable/throw-log", {std::byte{1}}, "not-bytes"));
+  log_sink->throwing = false;
   EXPECT_EQ(engine->put_calls, 0);
   transport.PutSample("sitos/buffers/s/durable/empty", {}, "zenoh/bytes");
   EXPECT_EQ(engine->put_calls, 1);
@@ -300,22 +347,46 @@ TEST_F(StorageNodeBufferRoutingTest, DurableQuerySelectorsAndFailures) {
   transport.PutSample("sitos/buffers/s/durable/a/k", {std::byte{1}});
   transport.PutSample("sitos/buffers/s/durable/a/l", {std::byte{2}});
   transport.PutSample("sitos/buffers/s/durable/b", {std::byte{3}});
-  EXPECT_EQ(transport.Query("sitos/buffers/s/durable/a/k").replies.size(), 1u);
-  EXPECT_EQ(transport.Query("sitos/buffers/s/durable/**").replies.size(), 3u);
-  EXPECT_EQ(transport.Query("sitos/buffers/s/durable/a/**").replies.size(), 2u);
+  auto exact = transport.Query("sitos/buffers/s/durable/a/k");
+  ASSERT_EQ(exact.replies.size(), 1u);
+  EXPECT_EQ(exact.replies[0].first, "sitos/buffers/s/durable/a/k");
+  EXPECT_EQ(exact.replies[0].second, (std::vector<std::byte>{std::byte{1}}));
+  EXPECT_EQ(exact.encodings[0].id, "zenoh/bytes");
+  auto root = transport.Query("sitos/buffers/s/durable/**");
+  ASSERT_EQ(root.replies.size(), 3u);
+  EXPECT_EQ(root.replies[0].first, "sitos/buffers/s/durable/a/k");
+  EXPECT_EQ(root.replies[1].first, "sitos/buffers/s/durable/a/l");
+  EXPECT_EQ(root.replies[2].first, "sitos/buffers/s/durable/b");
+  for (const auto& encoding : root.encodings) EXPECT_EQ(encoding.id, "zenoh/bytes");
+  auto subtree = transport.Query("sitos/buffers/s/durable/a/**");
+  ASSERT_EQ(subtree.replies.size(), 2u);
+  EXPECT_EQ(subtree.replies[0].first, "sitos/buffers/s/durable/a/k");
+  EXPECT_EQ(subtree.replies[1].first, "sitos/buffers/s/durable/a/l");
   EXPECT_EQ(transport.Query("sitos/buffers/s/durable/missing").replies.size(), 0u);
   EXPECT_EQ(transport.Query("sitos/buffers/s/ephemeral/**").replies.size(), 0u);
+  ASSERT_TRUE(node.CreateSession("eph", {.ephemeral_buffers = true}).IsOk());
+  EXPECT_TRUE(transport.Query("sitos/buffers/eph/durable/**").replies.empty());
+  EXPECT_TRUE(transport.Query("sitos/buffers/unknown/durable/**").replies.empty());
+  EXPECT_TRUE(transport.Query("sitos/buffers/s/durable/a/*").replies.empty());
+  ASSERT_TRUE(node.CloseSession("eph").IsOk());
+  EXPECT_TRUE(transport.Query("sitos/buffers/eph/durable/**").replies.empty());
 
   auto* engine = engines.at("s");
   engine->false_list = true;
   EXPECT_TRUE(transport.Query("sitos/buffers/s/durable/**").replies.empty());
   engine->false_list = false;
+  engine->throw_list = true;
+  EXPECT_TRUE(transport.Query("sitos/buffers/s/durable/**").replies.empty());
+  engine->throw_list = false;
   engine->throw_get = true;
   EXPECT_TRUE(transport.Query("sitos/buffers/s/durable/a/k").replies.empty());
   engine->throw_get = false;
   auto partial = transport.Query("sitos/buffers/s/durable/**", 1);
   EXPECT_EQ(partial.replies.size(), 1u);
   EXPECT_EQ(partial.reply_calls, 1);
+  auto throwing = transport.Query("sitos/buffers/s/durable/**", 1, true);
+  EXPECT_EQ(throwing.replies.size(), 1u);
+  EXPECT_EQ(throwing.reply_calls, 1);
 }
 
 TEST_F(StorageNodeBufferRoutingTest, EngineFailuresAndExceptionsAreContained) {
@@ -325,16 +396,22 @@ TEST_F(StorageNodeBufferRoutingTest, EngineFailuresAndExceptionsAreContained) {
   EXPECT_NO_THROW(transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}}));
   EXPECT_EQ(engine->put_calls, 1);
   engine->throw_put = false;
+  EXPECT_NO_THROW(transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}}));
+  EXPECT_EQ(engine->put_calls, 2);
   engine->throw_get = true;
   EXPECT_NO_THROW(transport.Query("sitos/buffers/s/durable/k"));
-  EXPECT_NO_THROW(transport.PutSample("sitos/buffers/s/durable/k", {std::byte{2}}));
+  engine->throw_get = false;
 }
 
 TEST_F(StorageNodeBufferRoutingTest, BufferRoutesDoNotEnterParameterSurfaces) {
   ASSERT_TRUE(node.CreateSession("s", {.durable_buffers = true}).IsOk());
+  auto metadata_before = transport.Query("sitos/meta/session/s");
   transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}});
   EXPECT_TRUE(transport.Query("sitos/session/s/k").replies.empty());
-  EXPECT_TRUE(transport.Query("sitos/meta/session/s").replies.empty() == false);
+  auto metadata_after = transport.Query("sitos/meta/session/s");
+  ASSERT_EQ(metadata_before.replies.size(), 1u);
+  ASSERT_EQ(metadata_after.replies.size(), 1u);
+  EXPECT_EQ(metadata_before.replies[0].second, metadata_after.replies[0].second);
 }
 
 TEST_F(StorageNodeBufferRoutingTest, BufferDeleteAndControlRoutesAreRejected) {
@@ -343,6 +420,9 @@ TEST_F(StorageNodeBufferRoutingTest, BufferDeleteAndControlRoutesAreRejected) {
   EXPECT_NO_THROW(transport.DeleteSample("sitos/buffers/s/durable/k"));
   transport.PutSample("sitos/buffers/s/durable/k/*", {std::byte{1}});
   transport.PutSample("sitos/buffers/s/durable", {std::byte{1}});
+  transport.PutSample("sitos/buffers/s/durable/:batch", {std::byte{1}});
+  transport.PutSample("sitos/buffers/s/durable/:fence", {std::byte{1}});
+  transport.PutSample("sitos/snap/s/k", {std::byte{1}});
   EXPECT_EQ(engine->put_calls, 0);
 }
 

--- a/tests/unit/storage_node_buffer_routing_test.cpp
+++ b/tests/unit/storage_node_buffer_routing_test.cpp
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <condition_variable>
 #include <cstddef>
 #include <functional>
@@ -210,6 +211,7 @@ class RecordingLogSink final : public LogSink {
  public:
   void Write(const LogRecord& record) override {
     std::scoped_lock lock(mutex);
+    ++write_attempts;
     if (throwing) throw std::runtime_error("log failure");
     messages.emplace_back(record.message);
   }
@@ -219,6 +221,7 @@ class RecordingLogSink final : public LogSink {
   }
   mutable std::mutex mutex;
   std::vector<std::string> messages;
+  int write_attempts = 0;
   bool throwing = false;
 };
 
@@ -251,14 +254,22 @@ TEST_F(StorageNodeBufferRoutingTest, CapabilityMatrix) {
       node.CreateSession("both", {.durable_buffers = true, .ephemeral_buffers = true}).IsOk());
   EXPECT_EQ(factory_sids, (std::vector<std::string>{"dur", "both"}));
 
+  const auto enabled_ephemeral_before = log_sink->Messages().size();
+  transport.PutSample("sitos/buffers/eph/ephemeral/k", {std::byte{1}});
+  transport.PutSample("sitos/buffers/both/ephemeral/k", {std::byte{1}});
+  EXPECT_EQ(log_sink->Messages().size(), enabled_ephemeral_before);
+  const auto disabled_before = log_sink->Messages().size();
   transport.PutSample("sitos/buffers/none/durable/k", {std::byte{1}});
   transport.PutSample("sitos/buffers/none/ephemeral/k", {std::byte{1}});
-  transport.PutSample("sitos/buffers/dur/durable/k", {std::byte{1}});
   transport.PutSample("sitos/buffers/dur/ephemeral/k", {std::byte{1}});
   transport.PutSample("sitos/buffers/eph/durable/k", {std::byte{1}});
-  transport.PutSample("sitos/buffers/eph/ephemeral/k", {std::byte{1}});
+  const auto disabled_messages = log_sink->Messages();
+  ASSERT_EQ(disabled_messages.size(), disabled_before + 4);
+  for (std::size_t i = disabled_before; i < disabled_messages.size(); ++i) {
+    EXPECT_EQ(disabled_messages[i], "buffer capability disabled");
+  }
+  transport.PutSample("sitos/buffers/dur/durable/k", {std::byte{1}});
   transport.PutSample("sitos/buffers/both/durable/k", {std::byte{1}});
-  transport.PutSample("sitos/buffers/both/ephemeral/k", {std::byte{1}});
   EXPECT_EQ(engines.at("dur")->put_calls, 1);
   EXPECT_EQ(engines.at("both")->put_calls, 1);
   EXPECT_FALSE(engines.contains("eph"));
@@ -316,15 +327,13 @@ TEST_F(StorageNodeBufferRoutingTest, WholeSubscriberSerializationPreventsConflic
   std::mutex observer_mutex;
   std::condition_variable observer_cv;
   int boundary_entries = 0;
-  bool release_second = false;
   ASSERT_TRUE(
       storage_node_test_access::StorageNodeTestAccess::SetSubscriberEntryObserver(node, [&] {
-        std::unique_lock lock(observer_mutex);
-        ++boundary_entries;
-        observer_cv.notify_all();
-        if (boundary_entries >= 2) {
-          observer_cv.wait(lock, [&] { return release_second; });
+        {
+          std::scoped_lock lock(observer_mutex);
+          ++boundary_entries;
         }
+        observer_cv.notify_all();
       }));
   std::thread first([&] { transport.PutSample("sitos/buffers/s/durable/k", {std::byte{1}}); });
   engine->WaitFor(engine->get_entered);
@@ -337,12 +346,8 @@ TEST_F(StorageNodeBufferRoutingTest, WholeSubscriberSerializationPreventsConflic
     std::scoped_lock lock(engine->gate_mutex_);
     EXPECT_EQ(engine->get_entered, 1);
   }
+  EXPECT_FALSE(storage_node_test_access::StorageNodeTestAccess::TryLockSubscriberMutex(node));
   engine->ReleaseGet();
-  {
-    std::scoped_lock lock(observer_mutex);
-    release_second = true;
-  }
-  observer_cv.notify_all();
   first.join();
   second.join();
   EXPECT_EQ(engine->put_calls, 1);
@@ -382,8 +387,10 @@ TEST_F(StorageNodeBufferRoutingTest, NonBytesEncodingIsRejected) {
   EXPECT_EQ(engine->get_calls, 0);
   EXPECT_EQ(engine->put_calls, 0);
   log_sink->throwing = true;
+  const int subscriber_log_attempts = log_sink->write_attempts;
   EXPECT_NO_THROW(
       transport.PutSample("sitos/buffers/s/durable/throw-log", {std::byte{1}}, "not-bytes"));
+  EXPECT_EQ(log_sink->write_attempts, subscriber_log_attempts + 1);
   log_sink->throwing = false;
   EXPECT_EQ(engine->put_calls, 0);
   transport.PutSample("sitos/buffers/s/durable/empty", {}, "zenoh/bytes");
@@ -460,8 +467,17 @@ TEST_F(StorageNodeBufferRoutingTest, DurableQuerySelectorsAndFailures) {
   EXPECT_EQ(throwing.replies.size(), 1u);
   EXPECT_EQ(throwing.reply_calls, 1);
   EXPECT_EQ(throwing.reply_attempts, 2);
+  const int returned_reply_before = diagnostic_count("durable buffer query failed");
+  const int returned_reply_attempts = log_sink->write_attempts;
+  auto returned_failure = transport.Query("sitos/buffers/s/durable/**", 1);
+  EXPECT_EQ(returned_failure.replies.size(), 1u);
+  EXPECT_EQ(returned_failure.reply_attempts, 2);
+  EXPECT_EQ(diagnostic_count("durable buffer query failed"), returned_reply_before + 1);
+  EXPECT_EQ(log_sink->write_attempts, returned_reply_attempts + 1);
+  const int throwing_reply_attempts = log_sink->write_attempts;
   log_sink->throwing = true;
   EXPECT_NO_THROW(transport.Query("sitos/buffers/s/durable/**", 1));
+  EXPECT_EQ(log_sink->write_attempts, throwing_reply_attempts + 1);
   log_sink->throwing = false;
 }
 


### PR DESCRIPTION
Closes #141

## Implementation summary

This PR implements the frozen Issue #141 C++ Session capability and mixed durable/ephemeral buffer routing contract on top of #139/#140. It adds the capability overload and durable engine factory, preserves the legacy overload, admits exact `zenoh/bytes` buffer PUTs, applies durable write-once/idempotent routing, keeps ephemeral routes live-only, and materializes durable query results before releasing Session admission.

## Frozen Issue checklist

## Summary

Implement the public Session capability and durable-engine factory API plus StorageNode's mixed
durable and ephemeral buffer routing on the lifecycle foundation from #140.

This is stage 3 of the owner-approved Issue #56 split in DEC-56-SPLIT-001. It proves the contract
with deterministic in-process and fake-Transport tests. Raw Zenoh, RocksDB, installed-package, and
combined-CI evidence remain in final Issue #56.

## Branch

`feat/141-mixed-session-buffer-routing`

## Dependencies

- Depends on #139 and #140.
- Parent integration issue: #56.
- Contract Registry change: none; implementation remains `Planned` until final Issue #56.

## Normative references

- ADR-0032, Accepted on 2026-07-31
- `docs/01_requirements.md`
- `docs/02_architecture.md` buffer callbacks and Session lifecycle
- `docs/03_wire_protocol.md` canonical buffer routes and Encoding
- `docs/04_api_cpp.md` public Session API
- DEC-56-FACTORY-FAILURE-001
- DEC-56-SETUP-FAILURE-001
- DEC-56-STOP-CREATE-001, limited to admitted-Create completion ordering
- DEC-56-PERSISTENCE-FAILURE-001
- DEC-56-ENCODING-ADMISSION-001
- DEC-56-PUBLIC-API-001
- DEC-140-STOP-STATUS-002 for the preserved stopped-node / gate-closed status taxonomy

## Public API

- [x] Add `SessionOptions` to `include/sitos/session.hpp` with default-false durable and ephemeral
  capability booleans.
- [x] Add the exact `DurableBufferEngineFactory` alias to `include/sitos/storage_node.hpp`.
- [x] Append `durable_buffer_engine_factory` to `StorageNodeConfig` and move it once into the
  callback-shared State during Start.
- [x] Preserve the exact one-argument `CreateSession(std::string_view)` member and behavior.
- [x] Add the separate two-argument `CreateSession(std::string_view, SessionOptions)` overload.
- [x] Invoke the factory at most once per creation request: exactly once only when durable is
  enabled, the same Creating reservation remains valid, and every pre-factory setup step succeeds.
  Invoke it zero times for disabled durable capability, invalid input, lifecycle collision, a
  stopped node or closed node gate, or any pre-factory failure.
- [x] Preserve the merged stopped-node and gate-closed result for both CreateSession overloads:
  `InvalidArgument`, `std::errc::invalid_argument`, and an empty message per
  DEC-140-STOP-STATUS-002. This status preservation supersedes only the non-admitted stopped-node
  classification from DEC-56-STOP-CREATE-001; the admitted-Create ordering rule still applies.
- [x] Pass the exact SID, share the returned engine across all durable keys in that Session, retain
  no alias outside the SessionRecord, and destroy it on rollback or Session close.
- [x] Add no public Encoding constant.
- [x] Require consumer rebuild rather than binary ABI compatibility for the aggregate extension.

## Transactional creation and factory failures

- [x] Prepare snapshot, overlay, metadata, and non-factory resources before factory invocation.
- [x] Preserve DEC-56-SETUP-FAILURE-001 exactly for all pre-factory setup failures, including
  snapshot-null and snapshot-exception Status, cause, message, rollback, retryability, and zero
  factory invocation.
- [x] Keep all external factory work outside the Session-state mutex while retaining the node gate.
- [x] For durable-enabled creation, commit only a valid non-null engine to the same
  still-Creating reservation.
- [x] Preserve a factory `Err` status, cause, and message exactly.
- [x] Implement every exact Status, cause, and message in DEC-56-FACTORY-FAILURE-001.
- [x] Roll back every factory non-commit outcome and release all attempt-created state.
- [x] Keep the prohibition on synchronous same-node waiting-lifecycle re-entry from the factory;
  do not add runtime deadlock detection.
- [x] Preserve DEC-56-STOP-CREATE-001 completion ordering for an admitted factory call.

## Route admission and storage

- [x] Handle `<prefix>/buffers/<sid>/durable/<key>` and `ephemeral/<key>` explicitly in both
  StorageNode Transport callbacks.
- [x] Acquire the exact Active SessionRecord and admission lease before touching Session resources.
- [x] Apply the four capability combinations: none, durable only, ephemeral only, and both.
- [x] Never create or mutate a durable engine when durable routing is disabled.
- [x] Accept buffer PUT only for exact bare `zenoh/bytes`; accept both non-empty and empty opaque
  payloads.
- [x] In the fixed Encoding test, reject `sitos.v1`, `sitos.v1.batch`, a schema-suffixed bytes
  identifier, an empty identifier, and an unknown identifier. Each rejection performs zero durable
  Get/Put calls, creates no ephemeral state, and emits a payload-free non-throwing diagnostic.
  Existing parameter-route schema behavior remains unchanged.
- [x] Preserve independent Zenoh live fanout; rejection is not a network ACL or retraction.
- [x] Admit enabled ephemeral PUT without node-side storage or write-once tracking.
- [x] Serialize durable `ReadExact`, compare, and optional Put under the whole-subscriber mutex.
- [x] Treat equal existing bytes as idempotent and reject conflicting bytes without mutation.
- [x] Inspect Put failure and implement the retry/source-of-truth rule from
  DEC-56-PERSISTENCE-FAILURE-001.
- [x] Support exact durable Get, root `durable/**` as `List("")`, and subtree `durable/a/**` as
  `List("a/")`; return canonical full durable keys, byte-exact payloads, and bare-byte Encoding.
- [x] Return zero replies for ephemeral queries, disabled capabilities, non-Active or unknown SIDs,
  malformed selectors, non-terminal wildcards, and control forms. Query callbacks do not acquire
  the subscriber mutex.
- [x] Copy engine key/value views into owned storage during Get/List, complete the engine operation,
  and release Session admission before sending any reply. An exact Get returning false without
  invoking its sink is a normal zero-reply miss. A List collection that returns false, or a Get/List
  exception before reply dispatch, produces zero replies and a payload-free diagnostic. After reply
  dispatch begins, a reply-handler failure is contained, suppresses subsequent replies, and may
  leave earlier replies delivered; #141 does not add an atomic or rollback-capable transport reply
  guarantee.
- [x] Buffer DELETE and control forms remain unsupported. Existing raw base and Session DELETE
  behavior remains unchanged.
- [x] Contain ReadExact, Get, List, Put, reply-handler, and LogSink failures or exceptions, release
  locks and admission through RAII, then emit diagnostics while the node gate lease remains valid.

## Isolation

- [x] Buffer routes must not enter ParamStore, ParamCache, ParamSubscription, snapshot, or
  SessionView parameter surfaces.
- [x] Keep capabilities, factory details, engine type, and engine path out of metadata and query
  routes. Preserve the existing `meta/session/<sid>` payload unchanged.
- [x] Add no production or test-only BufferPublisher, BufferSubscriber, late-join collector, or
  Python buffer API in this stage. Final Issue #56 owns all late-join evidence.

## R5 review corrections

The current head retains the mutation-resistant subscriber proof, synchronized observer seam,
and allocation-free Stop drain. R5 synchronizes the public documentation with the exact
stopped/captured-closed-gate CreateSession InvalidArgument contract, documents that independent
CreateSession calls may invoke a mutable factory concurrently, and proves both returned and thrown
reply-handler diagnostics. The thrown-handler case asserts the exact payload-free diagnostic and
repeats with a throwing LogSink to prove contained invocation. The architecture pseudocode collects
owned durable results under admission and dispatches replies only after admission release.

## Public API correction

The corrected head publishes the frozen exact source API: `SessionOptions::durable_buffers` and
`SessionOptions::ephemeral_buffers` are default-false booleans in `include/sitos/session.hpp`, and
`DurableBufferEngineFactory` is declared in `include/sitos/storage_node.hpp`. The legacy one-argument
`CreateSession(std::string_view)` member-pointer shape and the separate capability overload remain
unchanged.

## TDD and fixed acceptance tests

Write tests first and record RED evidence. All concurrency tests use deterministic barriers or
latches and no fixed sleeps.

Validation classification: the public API and legacy member-pointer assertions have genuine
pre-implementation compile/contract RED evidence. Under owner decision DEC-141-TDD-EXCEPTION-001,
the deterministic factory, lifecycle, routing, persistence, and query scenarios are classified as
review-driven regression coverage; their missing pre-implementation behavioral RED chronology is
not fabricated or reconstructed.

- [x] `StorageNodeBufferApiTest.PreservesLegacyCreateSessionOverload`
- [x] `StorageNodeBufferApiTest.ExposesCapabilityOverloadAndFactory`
- [x] `StorageNodeBufferLifecycleTest.FactoryFailureTaxonomyAndRollback`
- [x] `StorageNodeBufferLifecycleTest.FactoryAndStopLinearizeDeterministically`
- [x] `StorageNodeBufferLifecycleTest.CloseQuiescesDurableOperationsAndDestroysEngine`
- [x] `StorageNodeBufferLifecycleTest.SameSidRecreationUsesFreshEngine`
- [x] `StorageNodeBufferRoutingTest.CapabilityMatrix`
- [x] `StorageNodeBufferRoutingTest.DurablePutIsByteExactAndWriteOnce`
- [x] `StorageNodeBufferRoutingTest.PutFailureRereadsAuthoritativeEngineState`
- [x] `StorageNodeBufferRoutingTest.WholeSubscriberSerializationPreventsConflictingPuts`
- [x] `StorageNodeBufferRoutingTest.EphemeralPutNeverTouchesEngine`
- [x] `StorageNodeBufferRoutingTest.NonBytesEncodingIsRejected`
- [x] `StorageNodeBufferRoutingTest.DurableQuerySelectorsAndFailures`
- [x] `StorageNodeBufferRoutingTest.EngineFailuresAndExceptionsAreContained`
- [x] `StorageNodeBufferRoutingTest.BufferRoutesDoNotEnterParameterSurfaces`
- [x] `StorageNodeBufferRoutingTest.BufferDeleteAndControlRoutesAreRejected`

The factory test covers every zero-call and one-call case, exact SID forwarding, Result taxonomy,
DEC-56-SETUP-FAILURE-001 setup failures before factory invocation, DEC-140-STOP-STATUS-002 stopped
and captured-State/closed-gate status preservation, shared engine identity across both routed keys,
rollback, and destruction. The
persistence tests cover false and throw, engine-unmodified and partial-outcome cases, same-byte
retry, and conflicting retry. The query-failure tests distinguish zero replies for engine collection
failure before dispatch from contained reply-handler failure after dispatch begins. The lifecycle
test blocks durable PUT, exact Get, and List independently and proves Close cannot return before
operation completion and engine destruction. All concurrency tests use deterministic barriers.

The public API test must assert the legacy member-pointer shape at compile time. Focused lifecycle
and routing tests must run repeatedly under the existing sanitizer lanes.

## Expected files

- `include/sitos/session.hpp`
- `include/sitos/storage_node.hpp`
- `src/storage_node.cpp`
- `src/session_view.cpp` only if required by the merged lifecycle representation
- `tests/unit/storage_node_buffer_api_test.cpp`
- `tests/unit/storage_node_buffer_lifecycle_test.cpp`
- `tests/unit/storage_node_buffer_routing_test.cpp`
- focused parameter-surface tests only where an explicit regression is required
- `tests/consumer/storage_node_header_compile.cpp`
- `tests/CMakeLists.txt`
- `.github/workflows/ci.yml` for sanitizer test-pattern inclusion
- `docs/02_architecture.md` and `docs/04_api_cpp.md` for exact owner taxonomy synchronization,
  owned-query materialization, stopped-node status preservation, and reply-failure boundaries
- `docs/07_issue_breakdown.md` for the narrowed query-failure / reply-handler boundary
- `docs/06_build_test_packaging.md` for sanitizer filter synchronization

Any additional file requires owner approval before implementation.

## Out of scope

- raw Zenoh or process fixtures
- RocksDB-specific lifecycle or physical directory cleanup
- installed-package relocation or combined Zenoh-ON/RocksDB-ON CI
- production publisher/subscriber or Python buffer APIs
- Sync, Fence, ack, tombstones, per-key DELETE, overwrite, restart catalog, or retention
- Issues #105-#108 behavior

## Governance

- [x] Independent pre-implementation review completed.
- [x] Owner declares this exact checklist ready and frozen for implementation.
- [x] Genuine API compile/contract RED evidence captured before production edits; behavioral chronology is covered by DEC-141-TDD-EXCEPTION-001.
- [x] Independent exact-head review completed.
- [x] Separate one-time owner merge authorization recorded.

## Requirement IDs

- C06: mixed durable and ephemeral Session buffer routes and bare-byte admission.
- X01: Session lifecycle ownership and callback/admission safety.
- X03: canonical buffer route consumption.

## TDD RED evidence

Classification: pre-implementation compile/contract RED for the public API and member-pointer assertions.
The substantive behavioral acceptance tests added during this fix are `review-driven regression`
coverage under DEC-141-TDD-EXCEPTION-001. No behavioral pre-implementation RED is claimed.
DEC-141-TDD-EXCEPTION-001 was published by the owner: https://github.com/tetsuh/sitos/issues/141#issuecomment-5156531710.

- Command: `cmake -S . -B /tmp/issue141-build-red -G Ninja -DCMAKE_BUILD_TYPE=Debug -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=OFF && cmake --build /tmp/issue141-build-red --target sitos_storage_node_buffer_api_test -j2`
- Failing tests/contracts: `StorageNodeBufferApiTest.PreservesLegacyCreateSessionOverload` and `StorageNodeBufferApiTest.ExposesCapabilityOverloadAndFactory`.
- Expected reason: `SessionOptions`, `DurableBufferEngineFactory`, and the capability overload were absent before implementation.
- Representative failure: `error: ‘SessionOptions’ was not declared in this scope`.
- Raw evidence: `/tmp/issue141-red-evidence.txt` and `/tmp/issue141-red-build.log`.

## Validation

- Fresh Debug build `/tmp/pr145-r3-build` after R5 edits: passed.
- Fresh full CTest: passed, 338/338 (`/tmp/pr145-r5-ctest-full.log`).
- Fresh exact fixed selection: passed, 16/16 (`/tmp/pr145-r3-build`).
- Fresh ASan/UBSan exact selection: passed, 16/16 (`/tmp/pr145-r3-asan`).
- Fresh TSan build: passed; local CTest discovery is blocked by the environment error
  `ThreadSanitizer: unexpected memory mapping` (`/tmp/pr145-r5-tsan-test.log`).
- Release build with warnings-as-errors and documented consumer compile probe: passed.
- Hosted checks for final head `4aa35d937e1478aa0d8221aa1359a54b1b637088` passed, including Linux/Windows builds and packages, both sanitizer lanes, vcpkg, Python integration, Linux/Windows wheels, transport isolation, CodeQL, SonarCloud, and CodeRabbit; the optional compatibility check was skipped.

## ADR and Contract Registry

- ADR-0032 applies; no new ADR is required.
- Contract Registry transition: none; the buffer row remains `Planned` as required by the frozen scope.

## Exclusions

Raw Zenoh/process fixtures, RocksDB-specific lifecycle/cleanup, installed-package relocation, combined Zenoh/RocksDB CI, late join, production BufferPublisher/BufferSubscriber, Python buffer/factory APIs, Sync/Fence/ack/tombstones/overwrite/restart catalog/retention, Issues #105–#108 behavior, and the final Issue #56 Registry transition remain excluded.

## Merge authorization

Corrected implementation head: `4aa35d937e1478aa0d8221aa1359a54b1b637088`.

Owner authorized a one-time normal merge of exact head `4aa35d937e1478aa0d8221aa1359a54b1b637088`: https://github.com/tetsuh/sitos/pull/145#issuecomment-5156827282. Auto-merge and rebase merge are not authorized.

## Residual risks

The local TSan lane requires an environment with supported address-space mapping; hosted TSan is
required evidence. Exact-head normal-merge authorization is recorded above.


