### PR TITLE
feat(integration): complete mixed buffer integration (#56)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
             -R 'ParamStoreSubscribeTest.(CloseWaitsForBlockedCallback|DeclarationFailureWaitsForAdmittedCallbackCopy)'
           lifecycle_filter="StorageNodeLifecycleTest|StorageNodeSessionTest|"
           lifecycle_filter+="StorageNodeSessionLifecycleTest|StorageNodeBufferLifecycleTest|"
-          lifecycle_filter+="StorageNodeBufferRoutingTest|StorageNodeBufferApiTest|StorageNodeBatchTest|"
+          lifecycle_filter+="StorageNodeBufferRoutingTest|StorageNodeBufferApiTest|BufferLateJoinTest|StorageNodeBatchTest|"
           lifecycle_filter+="TransportGetCompletionTest|ParamStoreSubscribeTest|"
           lifecycle_filter+="ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture"
           ctest --test-dir build/sanitizer-tsan --output-on-failure --timeout 60 \
@@ -163,7 +163,7 @@ jobs:
         run: |
           lifecycle_filter="StorageNodeLifecycleTest|StorageNodeSessionTest|"
           lifecycle_filter+="StorageNodeSessionLifecycleTest|StorageNodeBufferLifecycleTest|"
-          lifecycle_filter+="StorageNodeBufferRoutingTest|StorageNodeBufferApiTest|StorageNodeBatchTest|"
+          lifecycle_filter+="StorageNodeBufferRoutingTest|StorageNodeBufferApiTest|BufferLateJoinTest|StorageNodeBatchTest|"
           lifecycle_filter+="TransportGetCompletionTest|ParamStoreSubscribeTest|"
           lifecycle_filter+="ParamCacheTest|ParamCacheReadTest|SessionViewTest|SessionViewFixture"
           ctest --test-dir build/sanitizer-${{ matrix.name }} \
@@ -253,7 +253,10 @@ jobs:
       - name: Install Linux provisioning prerequisites
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build libssl-dev
+          sudo apt-get install -y cmake ninja-build libssl-dev python3-pip
+
+      - name: Install raw Zenoh interoperability dependencies
+        run: python3 -m pip install --break-system-packages --only-binary=:all: --require-hashes -r tests/interop/requirements.txt
 
       - name: Resolve vcpkg cache outer compatibility boundary
         id: vcpkg-cache-identity
@@ -358,6 +361,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install raw Zenoh interoperability dependencies
+        run: python -m pip install --only-binary=:all: --require-hashes -r tests/interop/requirements.txt
 
       - name: Resolve vcpkg cache outer compatibility boundary
         id: vcpkg-cache-identity

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,9 @@ jobs:
           sudo apt-get install -y cmake ninja-build libssl-dev python3-pip
 
       - name: Install raw Zenoh interoperability dependencies
-        run: python3 -m pip install --break-system-packages --only-binary=:all: --require-hashes -r tests/interop/requirements.txt
+        run: >-
+          python3 -m pip install --break-system-packages --only-binary=:all:
+          --require-hashes -r tests/interop/requirements.txt
 
       - name: Resolve vcpkg cache outer compatibility boundary
         id: vcpkg-cache-identity
@@ -367,7 +369,9 @@ jobs:
           python-version: "3.12"
 
       - name: Install raw Zenoh interoperability dependencies
-        run: python -m pip install --only-binary=:all: --require-hashes -r tests/interop/requirements.txt
+        run: >-
+          python -m pip install --only-binary=:all: --require-hashes
+          -r tests/interop/requirements.txt
 
       - name: Resolve vcpkg cache outer compatibility boundary
         id: vcpkg-cache-identity

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -302,7 +302,11 @@ node-retained ephemeral state.
 - `RocksDBBufferLifecycleTest.SameSidRecreationUsesFreshEngine`
 
 These tests verify C03/C06 raw-client interoperability and the process-isolated durable late-join
-boundary. The final stage also owns combined Zenoh-ON/RocksDB-ON package and CI evidence.
+boundary. The raw tests run against `sitos_raw_zenoh_buffer_fixture`, a process-isolated fixture
+that keeps one Transport and uses bounded command/readiness handshakes. The final stage also owns
+combined Zenoh-ON/RocksDB-ON package and CI evidence, relocated installed consumers without
+executing `RocksDBEngine::Open`, and wheel/installed-artifact guards rejecting both buffer fixture
+executable basenames with and without `.exe`.
 
 ## 5.2 Lifecycle sanitizer runs
 
@@ -317,7 +321,7 @@ cmake -S . -B build/tsan -G Ninja -DCMAKE_BUILD_TYPE=Debug \
 cmake --build build/tsan
 lifecycle_filter="StorageNodeLifecycleTest|StorageNodeSessionTest|"
 lifecycle_filter="${lifecycle_filter}StorageNodeSessionLifecycleTest|StorageNodeBufferLifecycleTest|"
-lifecycle_filter="${lifecycle_filter}StorageNodeBufferRoutingTest|StorageNodeBufferApiTest|StorageNodeBatchTest|"
+lifecycle_filter="${lifecycle_filter}StorageNodeBufferRoutingTest|StorageNodeBufferApiTest|BufferLateJoinTest|StorageNodeBatchTest|"
 lifecycle_filter="${lifecycle_filter}TransportGetCompletionTest|ParamStoreSubscribeTest|"
 lifecycle_filter="${lifecycle_filter}ParamCacheTest|ParamCacheReadTest|"
 lifecycle_filter="${lifecycle_filter}SessionViewTest|SessionViewFixture"

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -354,11 +354,13 @@ raw-Zenoh consumers such as #32 and #56. The accepted ADR-0032 implementation se
   * Combined Windows/Linux Zenoh-ON+RocksDB-ON validation passes while preserving
     Zenoh-ON/RocksDB-OFF and RocksDB-ON/Zenoh-OFF/vcpkg configurations. Buffer payloads remain
     plain `zenoh/bytes`.
-  * Validation classification is explicit: the six late-join/raw behavior cases are
-    pre-implementation behavioral RED; the two RocksDB lifecycle cases and inherited #139-#141
-    checks are review-driven regression; combined package/platform execution is co-developed
-    integration coverage; workflow/docs-only checks are N/A with a recorded reason. No RED history
-    may be fabricated or relabeled.
+  * Validation classification is explicit and follows published `DEC-56-TDD-EXCEPTION-001`: the
+    six attempted late-join/raw RED runs are retained as partial/incorrect factual evidence and do
+    not satisfy the TDD gate; every corrected or newly strengthened assertion for those six cases
+    is review-driven regression. The two RocksDB lifecycle cases and inherited #139-#141 checks are
+    review-driven regression; combined package/platform execution is co-developed integration
+    coverage; workflow/docs-only checks are N/A with a recorded reason. No RED history may be
+    fabricated or relabeled.
 * Depends on: #8, #12, #29, #121, #139, #140, #141
 * F10 applies here as the Session resource-release principle: CloseSession releases the durable
   buffer engine and other owned resources after callback quiescence.

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -354,6 +354,11 @@ raw-Zenoh consumers such as #32 and #56. The accepted ADR-0032 implementation se
   * Combined Windows/Linux Zenoh-ON+RocksDB-ON validation passes while preserving
     Zenoh-ON/RocksDB-OFF and RocksDB-ON/Zenoh-OFF/vcpkg configurations. Buffer payloads remain
     plain `zenoh/bytes`.
+  * Validation classification is explicit: the six late-join/raw behavior cases are
+    pre-implementation behavioral RED; the two RocksDB lifecycle cases and inherited #139-#141
+    checks are review-driven regression; combined package/platform execution is co-developed
+    integration coverage; workflow/docs-only checks are N/A with a recorded reason. No RED history
+    may be fabricated or relabeled.
 * Depends on: #8, #12, #29, #121, #139, #140, #141
 * F10 applies here as the Session resource-release principle: CloseSession releases the durable
   buffer engine and other owned resources after callback quiescence.

--- a/docs/08_contract_registry.md
+++ b/docs/08_contract_registry.md
@@ -56,7 +56,7 @@ open decision (`—` when settled); implementers and consumers are listed separa
 | `AckAttachmentV1` (17-byte acknowledged-operation UUIDv4 attachment) | Normative | Planned | [ADR-0028](adr/0028-unify-acknowledged-operation-results.md) | — | #14, #17; Fence reuse by #106, #107 |
 | Acknowledgement result Encoding (`sitos.v1.ack`, canonical `zenoh/bytes;sitos.v1.ack`) | Normative | Planned | [ADR-0028](adr/0028-unify-acknowledged-operation-results.md) | — | #14, #17; Fence reuse by #106, #107 |
 | Same-publisher in-band fence marker | Planned | Planned | — (pending Accepted #106 ADR; row registered by #115 / PR #116) | #106 → ADR | consumers #99, #107 |
-| `buffers/<sid>/{durable\|ephemeral}/<key>` value scope (plain opaque bytes) | Normative | Planned | [ADR-0032](adr/0032-mixed-session-buffer-routes.md) | — | #56; fences via #107 |
+| `buffers/<sid>/{durable\|ephemeral}/<key>` value scope (plain opaque bytes) | Normative | Implemented | [ADR-0032](adr/0032-mixed-session-buffer-routes.md) | — | #139-#141, #56 integration; fences via #107 |
 
 ## 3. Stable identifiers
 

--- a/docs/08_contract_registry.md
+++ b/docs/08_contract_registry.md
@@ -56,7 +56,7 @@ open decision (`—` when settled); implementers and consumers are listed separa
 | `AckAttachmentV1` (17-byte acknowledged-operation UUIDv4 attachment) | Normative | Planned | [ADR-0028](adr/0028-unify-acknowledged-operation-results.md) | — | #14, #17; Fence reuse by #106, #107 |
 | Acknowledgement result Encoding (`sitos.v1.ack`, canonical `zenoh/bytes;sitos.v1.ack`) | Normative | Planned | [ADR-0028](adr/0028-unify-acknowledged-operation-results.md) | — | #14, #17; Fence reuse by #106, #107 |
 | Same-publisher in-band fence marker | Planned | Planned | — (pending Accepted #106 ADR; row registered by #115 / PR #116) | #106 → ADR | consumers #99, #107 |
-| `buffers/<sid>/{durable\|ephemeral}/<key>` value scope (plain opaque bytes) | Normative | Implemented | [ADR-0032](adr/0032-mixed-session-buffer-routes.md) | — | #139-#141, #56 integration; fences via #107 |
+| `buffers/<sid>/{durable\|ephemeral}/<key>` value scope (plain opaque bytes) | Normative | Planned | [ADR-0032](adr/0032-mixed-session-buffer-routes.md) | — | #56; #139-#141 baseline; fences via #107 |
 
 ## 3. Stable identifiers
 

--- a/docs/08_contract_registry.md
+++ b/docs/08_contract_registry.md
@@ -56,7 +56,7 @@ open decision (`—` when settled); implementers and consumers are listed separa
 | `AckAttachmentV1` (17-byte acknowledged-operation UUIDv4 attachment) | Normative | Planned | [ADR-0028](adr/0028-unify-acknowledged-operation-results.md) | — | #14, #17; Fence reuse by #106, #107 |
 | Acknowledgement result Encoding (`sitos.v1.ack`, canonical `zenoh/bytes;sitos.v1.ack`) | Normative | Planned | [ADR-0028](adr/0028-unify-acknowledged-operation-results.md) | — | #14, #17; Fence reuse by #106, #107 |
 | Same-publisher in-band fence marker | Planned | Planned | — (pending Accepted #106 ADR; row registered by #115 / PR #116) | #106 → ADR | consumers #99, #107 |
-| `buffers/<sid>/{durable\|ephemeral}/<key>` value scope (plain opaque bytes) | Normative | Planned | [ADR-0032](adr/0032-mixed-session-buffer-routes.md) | — | #56; #139-#141 baseline; fences via #107 |
+| `buffers/<sid>/{durable\|ephemeral}/<key>` value scope (plain opaque bytes) | Normative | Implemented | [ADR-0032](adr/0032-mixed-session-buffer-routes.md) | — | #56; fences via #107 |
 
 ## 3. Stable identifiers
 

--- a/docs/09_dependency_policy.md
+++ b/docs/09_dependency_policy.md
@@ -164,6 +164,9 @@ Validation targets:
 * wire fixtures (`PayloadV1GoldenFixtures`, `BatchV1GoldenFixture`)
 * `RawZenohClientCanPutAndGet`
 * `RawZenohClientCanSendBatch`
+* `RawZenohClientCanUseMixedSessionBuffers`
+* `RawZenohDurableLateJoinPreservesDistinctKeys`
+* `RawZenohBufferInteropFixtureBoundaries`
 
 If latest stable fails:
 

--- a/scripts/check_wheel.py
+++ b/scripts/check_wheel.py
@@ -35,6 +35,8 @@ FORBIDDEN_BASENAMES = (
     "sitos_python_param_store_fixture.exe",
     "sitos_raw_zenoh_fixture",
     "sitos_raw_zenoh_fixture.exe",
+    "sitos_raw_zenoh_buffer_fixture",
+    "sitos_raw_zenoh_buffer_fixture.exe",
 )
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -199,6 +199,10 @@ if(SITOS_WITH_ROCKSDB)
   gtest_add_tests(
     TARGET sitos_rocksdb_buffer_lifecycle_test
     SOURCES integration/rocksdb_buffer_lifecycle_test.cpp)
+  set_tests_properties(
+    RocksDBBufferLifecycleTest.CloseReleasesEngineBeforeReturn
+    RocksDBBufferLifecycleTest.SameSidRecreationUsesFreshEngine
+    PROPERTIES TIMEOUT 60)
 endif()
 
 add_executable(sitos_in_memory_engine_test
@@ -270,6 +274,11 @@ sitos_enable_warnings(sitos_buffer_late_join_test)
 gtest_add_tests(
   TARGET sitos_buffer_late_join_test
   SOURCES integration/buffer_late_join_test.cpp)
+set_tests_properties(
+  BufferLateJoinTest.OrdersMaterializedBufferedAndLiveSamples
+  BufferLateJoinTest.DurableLateJoinDoesNotLoseDistinctKeys
+  BufferLateJoinTest.FailureInvokesNoObserverAndCleansUp
+  PROPERTIES TIMEOUT 60)
 
 add_executable(sitos_session_view_test
   unit/session_view_test.cpp)
@@ -304,6 +313,9 @@ if(SITOS_WITH_ZENOH)
   add_executable(sitos_raw_zenoh_buffer_fixture
     interop/raw_zenoh_buffer_fixture.cpp)
   target_link_libraries(sitos_raw_zenoh_buffer_fixture PRIVATE sitos::sitos)
+  if(SITOS_WITH_ROCKSDB)
+    target_compile_definitions(sitos_raw_zenoh_buffer_fixture PRIVATE SITOS_WITH_ROCKSDB=1)
+  endif()
   sitos_enable_warnings(sitos_raw_zenoh_buffer_fixture)
   sitos_copy_zenohc(sitos_raw_zenoh_buffer_fixture)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -189,6 +189,16 @@ if(SITOS_WITH_ROCKSDB)
     ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/src)
   sitos_enable_warnings(sitos_rocksdb_test_access_test)
   gtest_discover_tests(sitos_rocksdb_test_access_test DISCOVERY_MODE PRE_TEST)
+
+  add_executable(sitos_rocksdb_buffer_lifecycle_test
+    integration/rocksdb_buffer_lifecycle_test.cpp)
+  target_link_libraries(sitos_rocksdb_buffer_lifecycle_test
+    PRIVATE GTest::gtest_main sitos::sitos)
+  target_include_directories(sitos_rocksdb_buffer_lifecycle_test PRIVATE ${PROJECT_SOURCE_DIR}/src)
+  sitos_enable_warnings(sitos_rocksdb_buffer_lifecycle_test)
+  gtest_add_tests(
+    TARGET sitos_rocksdb_buffer_lifecycle_test
+    SOURCES integration/rocksdb_buffer_lifecycle_test.cpp)
 endif()
 
 add_executable(sitos_in_memory_engine_test
@@ -251,6 +261,16 @@ target_include_directories(sitos_storage_node_buffer_lifecycle_test PRIVATE ${PR
 sitos_enable_warnings(sitos_storage_node_buffer_lifecycle_test)
 gtest_add_tests(TARGET sitos_storage_node_buffer_lifecycle_test SOURCES unit/storage_node_buffer_lifecycle_test.cpp)
 
+add_executable(sitos_buffer_late_join_test
+  integration/buffer_late_join_test.cpp)
+target_link_libraries(sitos_buffer_late_join_test
+  PRIVATE GTest::gtest_main sitos::sitos)
+target_include_directories(sitos_buffer_late_join_test PRIVATE ${PROJECT_SOURCE_DIR}/src)
+sitos_enable_warnings(sitos_buffer_late_join_test)
+gtest_add_tests(
+  TARGET sitos_buffer_late_join_test
+  SOURCES integration/buffer_late_join_test.cpp)
+
 add_executable(sitos_session_view_test
   unit/session_view_test.cpp)
 target_link_libraries(sitos_session_view_test
@@ -281,6 +301,12 @@ if(SITOS_WITH_ZENOH)
   sitos_enable_warnings(sitos_raw_zenoh_fixture)
   sitos_copy_zenohc(sitos_raw_zenoh_fixture)
 
+  add_executable(sitos_raw_zenoh_buffer_fixture
+    interop/raw_zenoh_buffer_fixture.cpp)
+  target_link_libraries(sitos_raw_zenoh_buffer_fixture PRIVATE sitos::sitos)
+  sitos_enable_warnings(sitos_raw_zenoh_buffer_fixture)
+  sitos_copy_zenohc(sitos_raw_zenoh_buffer_fixture)
+
   find_package(Python3 3.10 REQUIRED COMPONENTS Interpreter)
   add_test(
     NAME RawZenohClientCanPutAndGet
@@ -293,10 +319,34 @@ if(SITOS_WITH_ZENOH)
             "${CMAKE_CURRENT_SOURCE_DIR}/interop/test_raw_zenoh_single.py"
             "${CMAKE_CURRENT_SOURCE_DIR}/interop/test_raw_zenoh_wheel_boundary.py"
             -k "not test_raw_zenoh_client_can_put_and_get")
+  add_test(
+    NAME RawZenohClientCanUseMixedSessionBuffers
+    COMMAND "${Python3_EXECUTABLE}" -m pytest -q
+            "${CMAKE_CURRENT_SOURCE_DIR}/interop/test_raw_zenoh_buffer.py"
+            -k test_raw_zenoh_client_can_use_mixed_session_buffers)
+  add_test(
+    NAME RawZenohDurableLateJoinPreservesDistinctKeys
+    COMMAND "${Python3_EXECUTABLE}" -m pytest -q
+            "${CMAKE_CURRENT_SOURCE_DIR}/interop/test_raw_zenoh_buffer.py"
+            -k test_raw_zenoh_durable_late_join_preserves_distinct_keys)
+  add_test(
+    NAME RawZenohBufferInteropFixtureBoundaries
+    COMMAND "${Python3_EXECUTABLE}" -m pytest -q
+            "${CMAKE_CURRENT_SOURCE_DIR}/interop/test_raw_zenoh_buffer.py"
+            -k test_raw_zenoh_buffer_interop_fixture_boundaries)
   set_tests_properties(
     RawZenohClientCanPutAndGet RawZenohInteropFixtureBoundaries
+    RawZenohClientCanUseMixedSessionBuffers RawZenohDurableLateJoinPreservesDistinctKeys
+    RawZenohBufferInteropFixtureBoundaries
     PROPERTIES
       ENVIRONMENT "SITOS_RAW_ZENOH_FIXTURE=$<TARGET_FILE:sitos_raw_zenoh_fixture>"
+      RUN_SERIAL TRUE
+      TIMEOUT 60)
+  set_tests_properties(
+    RawZenohClientCanUseMixedSessionBuffers RawZenohDurableLateJoinPreservesDistinctKeys
+    RawZenohBufferInteropFixtureBoundaries
+    PROPERTIES
+      ENVIRONMENT "SITOS_RAW_ZENOH_FIXTURE=$<TARGET_FILE:sitos_raw_zenoh_buffer_fixture>"
       RUN_SERIAL TRUE
       TIMEOUT 60)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -276,6 +276,9 @@ gtest_add_tests(
   SOURCES integration/buffer_late_join_test.cpp)
 set_tests_properties(
   BufferLateJoinTest.OrdersMaterializedBufferedAndLiveSamples
+  BufferLateJoinTest.BufferedIdenticalReplyPromotesToMaterializedCategory
+  BufferLateJoinTest.BufferedConflictingReplyFailsBeforeObserverDelivery
+  BufferLateJoinTest.ObservationBoundarySerializesInitialBatchAndLiveSample
   BufferLateJoinTest.DurableLateJoinDoesNotLoseDistinctKeys
   BufferLateJoinTest.FailureInvokesNoObserverAndCleansUp
   PROPERTIES TIMEOUT 60)

--- a/tests/integration/buffer_late_join_test.cpp
+++ b/tests/integration/buffer_late_join_test.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <cstddef>
@@ -242,6 +243,7 @@ class LateJoinCollector final {
     try {
       Dispatch(std::move(batch), observation_lock);
     } catch (...) {
+      observer_failed_.store(true, std::memory_order_release);
       if (observation_lock.owns_lock()) observation_lock.unlock();
       MarkFailed();
       return false;
@@ -359,10 +361,13 @@ class LateJoinCollector final {
       dispatch.push_back(observation);
       if (live_boundary_observer_) live_boundary_observer_();
       observation_lock.lock();
+      if (observer_failed_.load(std::memory_order_acquire)) return;
     }
     try {
       Dispatch(std::move(dispatch), observation_lock);
     } catch (...) {
+      observer_failed_.store(true, std::memory_order_release);
+      if (observation_lock.owns_lock()) observation_lock.unlock();
       MarkFailedPhase();
     }
   }
@@ -406,6 +411,7 @@ class LateJoinCollector final {
   std::string selector_;
   std::function<void(const Observation&)> observer_;
   std::function<void()> live_boundary_observer_;
+  std::atomic<bool> observer_failed_ = false;
   mutable std::mutex collector_mutex_;
   std::mutex observation_mutex_;
   std::optional<sitos::Subscription> subscription_;

--- a/tests/integration/buffer_late_join_test.cpp
+++ b/tests/integration/buffer_late_join_test.cpp
@@ -1,28 +1,35 @@
 // Copyright 2026 sitos contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sitos/in_memory_engine.hpp"
-#include "sitos/storage_node.hpp"
-#include "sitos/transport.hpp"
-
 #include <gtest/gtest.h>
 
 #include <chrono>
-#include <cstddef>
 #include <condition_variable>
+#include <cstddef>
 #include <functional>
+#include <initializer_list>
+#include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
-#include <set>
 #include <string>
 #include <system_error>
 #include <thread>
 #include <utility>
 #include <vector>
 
+#include "sitos/in_memory_engine.hpp"
+#include "sitos/storage_node.hpp"
+#include "sitos/transport.hpp"
 #include "transport/declaration_handle_test_access.hpp"
 
 namespace {
+
+struct Observation {
+  std::string key;
+  std::vector<std::byte> payload;
+  std::string encoding;
+};
 
 class LateJoinTransport final : public sitos::Transport {
  public:
@@ -30,7 +37,15 @@ class LateJoinTransport final : public sitos::Transport {
                           sitos::Encoding encoding, sitos::PutOptions) override {
     sitos::TransportSample sample{std::string(key), payload, std::move(encoding), std::nullopt,
                                   sitos::TransportSample::Kind::Put};
-    for (const auto& subscriber : subscribers_) subscriber(sample);
+    std::vector<std::function<void(const sitos::TransportSample&)>> callbacks;
+    {
+      std::scoped_lock lock(subscriber_mutex_);
+      for (const auto& [id, callback] : subscribers_) {
+        static_cast<void>(id);
+        callbacks.push_back(callback);
+      }
+    }
+    for (const auto& callback : callbacks) callback(sample);
     return sitos::Result<void>::Ok();
   }
 
@@ -40,11 +55,14 @@ class LateJoinTransport final : public sitos::Transport {
 
   sitos::Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
                           std::chrono::milliseconds) override {
-    if (query_failure) {
-      return sitos::Result<void>::Err(std::make_error_code(std::errc::io_error));
-    }
+    if (query_failure) return sitos::Result<void>::Err(std::make_error_code(std::errc::io_error));
+    int reply_count = 0;
     auto query = sitos::TransportQuery::ForTesting(
         [&](std::string_view key, std::span<const std::byte> payload, sitos::Encoding encoding) {
+          ++reply_count;
+          if (fail_after_replies >= 0 && reply_count > fail_after_replies) {
+            return sitos::Result<void>::Err(std::make_error_code(std::errc::broken_pipe));
+          }
           if (sink(key, payload, std::move(encoding))) return sitos::Result<void>::Ok();
           return sitos::Result<void>::Err(std::make_error_code(std::errc::broken_pipe));
         });
@@ -56,14 +74,28 @@ class LateJoinTransport final : public sitos::Transport {
       get_cv.notify_all();
       get_cv.wait(lock, [&] { return !block_get; });
     }
+    if (fail_after_replies >= 0 && reply_count > fail_after_replies) {
+      return sitos::Result<void>::Err(std::make_error_code(std::errc::broken_pipe));
+    }
     return sitos::Result<void>::Ok();
   }
 
   sitos::Result<sitos::Subscription> DeclareSubscriber(
       std::string_view, std::function<void(const sitos::TransportSample&)> callback) override {
-    subscribers_.push_back(std::move(callback));
+    if (declaration_failure) {
+      return sitos::Result<sitos::Subscription>::Err(
+          std::make_error_code(std::errc::permission_denied));
+    }
+    const int id = next_subscriber_id++;
+    {
+      std::scoped_lock lock(subscriber_mutex_);
+      subscribers_.emplace(id, std::move(callback));
+    }
     return sitos::Result<sitos::Subscription>::Ok(
-        sitos::transport_test_access::DeclarationHandleTestAccess::MakeSubscription([] {}));
+        sitos::transport_test_access::DeclarationHandleTestAccess::MakeSubscription([this, id] {
+          std::scoped_lock lock(subscriber_mutex_);
+          subscribers_.erase(id);
+        }));
   }
 
   sitos::Result<sitos::Queryable> DeclareQueryable(
@@ -73,21 +105,11 @@ class LateJoinTransport final : public sitos::Transport {
         sitos::transport_test_access::DeclarationHandleTestAccess::MakeQueryable([] {}));
   }
 
- private:
-  std::vector<std::function<void(const sitos::TransportSample&)>> subscribers_;
-  std::function<void(sitos::TransportQuery&)> queryable_;
-
- public:
-  bool query_failure = false;
-  bool block_get = false;
-  bool get_entered = false;
-  std::mutex get_mutex;
-  std::condition_variable get_cv;
-
   void WaitForGet() {
     std::unique_lock lock(get_mutex);
     get_cv.wait(lock, [&] { return get_entered; });
   }
+
   void ReleaseGet() {
     {
       std::scoped_lock lock(get_mutex);
@@ -95,48 +117,135 @@ class LateJoinTransport final : public sitos::Transport {
     }
     get_cv.notify_all();
   }
+
+  bool query_failure = false;
+  bool declaration_failure = false;
+  int fail_after_replies = -1;
+  bool block_get = false;
+  bool get_entered = false;
+  std::mutex get_mutex;
+  std::condition_variable get_cv;
+
+ private:
+  int next_subscriber_id = 1;
+  std::mutex subscriber_mutex_;
+  std::map<int, std::function<void(const sitos::TransportSample&)>> subscribers_;
+  std::function<void(sitos::TransportQuery&)> queryable_;
 };
 
-class LateJoinCollector {
+class LateJoinCollector final {
  public:
   LateJoinCollector(LateJoinTransport& transport, std::string selector,
-                    std::function<void(std::string)> observer)
+                    std::function<void(const Observation&)> observer)
       : transport_(transport), selector_(std::move(selector)), observer_(std::move(observer)) {}
 
   bool Join() {
-    auto subscription_result = transport_.DeclareSubscriber(
-        selector_, [this](const sitos::TransportSample& sample) {
-          if (transitioned_) {
-            observer_(sample.key);
-          } else {
-            buffered_.push_back(sample.key);
-          }
-        });
-    if (!subscription_result.IsOk()) return false;
-    subscription_ = std::move(subscription_result).Value();
+    auto declaration = transport_.DeclareSubscriber(
+        selector_, [this](const sitos::TransportSample& sample) { OnSample(sample); });
+    if (!declaration.IsOk()) {
+      std::scoped_lock lock(collector_mutex_);
+      phase_ = Phase::Failed;
+      return false;
+    }
+    {
+      std::scoped_lock lock(collector_mutex_);
+      subscription_ = std::move(declaration).Value();
+    }
 
-    std::vector<std::string> materialized;
     const auto result = transport_.Get(
-        selector_, [&](std::string_view key, std::span<const std::byte>, sitos::Encoding) {
-          materialized.emplace_back(key);
-          return true;
+        selector_,
+        [this](std::string_view key, std::span<const std::byte> payload, sitos::Encoding encoding) {
+          Observation observation{
+              std::string(key), {payload.begin(), payload.end()}, std::move(encoding.id)};
+          std::scoped_lock lock(collector_mutex_);
+          return AddObservation(observation);
         },
         std::chrono::seconds(1));
-    if (!result.IsOk()) return false;
-    for (const auto& key : materialized) observer_(key);
-    transitioned_ = true;
-    for (const auto& key : buffered_) observer_(key);
-    buffered_.clear();
+    std::vector<Observation> batch;
+    {
+      std::unique_lock lock(collector_mutex_);
+      if (!result.IsOk() || phase_ == Phase::Failed) {
+        phase_ = Phase::Failed;
+        subscription_.reset();
+        pending_.clear();
+        return false;
+      }
+      observation_mutex_.lock();
+      phase_ = Phase::Live;
+      batch = std::move(pending_);
+      pending_.clear();
+    }
+    DispatchAndUnlock(std::move(batch));
     return true;
   }
 
+  bool Failed() const {
+    std::scoped_lock lock(collector_mutex_);
+    return phase_ == Phase::Failed;
+  }
+
+  ~LateJoinCollector() {
+    std::scoped_lock lock(collector_mutex_);
+    phase_ = Phase::Failed;
+    subscription_.reset();
+    pending_.clear();
+  }
+
  private:
+  enum class Phase { Collecting, Live, Failed };
+
+  static bool Same(const Observation& lhs, const Observation& rhs) {
+    return lhs.key == rhs.key && lhs.payload == rhs.payload && lhs.encoding == rhs.encoding;
+  }
+
+  bool AddObservation(const Observation& observation) {
+    auto it = seen_.find(observation.key);
+    if (it != seen_.end()) return Same(it->second, observation);
+    seen_.emplace(observation.key, observation);
+    pending_.push_back(observation);
+    return true;
+  }
+
+  void OnSample(const sitos::TransportSample& sample) {
+    Observation observation{
+        sample.key, {sample.payload.begin(), sample.payload.end()}, sample.encoding.id};
+    std::vector<Observation> dispatch;
+    {
+      std::unique_lock lock(collector_mutex_);
+      if (phase_ == Phase::Failed) return;
+      if (phase_ == Phase::Collecting) {
+        if (!AddObservation(observation)) phase_ = Phase::Failed;
+        return;
+      }
+      if (const auto it = seen_.find(observation.key); it != seen_.end()) {
+        if (!Same(it->second, observation)) phase_ = Phase::Failed;
+        return;
+      }
+      if (!AddObservation(observation)) {
+        phase_ = Phase::Failed;
+        return;
+      }
+      dispatch.push_back(observation);
+      observation_mutex_.lock();
+    }
+    for (const auto& item : dispatch) observer_(item);
+    observation_mutex_.unlock();
+  }
+
+  void DispatchAndUnlock(std::vector<Observation> batch) {
+    for (const auto& observation : batch) observer_(observation);
+    observation_mutex_.unlock();
+  }
+
   LateJoinTransport& transport_;
   std::string selector_;
-  std::function<void(std::string)> observer_;
+  std::function<void(const Observation&)> observer_;
+  mutable std::mutex collector_mutex_;
+  std::mutex observation_mutex_;
   std::optional<sitos::Subscription> subscription_;
-  std::vector<std::string> buffered_;
-  bool transitioned_ = false;
+  std::map<std::string, Observation> seen_;
+  std::vector<Observation> pending_;
+  Phase phase_ = Phase::Collecting;
 };
 
 struct LateJoinFixture {
@@ -146,8 +255,7 @@ struct LateJoinFixture {
 
   void Start() {
     ASSERT_TRUE(node.Start(
-        engine, {.prefix = "sitos",
-                 .durable_buffer_engine_factory = [](std::string_view) {
+        engine, {.prefix = "sitos", .durable_buffer_engine_factory = [](std::string_view) {
                    return sitos::Result<std::unique_ptr<sitos::StorageEngine>>::Ok(
                        std::make_unique<sitos::InMemoryEngine>());
                  }}));
@@ -155,85 +263,111 @@ struct LateJoinFixture {
   }
 };
 
+std::vector<std::byte> Bytes(std::initializer_list<unsigned char> values) {
+  std::vector<std::byte> result;
+  for (const auto value : values) result.push_back(std::byte{value});
+  return result;
+}
+
 TEST(BufferLateJoinTest, OrdersMaterializedBufferedAndLiveSamples) {
   LateJoinFixture fixture;
   fixture.Start();
-  const std::vector<std::byte> first{std::byte{1}};
-  const std::vector<std::byte> second{std::byte{2}};
-  ASSERT_TRUE(fixture.transport.Put("sitos/buffers/session/durable/first", first,
-                                    {"zenoh/bytes"}, {})
-                  .IsOk());
-  ASSERT_TRUE(fixture.transport.Put("sitos/buffers/session/durable/second", second,
-                                    {"zenoh/bytes"}, {})
-                  .IsOk());
+  ASSERT_TRUE(
+      fixture.transport.Put("sitos/buffers/session/durable/first", Bytes({1}), {"zenoh/bytes"}, {})
+          .IsOk());
+  ASSERT_TRUE(
+      fixture.transport.Put("sitos/buffers/session/durable/second", Bytes({2}), {"zenoh/bytes"}, {})
+          .IsOk());
 
-  std::vector<std::string> observed;
-  LateJoinCollector collector(fixture.transport, "sitos/buffers/session/durable/**",
-                               [&](std::string key) { observed.push_back(std::move(key)); });
+  std::vector<Observation> observed;
+  LateJoinCollector collector(
+      fixture.transport, "sitos/buffers/session/durable/**",
+      [&](const Observation& observation) { observed.push_back(observation); });
   fixture.transport.block_get = true;
   std::optional<bool> joined;
   std::thread join([&] { joined = collector.Join(); });
   fixture.transport.WaitForGet();
-  const std::vector<std::byte> buffered{std::byte{3}};
-  ASSERT_TRUE(fixture.transport.Put("sitos/buffers/session/durable/buffered", buffered,
-                                    {"zenoh/bytes"}, {})
+  ASSERT_TRUE(fixture.transport
+                  .Put("sitos/buffers/session/durable/buffered", Bytes({3}), {"zenoh/bytes"}, {})
                   .IsOk());
   fixture.transport.ReleaseGet();
   join.join();
   ASSERT_TRUE(joined.has_value());
   ASSERT_TRUE(*joined);
-  const std::vector<std::byte> live{std::byte{4}};
-  ASSERT_TRUE(fixture.transport.Put("sitos/buffers/session/durable/live", live,
-                                    {"zenoh/bytes"}, {})
-                  .IsOk());
+  ASSERT_TRUE(
+      fixture.transport.Put("sitos/buffers/session/durable/live", Bytes({4}), {"zenoh/bytes"}, {})
+          .IsOk());
 
   ASSERT_EQ(observed.size(), 4u);
-  EXPECT_EQ(observed[0], "sitos/buffers/session/durable/first");
-  EXPECT_EQ(observed[1], "sitos/buffers/session/durable/second");
-  EXPECT_EQ(observed[2], "sitos/buffers/session/durable/buffered");
-  EXPECT_EQ(observed[3], "sitos/buffers/session/durable/live");
+  EXPECT_EQ(observed[0].key, "sitos/buffers/session/durable/first");
+  EXPECT_EQ(observed[1].key, "sitos/buffers/session/durable/second");
+  EXPECT_EQ(observed[2].key, "sitos/buffers/session/durable/buffered");
+  EXPECT_EQ(observed[3].key, "sitos/buffers/session/durable/live");
+  EXPECT_EQ(observed[2].payload, Bytes({3}));
+  EXPECT_EQ(observed[3].payload, Bytes({4}));
 }
 
 TEST(BufferLateJoinTest, DurableLateJoinDoesNotLoseDistinctKeys) {
   LateJoinFixture fixture;
   fixture.Start();
   for (const auto key : {"a", "b", "c"}) {
-    const std::vector<std::byte> value{std::byte{1}};
-    ASSERT_TRUE(fixture.transport.Put(
-                         "sitos/buffers/session/durable/" + std::string(key), value,
+    ASSERT_TRUE(fixture.transport
+                    .Put("sitos/buffers/session/durable/" + std::string(key), Bytes({1}),
                          {"zenoh/bytes"}, {})
                     .IsOk());
   }
 
-  std::vector<std::string> observed;
-  LateJoinCollector collector(fixture.transport, "sitos/buffers/session/durable/**",
-                               [&](std::string key) { observed.push_back(std::move(key)); });
+  std::vector<Observation> observed;
+  LateJoinCollector collector(
+      fixture.transport, "sitos/buffers/session/durable/**",
+      [&](const Observation& observation) { observed.push_back(observation); });
   ASSERT_TRUE(collector.Join());
+  ASSERT_TRUE(
+      fixture.transport.Put("sitos/buffers/session/durable/a", Bytes({1}), {"zenoh/bytes"}, {})
+          .IsOk());
+  ASSERT_TRUE(
+      fixture.transport.Put("sitos/buffers/session/durable/b", Bytes({2}), {"zenoh/bytes"}, {})
+          .IsOk());
+  EXPECT_TRUE(collector.Failed());
   ASSERT_EQ(observed.size(), 3u);
-  EXPECT_EQ(std::set<std::string>(observed.begin(), observed.end()),
-            (std::set<std::string>{"sitos/buffers/session/durable/a",
-                                   "sitos/buffers/session/durable/b",
-                                   "sitos/buffers/session/durable/c"}));
+  EXPECT_EQ(observed[0].payload, Bytes({1}));
+  EXPECT_EQ(observed[1].payload, Bytes({1}));
+  EXPECT_EQ(observed[2].payload, Bytes({1}));
 }
 
 TEST(BufferLateJoinTest, FailureInvokesNoObserverAndCleansUp) {
   LateJoinFixture fixture;
   fixture.Start();
-  const std::vector<std::byte> failing{std::byte{9}};
-  ASSERT_TRUE(fixture.transport.Put("sitos/buffers/session/durable/failing", failing,
-                                    {"zenoh/bytes"}, {})
-                  .IsOk());
-  std::vector<std::string> observed;
-  fixture.transport.query_failure = true;
-  LateJoinCollector collector(fixture.transport, "sitos/buffers/session/durable/**",
-                               [&](std::string key) { observed.push_back(std::move(key)); });
-  EXPECT_FALSE(collector.Join());
-  EXPECT_TRUE(observed.empty());
-  EXPECT_TRUE(fixture.node.CloseSession("session").IsOk());
-  const std::vector<std::byte> after_close{std::byte{1}};
-  EXPECT_TRUE(fixture.transport.Put("sitos/buffers/session/durable/after-close", after_close,
-                                     {"zenoh/bytes"}, {})
-                  .IsOk());
+  ASSERT_TRUE(
+      fixture.transport.Put("sitos/buffers/session/durable/a", Bytes({1}), {"zenoh/bytes"}, {})
+          .IsOk());
+  ASSERT_TRUE(
+      fixture.transport.Put("sitos/buffers/session/durable/b", Bytes({2}), {"zenoh/bytes"}, {})
+          .IsOk());
+
+  std::vector<Observation> observed;
+  fixture.transport.declaration_failure = true;
+  {
+    LateJoinCollector collector(
+        fixture.transport, "sitos/buffers/session/durable/**",
+        [&](const Observation& observation) { observed.push_back(observation); });
+    EXPECT_FALSE(collector.Join());
+    EXPECT_TRUE(collector.Failed());
+  }
+  fixture.transport.declaration_failure = false;
+  fixture.transport.fail_after_replies = 1;
+  {
+    LateJoinCollector collector(
+        fixture.transport, "sitos/buffers/session/durable/**",
+        [&](const Observation& observation) { observed.push_back(observation); });
+    EXPECT_FALSE(collector.Join());
+    EXPECT_TRUE(collector.Failed());
+  }
+  fixture.transport.fail_after_replies = -1;
+  ASSERT_TRUE(
+      fixture.transport
+          .Put("sitos/buffers/session/durable/after-destroy", Bytes({9}), {"zenoh/bytes"}, {})
+          .IsOk());
   EXPECT_TRUE(observed.empty());
 }
 

--- a/tests/integration/buffer_late_join_test.cpp
+++ b/tests/integration/buffer_late_join_test.cpp
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <condition_variable>
 #include <cstddef>
@@ -45,6 +46,14 @@ class LateJoinTransport final : public sitos::Transport {
         callbacks.push_back(callback);
       }
     }
+    {
+      std::unique_lock lock(copied_callback_mutex);
+      if (park_copied_callbacks) {
+        copied_callbacks_entered = true;
+        copied_callback_cv.notify_all();
+        copied_callback_cv.wait(lock, [&] { return !park_copied_callbacks; });
+      }
+    }
     for (const auto& callback : callbacks) callback(sample);
     return sitos::Result<void>::Ok();
   }
@@ -63,16 +72,28 @@ class LateJoinTransport final : public sitos::Transport {
           if (fail_after_replies >= 0 && reply_count > fail_after_replies) {
             return sitos::Result<void>::Err(std::make_error_code(std::errc::broken_pipe));
           }
-          if (sink(key, payload, std::move(encoding))) return sitos::Result<void>::Ok();
-          return sitos::Result<void>::Err(std::make_error_code(std::errc::broken_pipe));
+          if (!sink(key, payload, std::move(encoding))) {
+            return sitos::Result<void>::Err(std::make_error_code(std::errc::broken_pipe));
+          }
+          if (reply_count == 1) {
+            std::unique_lock lock(reply_mutex);
+            if (block_after_first_reply) {
+              first_reply_entered = true;
+              reply_cv.notify_all();
+              reply_cv.wait(lock, [&] { return !block_after_first_reply; });
+            }
+          }
+          return sitos::Result<void>::Ok();
         });
     query.keyexpr = std::string(keyexpr);
     if (queryable_) queryable_(query);
-    if (block_get) {
+    {
       std::unique_lock lock(get_mutex);
-      get_entered = true;
-      get_cv.notify_all();
-      get_cv.wait(lock, [&] { return !block_get; });
+      if (block_get) {
+        get_entered = true;
+        get_cv.notify_all();
+        get_cv.wait(lock, [&] { return !block_get; });
+      }
     }
     if (fail_after_replies >= 0 && reply_count > fail_after_replies) {
       return sitos::Result<void>::Err(std::make_error_code(std::errc::broken_pipe));
@@ -86,9 +107,10 @@ class LateJoinTransport final : public sitos::Transport {
       return sitos::Result<sitos::Subscription>::Err(
           std::make_error_code(std::errc::permission_denied));
     }
-    const int id = next_subscriber_id++;
+    int id = 0;
     {
       std::scoped_lock lock(subscriber_mutex_);
+      id = next_subscriber_id++;
       subscribers_.emplace(id, std::move(callback));
     }
     return sitos::Result<sitos::Subscription>::Ok(
@@ -118,13 +140,47 @@ class LateJoinTransport final : public sitos::Transport {
     get_cv.notify_all();
   }
 
+  void WaitForFirstReply() {
+    std::unique_lock lock(reply_mutex);
+    reply_cv.wait(lock, [&] { return first_reply_entered; });
+  }
+
+  void ReleaseFirstReply() {
+    {
+      std::scoped_lock lock(reply_mutex);
+      block_after_first_reply = false;
+    }
+    reply_cv.notify_all();
+  }
+
+  void WaitForCopiedCallbacks() {
+    std::unique_lock lock(copied_callback_mutex);
+    copied_callback_cv.wait(lock, [&] { return copied_callbacks_entered; });
+  }
+
+  void ReleaseCopiedCallbacks() {
+    {
+      std::scoped_lock lock(copied_callback_mutex);
+      park_copied_callbacks = false;
+    }
+    copied_callback_cv.notify_all();
+  }
+
   bool query_failure = false;
   bool declaration_failure = false;
   int fail_after_replies = -1;
   bool block_get = false;
   bool get_entered = false;
+  bool block_after_first_reply = false;
+  bool first_reply_entered = false;
+  bool park_copied_callbacks = false;
+  bool copied_callbacks_entered = false;
   std::mutex get_mutex;
   std::condition_variable get_cv;
+  std::mutex reply_mutex;
+  std::condition_variable reply_cv;
+  std::mutex copied_callback_mutex;
+  std::condition_variable copied_callback_cv;
 
  private:
   int next_subscriber_id = 1;
@@ -140,42 +196,49 @@ class LateJoinCollector final {
       : transport_(transport), selector_(std::move(selector)), observer_(std::move(observer)) {}
 
   bool Join() {
+    auto callback_state = std::make_shared<CallbackState>();
+    callback_state->handler = [this](const sitos::TransportSample& sample) { OnSample(sample); };
     auto declaration = transport_.DeclareSubscriber(
-        selector_, [this](const sitos::TransportSample& sample) { OnSample(sample); });
+        selector_,
+        [callback_state](const sitos::TransportSample& sample) { callback_state->Invoke(sample); });
     if (!declaration.IsOk()) {
-      std::scoped_lock lock(collector_mutex_);
-      phase_ = Phase::Failed;
+      MarkFailed();
       return false;
     }
     {
       std::scoped_lock lock(collector_mutex_);
+      callback_state_ = callback_state;
       subscription_ = std::move(declaration).Value();
     }
 
     const auto result = transport_.Get(
         selector_,
         [this](std::string_view key, std::span<const std::byte> payload, sitos::Encoding encoding) {
+          std::scoped_lock lock(collector_mutex_);
           Observation observation{
               std::string(key), {payload.begin(), payload.end()}, std::move(encoding.id)};
-          std::scoped_lock lock(collector_mutex_);
-          return AddObservation(observation);
+          return AddMaterialized(observation);
         },
         std::chrono::seconds(1));
+
     std::vector<Observation> batch;
+    std::unique_lock observation_lock(observation_mutex_, std::defer_lock);
     {
       std::unique_lock lock(collector_mutex_);
       if (!result.IsOk() || phase_ == Phase::Failed) {
-        phase_ = Phase::Failed;
-        subscription_.reset();
-        pending_.clear();
+        lock.unlock();
+        MarkFailed();
         return false;
       }
-      observation_mutex_.lock();
+      observation_lock.lock();
       phase_ = Phase::Live;
-      batch = std::move(pending_);
-      pending_.clear();
+      batch = std::move(materialized_);
+      batch.insert(batch.end(), std::make_move_iterator(buffered_.begin()),
+                   std::make_move_iterator(buffered_.end()));
+      materialized_.clear();
+      buffered_.clear();
     }
-    DispatchAndUnlock(std::move(batch));
+    Dispatch(std::move(batch), observation_lock);
     return true;
   }
 
@@ -184,57 +247,137 @@ class LateJoinCollector final {
     return phase_ == Phase::Failed;
   }
 
-  ~LateJoinCollector() {
-    std::scoped_lock lock(collector_mutex_);
-    phase_ = Phase::Failed;
-    subscription_.reset();
-    pending_.clear();
-  }
+  ~LateJoinCollector() { MarkFailed(); }
 
  private:
   enum class Phase { Collecting, Live, Failed };
+  enum class Source { Materialized, Buffered, Live };
+
+  struct Seen {
+    Observation observation;
+    Source source;
+  };
+
+  struct CallbackState {
+    std::mutex mutex;
+    std::condition_variable condition;
+    bool active = true;
+    size_t in_flight = 0;
+    std::function<void(const sitos::TransportSample&)> handler;
+
+    void Invoke(const sitos::TransportSample& sample) {
+      {
+        std::scoped_lock lock(mutex);
+        if (!active) return;
+        ++in_flight;
+      }
+      struct Admission {
+        CallbackState& state;
+        ~Admission() {
+          std::scoped_lock lock(state.mutex);
+          --state.in_flight;
+          if (state.in_flight == 0) state.condition.notify_all();
+        }
+      } admission{*this};
+      handler(sample);
+    }
+
+    void DeactivateAndDrain() {
+      std::unique_lock lock(mutex);
+      active = false;
+      condition.wait(lock, [&] { return in_flight == 0; });
+      handler = {};
+    }
+  };
 
   static bool Same(const Observation& lhs, const Observation& rhs) {
     return lhs.key == rhs.key && lhs.payload == rhs.payload && lhs.encoding == rhs.encoding;
   }
 
-  bool AddObservation(const Observation& observation) {
-    auto it = seen_.find(observation.key);
-    if (it != seen_.end()) return Same(it->second, observation);
-    seen_.emplace(observation.key, observation);
-    pending_.push_back(observation);
+  bool AddMaterialized(const Observation& observation) {
+    const auto it = seen_.find(observation.key);
+    if (it == seen_.end()) {
+      seen_.emplace(observation.key, Seen{observation, Source::Materialized});
+      materialized_.push_back(observation);
+      return true;
+    }
+    if (!Same(it->second.observation, observation)) {
+      phase_ = Phase::Failed;
+      return false;
+    }
+    if (it->second.source == Source::Buffered) {
+      const auto buffered =
+          std::find_if(buffered_.begin(), buffered_.end(),
+                       [&](const Observation& item) { return item.key == observation.key; });
+      if (buffered != buffered_.end()) buffered_.erase(buffered);
+      it->second.source = Source::Materialized;
+      materialized_.push_back(observation);
+    }
+    return true;
+  }
+
+  bool AddBuffered(const Observation& observation) {
+    const auto it = seen_.find(observation.key);
+    if (it != seen_.end()) {
+      if (!Same(it->second.observation, observation)) phase_ = Phase::Failed;
+      return Same(it->second.observation, observation);
+    }
+    seen_.emplace(observation.key, Seen{observation, Source::Buffered});
+    buffered_.push_back(observation);
     return true;
   }
 
   void OnSample(const sitos::TransportSample& sample) {
-    Observation observation{
-        sample.key, {sample.payload.begin(), sample.payload.end()}, sample.encoding.id};
     std::vector<Observation> dispatch;
+    std::unique_lock observation_lock(observation_mutex_, std::defer_lock);
     {
       std::unique_lock lock(collector_mutex_);
+      Observation observation{
+          sample.key, {sample.payload.begin(), sample.payload.end()}, sample.encoding.id};
       if (phase_ == Phase::Failed) return;
       if (phase_ == Phase::Collecting) {
-        if (!AddObservation(observation)) phase_ = Phase::Failed;
+        AddBuffered(observation);
         return;
       }
       if (const auto it = seen_.find(observation.key); it != seen_.end()) {
-        if (!Same(it->second, observation)) phase_ = Phase::Failed;
+        if (!Same(it->second.observation, observation)) phase_ = Phase::Failed;
         return;
       }
-      if (!AddObservation(observation)) {
-        phase_ = Phase::Failed;
-        return;
-      }
+      AddLive(observation);
       dispatch.push_back(observation);
-      observation_mutex_.lock();
+      observation_lock.lock();
     }
-    for (const auto& item : dispatch) observer_(item);
-    observation_mutex_.unlock();
+    Dispatch(std::move(dispatch), observation_lock);
   }
 
-  void DispatchAndUnlock(std::vector<Observation> batch) {
+  bool AddLive(const Observation& observation) {
+    const auto it = seen_.find(observation.key);
+    if (it != seen_.end()) {
+      if (!Same(it->second.observation, observation)) phase_ = Phase::Failed;
+      return Same(it->second.observation, observation);
+    }
+    seen_.emplace(observation.key, Seen{observation, Source::Live});
+    return true;
+  }
+
+  void Dispatch(std::vector<Observation> batch, std::unique_lock<std::mutex>& observation_lock) {
     for (const auto& observation : batch) observer_(observation);
-    observation_mutex_.unlock();
+    observation_lock.unlock();
+  }
+
+  void MarkFailed() {
+    std::optional<sitos::Subscription> subscription;
+    std::shared_ptr<CallbackState> callback_state;
+    {
+      std::scoped_lock lock(collector_mutex_);
+      phase_ = Phase::Failed;
+      subscription = std::move(subscription_);
+      callback_state = std::move(callback_state_);
+      materialized_.clear();
+      buffered_.clear();
+    }
+    subscription.reset();
+    if (callback_state) callback_state->DeactivateAndDrain();
   }
 
   LateJoinTransport& transport_;
@@ -243,8 +386,10 @@ class LateJoinCollector final {
   mutable std::mutex collector_mutex_;
   std::mutex observation_mutex_;
   std::optional<sitos::Subscription> subscription_;
-  std::map<std::string, Observation> seen_;
-  std::vector<Observation> pending_;
+  std::shared_ptr<CallbackState> callback_state_;
+  std::map<std::string, Seen> seen_;
+  std::vector<Observation> materialized_;
+  std::vector<Observation> buffered_;
   Phase phase_ = Phase::Collecting;
 };
 
@@ -283,15 +428,15 @@ TEST(BufferLateJoinTest, OrdersMaterializedBufferedAndLiveSamples) {
   LateJoinCollector collector(
       fixture.transport, "sitos/buffers/session/durable/**",
       [&](const Observation& observation) { observed.push_back(observation); });
-  fixture.transport.block_get = true;
+  fixture.transport.block_after_first_reply = true;
   std::optional<bool> joined;
   std::thread join([&] { joined = collector.Join(); });
-  fixture.transport.WaitForGet();
-  ASSERT_TRUE(fixture.transport
-                  .Put("sitos/buffers/session/durable/buffered", Bytes({3}), {"zenoh/bytes"}, {})
-                  .IsOk());
-  fixture.transport.ReleaseGet();
+  fixture.transport.WaitForFirstReply();
+  const auto buffered_result = fixture.transport.Put("sitos/buffers/session/durable/buffered",
+                                                     Bytes({3}), {"zenoh/bytes"}, {});
+  fixture.transport.ReleaseFirstReply();
   join.join();
+  ASSERT_TRUE(buffered_result.IsOk());
   ASSERT_TRUE(joined.has_value());
   ASSERT_TRUE(*joined);
   ASSERT_TRUE(
@@ -310,11 +455,12 @@ TEST(BufferLateJoinTest, OrdersMaterializedBufferedAndLiveSamples) {
 TEST(BufferLateJoinTest, DurableLateJoinDoesNotLoseDistinctKeys) {
   LateJoinFixture fixture;
   fixture.Start();
-  for (const auto key : {"a", "b", "c"}) {
-    ASSERT_TRUE(fixture.transport
-                    .Put("sitos/buffers/session/durable/" + std::string(key), Bytes({1}),
-                         {"zenoh/bytes"}, {})
-                    .IsOk());
+  const std::map<std::string, std::vector<std::byte>> expected{
+      {"sitos/buffers/session/durable/a", Bytes({1})},
+      {"sitos/buffers/session/durable/b", Bytes({2})},
+      {"sitos/buffers/session/durable/c", Bytes({3})}};
+  for (const auto& [key, payload] : expected) {
+    ASSERT_TRUE(fixture.transport.Put(key, payload, {"zenoh/bytes"}, {}).IsOk());
   }
 
   std::vector<Observation> observed;
@@ -322,17 +468,28 @@ TEST(BufferLateJoinTest, DurableLateJoinDoesNotLoseDistinctKeys) {
       fixture.transport, "sitos/buffers/session/durable/**",
       [&](const Observation& observation) { observed.push_back(observation); });
   ASSERT_TRUE(collector.Join());
-  ASSERT_TRUE(
-      fixture.transport.Put("sitos/buffers/session/durable/a", Bytes({1}), {"zenoh/bytes"}, {})
-          .IsOk());
-  ASSERT_TRUE(
-      fixture.transport.Put("sitos/buffers/session/durable/b", Bytes({2}), {"zenoh/bytes"}, {})
-          .IsOk());
+  ASSERT_EQ(observed.size(), expected.size());
+  std::map<std::string, Observation> actual;
+  for (const auto& observation : observed) {
+    ASSERT_TRUE(actual.emplace(observation.key, observation).second);
+  }
+  ASSERT_EQ(actual.size(), expected.size());
+  for (const auto& [key, payload] : expected) {
+    ASSERT_EQ(actual.at(key).payload, payload);
+    EXPECT_EQ(actual.at(key).encoding, "zenoh/bytes");
+  }
+
+  const auto duplicate =
+      fixture.transport.Put("sitos/buffers/session/durable/a", Bytes({1}), {"zenoh/bytes"}, {});
+  EXPECT_TRUE(duplicate.IsOk());
+  EXPECT_FALSE(collector.Failed());
+  EXPECT_EQ(observed.size(), expected.size());
+
+  const auto conflict =
+      fixture.transport.Put("sitos/buffers/session/durable/b", Bytes({9}), {"zenoh/bytes"}, {});
+  EXPECT_TRUE(conflict.IsOk());
   EXPECT_TRUE(collector.Failed());
-  ASSERT_EQ(observed.size(), 3u);
-  EXPECT_EQ(observed[0].payload, Bytes({1}));
-  EXPECT_EQ(observed[1].payload, Bytes({1}));
-  EXPECT_EQ(observed[2].payload, Bytes({1}));
+  EXPECT_EQ(observed.size(), expected.size());
 }
 
 TEST(BufferLateJoinTest, FailureInvokesNoObserverAndCleansUp) {
@@ -355,6 +512,15 @@ TEST(BufferLateJoinTest, FailureInvokesNoObserverAndCleansUp) {
     EXPECT_TRUE(collector.Failed());
   }
   fixture.transport.declaration_failure = false;
+  fixture.transport.query_failure = true;
+  {
+    LateJoinCollector collector(
+        fixture.transport, "sitos/buffers/session/durable/**",
+        [&](const Observation& observation) { observed.push_back(observation); });
+    EXPECT_FALSE(collector.Join());
+    EXPECT_TRUE(collector.Failed());
+  }
+  fixture.transport.query_failure = false;
   fixture.transport.fail_after_replies = 1;
   {
     LateJoinCollector collector(
@@ -364,10 +530,28 @@ TEST(BufferLateJoinTest, FailureInvokesNoObserverAndCleansUp) {
     EXPECT_TRUE(collector.Failed());
   }
   fixture.transport.fail_after_replies = -1;
-  ASSERT_TRUE(
-      fixture.transport
-          .Put("sitos/buffers/session/durable/after-destroy", Bytes({9}), {"zenoh/bytes"}, {})
-          .IsOk());
+
+  fixture.transport.park_copied_callbacks = true;
+  std::thread publish;
+  {
+    LateJoinCollector collector(
+        fixture.transport, "sitos/buffers/session/durable/**",
+        [&](const Observation& observation) { observed.push_back(observation); });
+    ASSERT_TRUE(collector.Join());
+    observed.clear();
+    publish = std::thread([&] {
+      static_cast<void>(fixture.transport.Put("sitos/buffers/session/durable/copied", Bytes({8}),
+                                              {"zenoh/bytes"}, {}));
+    });
+    fixture.transport.WaitForCopiedCallbacks();
+  }
+  fixture.transport.ReleaseCopiedCallbacks();
+  publish.join();
+  EXPECT_TRUE(observed.empty());
+
+  const auto after_destroy = fixture.transport.Put("sitos/buffers/session/durable/after-destroy",
+                                                   Bytes({9}), {"zenoh/bytes"}, {});
+  EXPECT_TRUE(after_destroy.IsOk());
   EXPECT_TRUE(observed.empty());
 }
 

--- a/tests/integration/buffer_late_join_test.cpp
+++ b/tests/integration/buffer_late_join_test.cpp
@@ -1,0 +1,240 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/in_memory_engine.hpp"
+#include "sitos/storage_node.hpp"
+#include "sitos/transport.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <condition_variable>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <system_error>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "transport/declaration_handle_test_access.hpp"
+
+namespace {
+
+class LateJoinTransport final : public sitos::Transport {
+ public:
+  sitos::Result<void> Put(std::string_view key, std::span<const std::byte> payload,
+                          sitos::Encoding encoding, sitos::PutOptions) override {
+    sitos::TransportSample sample{std::string(key), payload, std::move(encoding), std::nullopt,
+                                  sitos::TransportSample::Kind::Put};
+    for (const auto& subscriber : subscribers_) subscriber(sample);
+    return sitos::Result<void>::Ok();
+  }
+
+  sitos::Result<void> Delete(std::string_view, sitos::PutOptions) override {
+    return sitos::Result<void>::Ok();
+  }
+
+  sitos::Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
+                          std::chrono::milliseconds) override {
+    if (query_failure) {
+      return sitos::Result<void>::Err(std::make_error_code(std::errc::io_error));
+    }
+    auto query = sitos::TransportQuery::ForTesting(
+        [&](std::string_view key, std::span<const std::byte> payload, sitos::Encoding encoding) {
+          if (sink(key, payload, std::move(encoding))) return sitos::Result<void>::Ok();
+          return sitos::Result<void>::Err(std::make_error_code(std::errc::broken_pipe));
+        });
+    query.keyexpr = std::string(keyexpr);
+    if (queryable_) queryable_(query);
+    if (block_get) {
+      std::unique_lock lock(get_mutex);
+      get_entered = true;
+      get_cv.notify_all();
+      get_cv.wait(lock, [&] { return !block_get; });
+    }
+    return sitos::Result<void>::Ok();
+  }
+
+  sitos::Result<sitos::Subscription> DeclareSubscriber(
+      std::string_view, std::function<void(const sitos::TransportSample&)> callback) override {
+    subscribers_.push_back(std::move(callback));
+    return sitos::Result<sitos::Subscription>::Ok(
+        sitos::transport_test_access::DeclarationHandleTestAccess::MakeSubscription([] {}));
+  }
+
+  sitos::Result<sitos::Queryable> DeclareQueryable(
+      std::string_view, std::function<void(sitos::TransportQuery&)> callback) override {
+    queryable_ = std::move(callback);
+    return sitos::Result<sitos::Queryable>::Ok(
+        sitos::transport_test_access::DeclarationHandleTestAccess::MakeQueryable([] {}));
+  }
+
+ private:
+  std::vector<std::function<void(const sitos::TransportSample&)>> subscribers_;
+  std::function<void(sitos::TransportQuery&)> queryable_;
+
+ public:
+  bool query_failure = false;
+  bool block_get = false;
+  bool get_entered = false;
+  std::mutex get_mutex;
+  std::condition_variable get_cv;
+
+  void WaitForGet() {
+    std::unique_lock lock(get_mutex);
+    get_cv.wait(lock, [&] { return get_entered; });
+  }
+  void ReleaseGet() {
+    {
+      std::scoped_lock lock(get_mutex);
+      block_get = false;
+    }
+    get_cv.notify_all();
+  }
+};
+
+class LateJoinCollector {
+ public:
+  LateJoinCollector(LateJoinTransport& transport, std::string selector,
+                    std::function<void(std::string)> observer)
+      : transport_(transport), selector_(std::move(selector)), observer_(std::move(observer)) {}
+
+  bool Join() {
+    auto subscription_result = transport_.DeclareSubscriber(
+        selector_, [this](const sitos::TransportSample& sample) {
+          if (transitioned_) {
+            observer_(sample.key);
+          } else {
+            buffered_.push_back(sample.key);
+          }
+        });
+    if (!subscription_result.IsOk()) return false;
+    subscription_ = std::move(subscription_result).Value();
+
+    std::vector<std::string> materialized;
+    const auto result = transport_.Get(
+        selector_, [&](std::string_view key, std::span<const std::byte>, sitos::Encoding) {
+          materialized.emplace_back(key);
+          return true;
+        },
+        std::chrono::seconds(1));
+    if (!result.IsOk()) return false;
+    for (const auto& key : materialized) observer_(key);
+    transitioned_ = true;
+    for (const auto& key : buffered_) observer_(key);
+    buffered_.clear();
+    return true;
+  }
+
+ private:
+  LateJoinTransport& transport_;
+  std::string selector_;
+  std::function<void(std::string)> observer_;
+  std::optional<sitos::Subscription> subscription_;
+  std::vector<std::string> buffered_;
+  bool transitioned_ = false;
+};
+
+struct LateJoinFixture {
+  LateJoinTransport transport;
+  std::shared_ptr<sitos::InMemoryEngine> engine = std::make_shared<sitos::InMemoryEngine>();
+  sitos::StorageNode node{transport};
+
+  void Start() {
+    ASSERT_TRUE(node.Start(
+        engine, {.prefix = "sitos",
+                 .durable_buffer_engine_factory = [](std::string_view) {
+                   return sitos::Result<std::unique_ptr<sitos::StorageEngine>>::Ok(
+                       std::make_unique<sitos::InMemoryEngine>());
+                 }}));
+    ASSERT_TRUE(node.CreateSession("session", {.durable_buffers = true}).IsOk());
+  }
+};
+
+TEST(BufferLateJoinTest, OrdersMaterializedBufferedAndLiveSamples) {
+  LateJoinFixture fixture;
+  fixture.Start();
+  const std::vector<std::byte> first{std::byte{1}};
+  const std::vector<std::byte> second{std::byte{2}};
+  ASSERT_TRUE(fixture.transport.Put("sitos/buffers/session/durable/first", first,
+                                    {"zenoh/bytes"}, {})
+                  .IsOk());
+  ASSERT_TRUE(fixture.transport.Put("sitos/buffers/session/durable/second", second,
+                                    {"zenoh/bytes"}, {})
+                  .IsOk());
+
+  std::vector<std::string> observed;
+  LateJoinCollector collector(fixture.transport, "sitos/buffers/session/durable/**",
+                               [&](std::string key) { observed.push_back(std::move(key)); });
+  fixture.transport.block_get = true;
+  std::optional<bool> joined;
+  std::thread join([&] { joined = collector.Join(); });
+  fixture.transport.WaitForGet();
+  const std::vector<std::byte> buffered{std::byte{3}};
+  ASSERT_TRUE(fixture.transport.Put("sitos/buffers/session/durable/buffered", buffered,
+                                    {"zenoh/bytes"}, {})
+                  .IsOk());
+  fixture.transport.ReleaseGet();
+  join.join();
+  ASSERT_TRUE(joined.has_value());
+  ASSERT_TRUE(*joined);
+  const std::vector<std::byte> live{std::byte{4}};
+  ASSERT_TRUE(fixture.transport.Put("sitos/buffers/session/durable/live", live,
+                                    {"zenoh/bytes"}, {})
+                  .IsOk());
+
+  ASSERT_EQ(observed.size(), 4u);
+  EXPECT_EQ(observed[0], "sitos/buffers/session/durable/first");
+  EXPECT_EQ(observed[1], "sitos/buffers/session/durable/second");
+  EXPECT_EQ(observed[2], "sitos/buffers/session/durable/buffered");
+  EXPECT_EQ(observed[3], "sitos/buffers/session/durable/live");
+}
+
+TEST(BufferLateJoinTest, DurableLateJoinDoesNotLoseDistinctKeys) {
+  LateJoinFixture fixture;
+  fixture.Start();
+  for (const auto key : {"a", "b", "c"}) {
+    const std::vector<std::byte> value{std::byte{1}};
+    ASSERT_TRUE(fixture.transport.Put(
+                         "sitos/buffers/session/durable/" + std::string(key), value,
+                         {"zenoh/bytes"}, {})
+                    .IsOk());
+  }
+
+  std::vector<std::string> observed;
+  LateJoinCollector collector(fixture.transport, "sitos/buffers/session/durable/**",
+                               [&](std::string key) { observed.push_back(std::move(key)); });
+  ASSERT_TRUE(collector.Join());
+  ASSERT_EQ(observed.size(), 3u);
+  EXPECT_EQ(std::set<std::string>(observed.begin(), observed.end()),
+            (std::set<std::string>{"sitos/buffers/session/durable/a",
+                                   "sitos/buffers/session/durable/b",
+                                   "sitos/buffers/session/durable/c"}));
+}
+
+TEST(BufferLateJoinTest, FailureInvokesNoObserverAndCleansUp) {
+  LateJoinFixture fixture;
+  fixture.Start();
+  const std::vector<std::byte> failing{std::byte{9}};
+  ASSERT_TRUE(fixture.transport.Put("sitos/buffers/session/durable/failing", failing,
+                                    {"zenoh/bytes"}, {})
+                  .IsOk());
+  std::vector<std::string> observed;
+  fixture.transport.query_failure = true;
+  LateJoinCollector collector(fixture.transport, "sitos/buffers/session/durable/**",
+                               [&](std::string key) { observed.push_back(std::move(key)); });
+  EXPECT_FALSE(collector.Join());
+  EXPECT_TRUE(observed.empty());
+  EXPECT_TRUE(fixture.node.CloseSession("session").IsOk());
+  const std::vector<std::byte> after_close{std::byte{1}};
+  EXPECT_TRUE(fixture.transport.Put("sitos/buffers/session/durable/after-close", after_close,
+                                     {"zenoh/bytes"}, {})
+                  .IsOk());
+  EXPECT_TRUE(observed.empty());
+}
+
+}  // namespace

--- a/tests/integration/buffer_late_join_test.cpp
+++ b/tests/integration/buffer_late_join_test.cpp
@@ -13,6 +13,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <system_error>
 #include <thread>
@@ -238,13 +239,24 @@ class LateJoinCollector final {
       materialized_.clear();
       buffered_.clear();
     }
-    Dispatch(std::move(batch), observation_lock);
+    try {
+      Dispatch(std::move(batch), observation_lock);
+    } catch (...) {
+      if (observation_lock.owns_lock()) observation_lock.unlock();
+      MarkFailed();
+      return false;
+    }
     return true;
   }
 
   bool Failed() const {
     std::scoped_lock lock(collector_mutex_);
     return phase_ == Phase::Failed;
+  }
+
+  void SetLiveBoundaryObserver(std::function<void()> observer) {
+    std::scoped_lock lock(collector_mutex_);
+    live_boundary_observer_ = std::move(observer);
   }
 
   ~LateJoinCollector() { MarkFailed(); }
@@ -345,9 +357,14 @@ class LateJoinCollector final {
       }
       AddLive(observation);
       dispatch.push_back(observation);
+      if (live_boundary_observer_) live_boundary_observer_();
       observation_lock.lock();
     }
-    Dispatch(std::move(dispatch), observation_lock);
+    try {
+      Dispatch(std::move(dispatch), observation_lock);
+    } catch (...) {
+      MarkFailedPhase();
+    }
   }
 
   bool AddLive(const Observation& observation) {
@@ -363,6 +380,11 @@ class LateJoinCollector final {
   void Dispatch(std::vector<Observation> batch, std::unique_lock<std::mutex>& observation_lock) {
     for (const auto& observation : batch) observer_(observation);
     observation_lock.unlock();
+  }
+
+  void MarkFailedPhase() {
+    std::scoped_lock lock(collector_mutex_);
+    phase_ = Phase::Failed;
   }
 
   void MarkFailed() {
@@ -383,6 +405,7 @@ class LateJoinCollector final {
   LateJoinTransport& transport_;
   std::string selector_;
   std::function<void(const Observation&)> observer_;
+  std::function<void()> live_boundary_observer_;
   mutable std::mutex collector_mutex_;
   std::mutex observation_mutex_;
   std::optional<sitos::Subscription> subscription_;
@@ -450,6 +473,140 @@ TEST(BufferLateJoinTest, OrdersMaterializedBufferedAndLiveSamples) {
   EXPECT_EQ(observed[3].key, "sitos/buffers/session/durable/live");
   EXPECT_EQ(observed[2].payload, Bytes({3}));
   EXPECT_EQ(observed[3].payload, Bytes({4}));
+}
+
+TEST(BufferLateJoinTest, BufferedIdenticalReplyPromotesToMaterializedCategory) {
+  LateJoinFixture fixture;
+  fixture.Start();
+  ASSERT_TRUE(
+      fixture.transport.Put("sitos/buffers/session/durable/first", Bytes({1}), {"zenoh/bytes"}, {})
+          .IsOk());
+  ASSERT_TRUE(
+      fixture.transport.Put("sitos/buffers/session/durable/second", Bytes({2}), {"zenoh/bytes"}, {})
+          .IsOk());
+
+  std::vector<Observation> observed;
+  LateJoinCollector collector(
+      fixture.transport, "sitos/buffers/session/durable/**",
+      [&](const Observation& observation) { observed.push_back(observation); });
+  fixture.transport.block_after_first_reply = true;
+  std::optional<bool> joined;
+  std::thread join([&] { joined = collector.Join(); });
+  fixture.transport.WaitForFirstReply();
+  const auto buffered = fixture.transport.Put("sitos/buffers/session/durable/second", Bytes({2}),
+                                              {"zenoh/bytes"}, {});
+  fixture.transport.ReleaseFirstReply();
+  join.join();
+  ASSERT_TRUE(buffered.IsOk());
+  ASSERT_TRUE(joined.has_value());
+  ASSERT_TRUE(*joined);
+  ASSERT_EQ(observed.size(), 2u);
+  EXPECT_EQ(observed[0].key, "sitos/buffers/session/durable/first");
+  EXPECT_EQ(observed[1].key, "sitos/buffers/session/durable/second");
+  EXPECT_EQ(observed[1].payload, Bytes({2}));
+}
+
+TEST(BufferLateJoinTest, BufferedConflictingReplyFailsBeforeObserverDelivery) {
+  LateJoinFixture fixture;
+  fixture.Start();
+  ASSERT_TRUE(
+      fixture.transport.Put("sitos/buffers/session/durable/first", Bytes({1}), {"zenoh/bytes"}, {})
+          .IsOk());
+  ASSERT_TRUE(
+      fixture.transport.Put("sitos/buffers/session/durable/second", Bytes({2}), {"zenoh/bytes"}, {})
+          .IsOk());
+
+  std::vector<Observation> observed;
+  LateJoinCollector collector(
+      fixture.transport, "sitos/buffers/session/durable/**",
+      [&](const Observation& observation) { observed.push_back(observation); });
+  fixture.transport.block_after_first_reply = true;
+  std::optional<bool> joined;
+  std::thread join([&] { joined = collector.Join(); });
+  fixture.transport.WaitForFirstReply();
+  const auto buffered = fixture.transport.Put("sitos/buffers/session/durable/second", Bytes({9}),
+                                              {"zenoh/bytes"}, {});
+  fixture.transport.ReleaseFirstReply();
+  join.join();
+  ASSERT_TRUE(buffered.IsOk());
+  ASSERT_TRUE(joined.has_value());
+  EXPECT_FALSE(*joined);
+  EXPECT_TRUE(collector.Failed());
+  EXPECT_TRUE(observed.empty());
+}
+
+TEST(BufferLateJoinTest, ObservationBoundarySerializesInitialBatchAndLiveSample) {
+  LateJoinFixture fixture;
+  fixture.Start();
+  ASSERT_TRUE(
+      fixture.transport.Put("sitos/buffers/session/durable/first", Bytes({1}), {"zenoh/bytes"}, {})
+          .IsOk());
+  ASSERT_TRUE(
+      fixture.transport.Put("sitos/buffers/session/durable/second", Bytes({2}), {"zenoh/bytes"}, {})
+          .IsOk());
+
+  std::vector<Observation> observed;
+  std::mutex observer_mutex;
+  std::condition_variable observer_cv;
+  bool first_observer_entered = false;
+  bool release_first_observer = false;
+  std::mutex live_mutex;
+  std::condition_variable live_cv;
+  bool live_boundary_attempted = false;
+  LateJoinCollector collector(fixture.transport, "sitos/buffers/session/durable/**",
+                              [&](const Observation& observation) {
+                                {
+                                  std::scoped_lock lock(observer_mutex);
+                                  observed.push_back(observation);
+                                  if (observation.key == "sitos/buffers/session/durable/first") {
+                                    first_observer_entered = true;
+                                    observer_cv.notify_all();
+                                  }
+                                }
+                                if (observation.key == "sitos/buffers/session/durable/first") {
+                                  std::unique_lock lock(observer_mutex);
+                                  observer_cv.wait(lock, [&] { return release_first_observer; });
+                                }
+                              });
+  collector.SetLiveBoundaryObserver([&] {
+    std::scoped_lock lock(live_mutex);
+    live_boundary_attempted = true;
+    live_cv.notify_all();
+  });
+  fixture.transport.block_after_first_reply = true;
+  std::optional<bool> joined;
+  std::thread join([&] { joined = collector.Join(); });
+  fixture.transport.WaitForFirstReply();
+  const auto buffered = fixture.transport.Put("sitos/buffers/session/durable/buffered", Bytes({3}),
+                                              {"zenoh/bytes"}, {});
+  fixture.transport.ReleaseFirstReply();
+  std::thread live([&] {
+    static_cast<void>(fixture.transport.Put("sitos/buffers/session/durable/live", Bytes({4}),
+                                            {"zenoh/bytes"}, {}));
+  });
+  {
+    std::unique_lock lock(observer_mutex);
+    observer_cv.wait(lock, [&] { return first_observer_entered; });
+  }
+  {
+    std::unique_lock lock(live_mutex);
+    live_cv.wait(lock, [&] { return live_boundary_attempted; });
+  }
+  {
+    std::scoped_lock lock(observer_mutex);
+    release_first_observer = true;
+  }
+  observer_cv.notify_all();
+  join.join();
+  live.join();
+  ASSERT_TRUE(buffered.IsOk());
+  ASSERT_TRUE(joined.has_value());
+  ASSERT_TRUE(*joined);
+  ASSERT_EQ(observed.size(), 4u);
+  EXPECT_EQ(observed[0].key, "sitos/buffers/session/durable/first");
+  EXPECT_EQ(observed[1].key, "sitos/buffers/session/durable/second");
+  EXPECT_EQ(observed[2].key, "sitos/buffers/session/durable/buffered");
+  EXPECT_EQ(observed[3].key, "sitos/buffers/session/durable/live");
 }
 
 TEST(BufferLateJoinTest, DurableLateJoinDoesNotLoseDistinctKeys) {
@@ -530,6 +687,42 @@ TEST(BufferLateJoinTest, FailureInvokesNoObserverAndCleansUp) {
     EXPECT_TRUE(collector.Failed());
   }
   fixture.transport.fail_after_replies = -1;
+
+  bool initial_exception_propagated = false;
+  {
+    LateJoinCollector collector(
+        fixture.transport, "sitos/buffers/session/durable/**",
+        [&](const Observation&) { throw std::runtime_error("initial observer failure"); });
+    bool joined = true;
+    try {
+      joined = collector.Join();
+    } catch (...) {
+      initial_exception_propagated = true;
+    }
+    EXPECT_FALSE(joined);
+    EXPECT_TRUE(collector.Failed());
+  }
+  EXPECT_FALSE(initial_exception_propagated);
+
+  int live_observer_calls = 0;
+  {
+    LateJoinCollector collector(fixture.transport, "sitos/buffers/session/durable/**",
+                                [&](const Observation&) {
+                                  ++live_observer_calls;
+                                  if (live_observer_calls > 2)
+                                    throw std::runtime_error("live observer failure");
+                                });
+    ASSERT_TRUE(collector.Join());
+    const auto first_live = fixture.transport.Put("sitos/buffers/session/durable/live-failure",
+                                                  Bytes({6}), {"zenoh/bytes"}, {});
+    EXPECT_TRUE(first_live.IsOk());
+    EXPECT_TRUE(collector.Failed());
+    const int calls_after_failure = live_observer_calls;
+    const auto second_live = fixture.transport.Put("sitos/buffers/session/durable/live-suppressed",
+                                                   Bytes({7}), {"zenoh/bytes"}, {});
+    EXPECT_TRUE(second_live.IsOk());
+    EXPECT_EQ(live_observer_calls, calls_after_failure);
+  }
 
   fixture.transport.park_copied_callbacks = true;
   std::thread publish;

--- a/tests/integration/buffer_late_join_test.cpp
+++ b/tests/integration/buffer_late_join_test.cpp
@@ -256,9 +256,15 @@ class LateJoinCollector final {
     return phase_ == Phase::Failed;
   }
 
-  void SetLiveBoundaryObserver(std::function<void()> observer) {
+  void EnableLiveBoundarySignal() {
     std::scoped_lock lock(collector_mutex_);
-    live_boundary_observer_ = std::move(observer);
+    live_boundary_enabled_ = true;
+    live_boundary_attempted_ = false;
+  }
+
+  bool WaitForLiveBoundaryAttempt(std::chrono::milliseconds timeout) {
+    std::unique_lock lock(collector_mutex_);
+    return live_boundary_cv_.wait_for(lock, timeout, [&] { return live_boundary_attempted_; });
   }
 
   ~LateJoinCollector() { MarkFailed(); }
@@ -359,10 +365,13 @@ class LateJoinCollector final {
       }
       AddLive(observation);
       dispatch.push_back(observation);
-      if (live_boundary_observer_) live_boundary_observer_();
-      observation_lock.lock();
-      if (observer_failed_.load(std::memory_order_acquire)) return;
+      if (live_boundary_enabled_) {
+        live_boundary_attempted_ = true;
+        live_boundary_cv_.notify_all();
+      }
     }
+    observation_lock.lock();
+    if (observer_failed_.load(std::memory_order_acquire)) return;
     try {
       Dispatch(std::move(dispatch), observation_lock);
     } catch (...) {
@@ -410,8 +419,10 @@ class LateJoinCollector final {
   LateJoinTransport& transport_;
   std::string selector_;
   std::function<void(const Observation&)> observer_;
-  std::function<void()> live_boundary_observer_;
   std::atomic<bool> observer_failed_ = false;
+  bool live_boundary_enabled_ = false;
+  bool live_boundary_attempted_ = false;
+  std::condition_variable live_boundary_cv_;
   mutable std::mutex collector_mutex_;
   std::mutex observation_mutex_;
   std::optional<sitos::Subscription> subscription_;
@@ -556,9 +567,6 @@ TEST(BufferLateJoinTest, ObservationBoundarySerializesInitialBatchAndLiveSample)
   std::condition_variable observer_cv;
   bool first_observer_entered = false;
   bool release_first_observer = false;
-  std::mutex live_mutex;
-  std::condition_variable live_cv;
-  bool live_boundary_attempted = false;
   LateJoinCollector collector(fixture.transport, "sitos/buffers/session/durable/**",
                               [&](const Observation& observation) {
                                 {
@@ -574,11 +582,7 @@ TEST(BufferLateJoinTest, ObservationBoundarySerializesInitialBatchAndLiveSample)
                                   observer_cv.wait(lock, [&] { return release_first_observer; });
                                 }
                               });
-  collector.SetLiveBoundaryObserver([&] {
-    std::scoped_lock lock(live_mutex);
-    live_boundary_attempted = true;
-    live_cv.notify_all();
-  });
+  collector.EnableLiveBoundarySignal();
   fixture.transport.block_after_first_reply = true;
   std::optional<bool> joined;
   std::thread join([&] { joined = collector.Join(); });
@@ -586,26 +590,34 @@ TEST(BufferLateJoinTest, ObservationBoundarySerializesInitialBatchAndLiveSample)
   const auto buffered = fixture.transport.Put("sitos/buffers/session/durable/buffered", Bytes({3}),
                                               {"zenoh/bytes"}, {});
   fixture.transport.ReleaseFirstReply();
-  std::thread live([&] {
-    static_cast<void>(fixture.transport.Put("sitos/buffers/session/durable/live", Bytes({4}),
-                                            {"zenoh/bytes"}, {}));
-  });
+  std::thread live;
+  bool live_started = false;
   {
     std::unique_lock lock(observer_mutex);
-    observer_cv.wait(lock, [&] { return first_observer_entered; });
+    if (!observer_cv.wait_for(lock, std::chrono::seconds(5),
+                              [&] { return first_observer_entered; })) {
+      release_first_observer = true;
+    } else {
+      live = std::thread([&] {
+        static_cast<void>(fixture.transport.Put("sitos/buffers/session/durable/live", Bytes({4}),
+                                                {"zenoh/bytes"}, {}));
+      });
+      live_started = true;
+    }
   }
-  {
-    std::unique_lock lock(live_mutex);
-    live_cv.wait(lock, [&] { return live_boundary_attempted; });
-  }
+  observer_cv.notify_all();
+  const bool boundary_seen =
+      live_started && collector.WaitForLiveBoundaryAttempt(std::chrono::seconds(5));
   {
     std::scoped_lock lock(observer_mutex);
     release_first_observer = true;
   }
   observer_cv.notify_all();
+  fixture.transport.ReleaseFirstReply();
   join.join();
-  live.join();
+  if (live_started) live.join();
   ASSERT_TRUE(buffered.IsOk());
+  ASSERT_TRUE(boundary_seen) << "live path did not reach observation boundary";
   ASSERT_TRUE(joined.has_value());
   ASSERT_TRUE(*joined);
   ASSERT_EQ(observed.size(), 4u);

--- a/tests/integration/rocksdb_buffer_lifecycle_test.cpp
+++ b/tests/integration/rocksdb_buffer_lifecycle_test.cpp
@@ -1,0 +1,114 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sitos/in_memory_engine.hpp"
+#include "sitos/rocksdb_engine.hpp"
+#include "sitos/storage_node.hpp"
+#include "sitos/transport.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "transport/declaration_handle_test_access.hpp"
+
+namespace {
+
+class RocksDbTransport final : public sitos::Transport {
+ public:
+  sitos::Result<void> Put(std::string_view, std::span<const std::byte>, sitos::Encoding,
+                          sitos::PutOptions) override {
+    return sitos::Result<void>::Ok();
+  }
+  sitos::Result<void> Delete(std::string_view, sitos::PutOptions) override {
+    return sitos::Result<void>::Ok();
+  }
+  sitos::Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
+                          std::chrono::milliseconds) override {
+    auto query = sitos::TransportQuery::ForTesting(
+        [&](std::string_view key, std::span<const std::byte> payload, sitos::Encoding encoding) {
+          if (sink(key, payload, std::move(encoding))) return sitos::Result<void>::Ok();
+          return sitos::Result<void>::Err(std::make_error_code(std::errc::broken_pipe));
+        });
+    query.keyexpr = std::string(keyexpr);
+    if (queryable_) queryable_(query);
+    return sitos::Result<void>::Ok();
+  }
+  sitos::Result<sitos::Subscription> DeclareSubscriber(
+      std::string_view, std::function<void(const sitos::TransportSample&)> callback) override {
+    subscriber_ = std::move(callback);
+    return sitos::Result<sitos::Subscription>::Ok(
+        sitos::transport_test_access::DeclarationHandleTestAccess::MakeSubscription([] {}));
+  }
+  sitos::Result<sitos::Queryable> DeclareQueryable(
+      std::string_view, std::function<void(sitos::TransportQuery&)> callback) override {
+    queryable_ = std::move(callback);
+    return sitos::Result<sitos::Queryable>::Ok(
+        sitos::transport_test_access::DeclarationHandleTestAccess::MakeQueryable([] {}));
+  }
+
+  void PutSample(std::string key, std::vector<std::byte> payload) {
+    subscriber_(sitos::TransportSample{std::move(key), payload, {"zenoh/bytes"}, std::nullopt,
+                                       sitos::TransportSample::Kind::Put});
+  }
+
+ private:
+  std::function<void(const sitos::TransportSample&)> subscriber_;
+  std::function<void(sitos::TransportQuery&)> queryable_;
+};
+
+TEST(RocksDBBufferLifecycleTest, CloseReleasesEngineBeforeReturn) {
+  RocksDbTransport transport;
+  const auto root = std::filesystem::temp_directory_path() / "sitos-issue56-rocksdb-close";
+  std::filesystem::remove_all(root);
+  auto base = std::make_shared<sitos::InMemoryEngine>();
+  sitos::StorageNode node{transport};
+  ASSERT_TRUE(node.Start(
+      base, {.prefix = "sitos",
+             .durable_buffer_engine_factory = [&](std::string_view) {
+               return sitos::RocksDBEngine::Open((root / "session").string());
+             }}));
+  ASSERT_TRUE(node.CreateSession("session", {.durable_buffers = true}).IsOk());
+  transport.PutSample("sitos/buffers/session/durable/key", {std::byte{7}});
+  ASSERT_TRUE(node.CloseSession("session").IsOk());
+  EXPECT_GT(std::filesystem::remove_all(root), 0u);
+  EXPECT_FALSE(std::filesystem::exists(root));
+}
+
+TEST(RocksDBBufferLifecycleTest, SameSidRecreationUsesFreshEngine) {
+  RocksDbTransport transport;
+  const auto root = std::filesystem::temp_directory_path() / "sitos-issue56-rocksdb-recreate";
+  std::filesystem::remove_all(root);
+  auto base = std::make_shared<sitos::InMemoryEngine>();
+  int factory_calls = 0;
+  sitos::StorageNode node{transport};
+  ASSERT_TRUE(node.Start(
+      base, {.prefix = "sitos",
+             .durable_buffer_engine_factory = [&](std::string_view) {
+               ++factory_calls;
+               return sitos::RocksDBEngine::Open((root / ("session-" + std::to_string(factory_calls))).string());
+             }}));
+  ASSERT_TRUE(node.CreateSession("session", {.durable_buffers = true}).IsOk());
+  transport.PutSample("sitos/buffers/session/durable/key", {std::byte{7}});
+  ASSERT_TRUE(node.CloseSession("session").IsOk());
+  ASSERT_TRUE(node.CreateSession("session", {.durable_buffers = true}).IsOk());
+  EXPECT_EQ(factory_calls, 2);
+  EXPECT_EQ(transport.Get("sitos/buffers/session/durable/key",
+                          [](std::string_view, std::span<const std::byte>, sitos::Encoding) {
+                            return true;
+                          },
+                          std::chrono::milliseconds(500))
+                .IsOk());
+  EXPECT_TRUE(node.CloseSession("session").IsOk());
+  std::filesystem::remove_all(root);
+}
+
+}  // namespace

--- a/tests/integration/rocksdb_buffer_lifecycle_test.cpp
+++ b/tests/integration/rocksdb_buffer_lifecycle_test.cpp
@@ -1,41 +1,272 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "sitos/in_memory_engine.hpp"
+#include "sitos/rocksdb_engine.hpp"
+#include "sitos/storage_node.hpp"
+#include "sitos/transport.hpp"
+#include "storage_node_test_access.hpp"
+#include "transport/declaration_handle_test_access.hpp"
+
+namespace {
+
+class RocksDbTransport final : public sitos::Transport {
+ public:
+  sitos::Result<void> Put(std::string_view, std::span<const std::byte>, sitos::Encoding,
+                          sitos::PutOptions) override {
+    return sitos::Result<void>::Ok();
+  }
+
+  sitos::Result<void> Delete(std::string_view, sitos::PutOptions) override {
+    return sitos::Result<void>::Ok();
+  }
+
+  sitos::Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
+                          std::chrono::milliseconds) override {
+    auto query = sitos::TransportQuery::ForTesting(
+        [&](std::string_view key, std::span<const std::byte> payload, sitos::Encoding encoding) {
+          if (sink(key, payload, std::move(encoding))) {
+            return sitos::Result<void>::Ok();
+          }
+          return sitos::Result<void>::Err(std::make_error_code(std::errc::broken_pipe));
+        });
+    query.keyexpr = std::string(keyexpr);
+    if (queryable_) {
+      queryable_(query);
+    }
+    return sitos::Result<void>::Ok();
+  }
+
+  sitos::Result<sitos::Subscription> DeclareSubscriber(
+      std::string_view, std::function<void(const sitos::TransportSample&)> callback) override {
+    subscriber_ = std::move(callback);
+    return sitos::Result<sitos::Subscription>::Ok(
+        sitos::transport_test_access::DeclarationHandleTestAccess::MakeSubscription([] {}));
+  }
+
+  sitos::Result<sitos::Queryable> DeclareQueryable(
+      std::string_view, std::function<void(sitos::TransportQuery&)> callback) override {
+    queryable_ = std::move(callback);
+    return sitos::Result<sitos::Queryable>::Ok(
+        sitos::transport_test_access::DeclarationHandleTestAccess::MakeQueryable([] {}));
+  }
+
+  sitos::Result<void> PutSample(std::string key, std::vector<std::byte> payload) {
+    subscriber_(sitos::TransportSample{
+        std::move(key), payload, {"zenoh/bytes"}, std::nullopt, sitos::TransportSample::Kind::Put});
+    return sitos::Result<void>::Ok();
+  }
+
+ private:
+  std::function<void(const sitos::TransportSample&)> subscriber_;
+  std::function<void(sitos::TransportQuery&)> queryable_;
+};
+
+struct GateState {
+  mutable std::mutex mutex;
+  std::condition_variable condition;
+  bool block_put = false;
+  bool block_get = false;
+  bool block_list = false;
+  int put_entered = 0;
+  int get_entered = 0;
+  int list_entered = 0;
+};
+
+class BlockingRocksDbEngine final : public sitos::StorageEngine {
+ public:
+  BlockingRocksDbEngine(std::unique_ptr<sitos::RocksDBEngine> engine,
+                        std::shared_ptr<GateState> gates, std::shared_ptr<bool> destroyed)
+      : engine_(std::move(engine)), gates_(std::move(gates)), destroyed_(std::move(destroyed)) {}
+
+  ~BlockingRocksDbEngine() override { *destroyed_ = true; }
+
+  bool Put(std::string_view key, sitos::Bytes value) override {
+    Wait(gates_->block_put, gates_->put_entered);
+    return engine_->Put(key, value);
+  }
+
+  bool Delete(std::string_view key) override { return engine_->Delete(key); }
+
+  bool Get(std::string_view key, const sitos::EntrySink& sink) const override {
+    Wait(gates_->block_get, gates_->get_entered);
+    return engine_->Get(key, sink);
+  }
+
+  bool List(std::string_view prefix, const sitos::EntrySink& sink) const override {
+    Wait(gates_->block_list, gates_->list_entered);
+    return engine_->List(prefix, sink);
+  }
+
+  std::shared_ptr<const sitos::StorageReader> TakeSnapshot() const override {
+    return engine_->TakeSnapshot();
+  }
+
+ private:
+  void Wait(bool& blocked, int& entered) const {
+    std::unique_lock lock(gates_->mutex);
+    if (!blocked) {
+      return;
+    }
+    ++entered;
+    gates_->condition.notify_all();
+    gates_->condition.wait(lock, [&] { return !blocked; });
+  }
+
+  std::unique_ptr<sitos::RocksDBEngine> engine_;
+  std::shared_ptr<GateState> gates_;
+  std::shared_ptr<bool> destroyed_;
+};
+
+class ScopedRoot {
+ public:
+  explicit ScopedRoot(std::string_view label) {
+    static std::atomic<unsigned long long> serial = 0;
+    const auto timestamp = std::chrono::steady_clock::now().time_since_epoch().count();
+    for (unsigned int attempt = 0; attempt < 100; ++attempt) {
+      const auto id = serial.fetch_add(1, std::memory_order_relaxed);
+      const auto candidate = std::filesystem::temp_directory_path() /
+                             ("sitos-issue56-" + std::string(label) + "-" +
+                              std::to_string(timestamp) + "-" + std::to_string(id));
+      std::error_code error;
+      if (std::filesystem::create_directory(candidate, error)) {
+        path_ = candidate;
+        return;
+      }
+      if (error != std::errc::file_exists) {
+        throw std::system_error(error, "create temporary RocksDB directory");
+      }
+    }
+    throw std::runtime_error("unable to allocate a unique temporary RocksDB directory");
+  }
+
+  ~ScopedRoot() {
+    std::error_code error;
+    std::filesystem::remove_all(path_, error);
+  }
+
+  ScopedRoot(const ScopedRoot&) = delete;
+  ScopedRoot& operator=(const ScopedRoot&) = delete;
+
+  const std::filesystem::path& Path() const { return path_; }
+
+ private:
+  std::filesystem::path path_;
+};
+
+class ThreadScope {
+ public:
+  explicit ThreadScope(std::shared_ptr<GateState> gates) : gates_(std::move(gates)) {}
+
+  ~ThreadScope() {
+    Release();
+    JoinAll();
+  }
+
+  void Add(std::thread& thread) { threads_.push_back(&thread); }
+
+  void Release() {
+    {
+      std::scoped_lock lock(gates_->mutex);
+      gates_->block_put = false;
+      gates_->block_get = false;
+      gates_->block_list = false;
+    }
+    gates_->condition.notify_all();
+  }
+
+  void JoinAll() {
+    for (auto* thread : threads_) {
+      if (thread->joinable()) {
+        thread->join();
+      }
+    }
+  }
+
+ private:
+  std::shared_ptr<GateState> gates_;
+  std::vector<std::thread*> threads_;
+};
+
+bool WaitForMaterialization(std::chrono::milliseconds timeout,
+                            const std::shared_ptr<GateState>& gates) {
+  std::unique_lock lock(gates->mutex);
+  return gates->condition.wait_for(lock, timeout, [&] {
+    return gates->put_entered > 0 && gates->get_entered > 0 && gates->list_entered > 0;
+  });
+}
+
+}  // namespace
 
 TEST(RocksDBBufferLifecycleTest, CloseReleasesEngineBeforeReturn) {
   RocksDbTransport transport;
-  const auto root = UniqueRoot("close");
+  ScopedRoot root("close");
   auto gates = std::make_shared<GateState>();
   auto destroyed = std::make_shared<bool>(false);
   sitos::StorageNode node{transport};
   ASSERT_TRUE(node.Start(
       std::make_shared<sitos::InMemoryEngine>(),
       {.prefix = "sitos", .durable_buffer_engine_factory = [&](std::string_view sid) {
-         auto opened = sitos::RocksDBEngine::Open((root / std::string(sid)).string());
-         if (!opened.IsOk())
+         auto opened = sitos::RocksDBEngine::Open((root.Path() / std::string(sid)).string());
+         if (!opened.IsOk()) {
            return sitos::Result<std::unique_ptr<sitos::StorageEngine>>::ErrFrom(opened);
+         }
          return sitos::Result<std::unique_ptr<sitos::StorageEngine>>::Ok(
              std::make_unique<BlockingRocksDbEngine>(std::move(opened).Value(), gates, destroyed));
        }}));
   ASSERT_TRUE(node.CreateSession("session", {.durable_buffers = true}).IsOk());
-  gates->block_put = true;
-  gates->block_get = true;
-  gates->block_list = true;
+  {
+    std::scoped_lock lock(gates->mutex);
+    gates->block_put = true;
+    gates->block_get = true;
+    gates->block_list = true;
+  }
 
-  std::thread put(
-      [&] { transport.PutSample("sitos/buffers/session/durable/key", {std::byte{7}}); });
+  std::optional<sitos::Result<void>> put_result;
+  std::optional<sitos::Result<void>> get_result;
+  std::optional<sitos::Result<void>> list_result;
+  ThreadScope threads(gates);
+  std::thread put([&] {
+    put_result = transport.PutSample("sitos/buffers/session/durable/key", {std::byte{7}});
+  });
+  threads.Add(put);
   std::thread get([&] {
-    transport.Get(
+    get_result = transport.Get(
         "sitos/buffers/session/durable/key", [](auto, auto, auto) { return true; },
         std::chrono::seconds(1));
   });
+  threads.Add(get);
   std::thread list([&] {
-    transport.Get(
+    list_result = transport.Get(
         "sitos/buffers/session/durable/**", [](auto, auto, auto) { return true; },
         std::chrono::seconds(1));
   });
-  {
-    std::unique_lock lock(gates->mutex);
-    gates->condition.wait(lock, [&] {
-      return gates->put_entered > 0 && gates->get_entered > 0 && gates->list_entered > 0;
-    });
+  threads.Add(list);
+
+  if (!WaitForMaterialization(std::chrono::seconds(5), gates)) {
+    threads.Release();
+    threads.JoinAll();
+    ADD_FAILURE() << "Put/Get/List did not all reach the real RocksDB barrier";
+    return;
   }
 
   std::optional<sitos::Result<void>> close_result;
@@ -44,32 +275,33 @@ TEST(RocksDBBufferLifecycleTest, CloseReleasesEngineBeforeReturn) {
     close_result = node.CloseSession("session");
     close_done.store(true, std::memory_order_release);
   });
-  ASSERT_TRUE(
-      sitos::storage_node_test_access::StorageNodeTestAccess::WaitForClosing(node, "session"));
-  EXPECT_FALSE(close_done.load(std::memory_order_acquire));
-  {
-    std::scoped_lock lock(gates->mutex);
-    gates->block_put = false;
-    gates->block_get = false;
-    gates->block_list = false;
-  }
-  gates->condition.notify_all();
-  put.join();
-  get.join();
-  list.join();
-  close.join();
+  threads.Add(close);
+  const bool closing_seen =
+      sitos::storage_node_test_access::StorageNodeTestAccess::WaitForClosing(node, "session");
+  const bool close_done_while_blocked = close_done.load(std::memory_order_acquire);
+  threads.Release();
+  threads.JoinAll();
+
+  EXPECT_TRUE(closing_seen);
+  EXPECT_FALSE(close_done_while_blocked);
+  ASSERT_TRUE(put_result.has_value());
+  ASSERT_TRUE(get_result.has_value());
+  ASSERT_TRUE(list_result.has_value());
   ASSERT_TRUE(close_result.has_value());
+  EXPECT_TRUE(put_result->IsOk());
+  EXPECT_TRUE(get_result->IsOk());
+  EXPECT_TRUE(list_result->IsOk());
   EXPECT_TRUE(close_result->IsOk());
   EXPECT_TRUE(*destroyed);
-  EXPECT_GT(std::filesystem::remove_all(root), 0u);
-  EXPECT_FALSE(std::filesystem::exists(root));
+  EXPECT_GT(std::filesystem::remove_all(root.Path()), 0u);
+  EXPECT_FALSE(std::filesystem::exists(root.Path()));
 }
 
 TEST(RocksDBBufferLifecycleTest, SameSidRecreationUsesFreshEngine) {
   RocksDbTransport transport;
-  const auto root = UniqueRoot("recreate");
-  const auto first_root = root / "first";
-  const auto second_root = root / "second";
+  ScopedRoot root("recreate");
+  const auto first_root = root.Path() / "first";
+  const auto second_root = root.Path() / "second";
   auto base = std::make_shared<sitos::InMemoryEngine>();
   std::vector<std::string> factory_sids;
   int factory_calls = 0;
@@ -80,15 +312,16 @@ TEST(RocksDBBufferLifecycleTest, SameSidRecreationUsesFreshEngine) {
                ++factory_calls;
                const auto path = factory_calls == 1 ? first_root : second_root;
                auto opened = sitos::RocksDBEngine::Open((path / std::string(sid)).string());
-               if (!opened.IsOk())
+               if (!opened.IsOk()) {
                  return sitos::Result<std::unique_ptr<sitos::StorageEngine>>::ErrFrom(opened);
+               }
                return sitos::Result<std::unique_ptr<sitos::StorageEngine>>::Ok(
                    std::make_unique<BlockingRocksDbEngine>(std::move(opened).Value(),
                                                            std::make_shared<GateState>(),
                                                            std::make_shared<bool>(false)));
              }}));
   ASSERT_TRUE(node.CreateSession("session", {.durable_buffers = true}).IsOk());
-  transport.PutSample("sitos/buffers/session/durable/key", {std::byte{7}});
+  ASSERT_TRUE(transport.PutSample("sitos/buffers/session/durable/key", {std::byte{7}}).IsOk());
   ASSERT_TRUE(node.CloseSession("session").IsOk());
   EXPECT_GT(std::filesystem::remove_all(first_root), 0u);
   EXPECT_FALSE(std::filesystem::exists(first_root));

--- a/tests/integration/rocksdb_buffer_lifecycle_test.cpp
+++ b/tests/integration/rocksdb_buffer_lifecycle_test.cpp
@@ -175,14 +175,22 @@ class ScopedRoot {
 
 class ThreadScope {
  public:
-  explicit ThreadScope(std::shared_ptr<GateState> gates) : gates_(std::move(gates)) {}
+  explicit ThreadScope(std::shared_ptr<GateState> gates) : gates_(std::move(gates)) {
+    threads_.reserve(4);
+  }
 
   ~ThreadScope() {
     Release();
     JoinAll();
   }
 
-  void Add(std::thread& thread) { threads_.push_back(&thread); }
+  template <typename Function>
+  void Start(Function&& function) {
+    if (threads_.size() == threads_.capacity()) {
+      throw std::logic_error("RocksDB lifecycle test exceeded thread-scope capacity");
+    }
+    threads_.emplace_back(std::forward<Function>(function));
+  }
 
   void Release() {
     {
@@ -195,16 +203,16 @@ class ThreadScope {
   }
 
   void JoinAll() {
-    for (auto* thread : threads_) {
-      if (thread->joinable()) {
-        thread->join();
+    for (auto& thread : threads_) {
+      if (thread.joinable()) {
+        thread.join();
       }
     }
   }
 
  private:
   std::shared_ptr<GateState> gates_;
-  std::vector<std::thread*> threads_;
+  std::vector<std::thread> threads_;
 };
 
 bool WaitForMaterialization(std::chrono::milliseconds timeout,
@@ -213,6 +221,14 @@ bool WaitForMaterialization(std::chrono::milliseconds timeout,
   return gates->condition.wait_for(lock, timeout, [&] {
     return gates->put_entered > 0 && gates->get_entered > 0 && gates->list_entered > 0;
   });
+}
+
+bool EnsureDirectory(const std::filesystem::path& path) {
+  std::error_code error;
+  std::filesystem::create_directories(path, error);
+  if (error) return false;
+  const bool directory = std::filesystem::is_directory(path, error);
+  return directory && !error;
 }
 
 }  // namespace
@@ -245,22 +261,19 @@ TEST(RocksDBBufferLifecycleTest, CloseReleasesEngineBeforeReturn) {
   std::optional<sitos::Result<void>> get_result;
   std::optional<sitos::Result<void>> list_result;
   ThreadScope threads(gates);
-  std::thread put([&] {
+  threads.Start([&] {
     put_result = transport.PutSample("sitos/buffers/session/durable/key", {std::byte{7}});
   });
-  threads.Add(put);
-  std::thread get([&] {
+  threads.Start([&] {
     get_result = transport.Get(
         "sitos/buffers/session/durable/key", [](auto, auto, auto) { return true; },
         std::chrono::seconds(1));
   });
-  threads.Add(get);
-  std::thread list([&] {
+  threads.Start([&] {
     list_result = transport.Get(
         "sitos/buffers/session/durable/**", [](auto, auto, auto) { return true; },
         std::chrono::seconds(1));
   });
-  threads.Add(list);
 
   if (!WaitForMaterialization(std::chrono::seconds(5), gates)) {
     threads.Release();
@@ -271,11 +284,10 @@ TEST(RocksDBBufferLifecycleTest, CloseReleasesEngineBeforeReturn) {
 
   std::optional<sitos::Result<void>> close_result;
   std::atomic<bool> close_done = false;
-  std::thread close([&] {
+  threads.Start([&] {
     close_result = node.CloseSession("session");
     close_done.store(true, std::memory_order_release);
   });
-  threads.Add(close);
   const bool closing_seen =
       sitos::storage_node_test_access::StorageNodeTestAccess::WaitForClosing(node, "session");
   const bool close_done_while_blocked = close_done.load(std::memory_order_acquire);
@@ -320,11 +332,13 @@ TEST(RocksDBBufferLifecycleTest, SameSidRecreationUsesFreshEngine) {
                                                            std::make_shared<GateState>(),
                                                            std::make_shared<bool>(false)));
              }}));
+  ASSERT_TRUE(EnsureDirectory(first_root));
   ASSERT_TRUE(node.CreateSession("session", {.durable_buffers = true}).IsOk());
   ASSERT_TRUE(transport.PutSample("sitos/buffers/session/durable/key", {std::byte{7}}).IsOk());
   ASSERT_TRUE(node.CloseSession("session").IsOk());
   EXPECT_GT(std::filesystem::remove_all(first_root), 0u);
   EXPECT_FALSE(std::filesystem::exists(first_root));
+  ASSERT_TRUE(EnsureDirectory(second_root));
 
   ASSERT_TRUE(node.CreateSession("session", {.durable_buffers = true}).IsOk());
   int replies = 0;

--- a/tests/integration/rocksdb_buffer_lifecycle_test.cpp
+++ b/tests/integration/rocksdb_buffer_lifecycle_test.cpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <filesystem>
 #include <functional>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -81,40 +82,57 @@ class RocksDbTransport final : public sitos::Transport {
   std::function<void(sitos::TransportQuery&)> queryable_;
 };
 
+struct Reply {
+  std::string key;
+  std::vector<std::byte> payload;
+  std::string encoding;
+};
+
 struct GateState {
   mutable std::mutex mutex;
   std::condition_variable condition;
   bool block_put = false;
-  bool block_get = false;
+  bool block_explicit_get = false;
   bool block_list = false;
   int put_entered = 0;
-  int get_entered = 0;
+  int explicit_get_entered = 0;
   int list_entered = 0;
+  bool put_completed = false;
+  bool explicit_get_completed = false;
+  bool list_completed = false;
 };
 
 class BlockingRocksDbEngine final : public sitos::StorageEngine {
  public:
   BlockingRocksDbEngine(std::unique_ptr<sitos::RocksDBEngine> engine,
-                        std::shared_ptr<GateState> gates, std::shared_ptr<bool> destroyed)
+                        std::shared_ptr<GateState> gates,
+                        std::shared_ptr<std::atomic<bool>> destroyed)
       : engine_(std::move(engine)), gates_(std::move(gates)), destroyed_(std::move(destroyed)) {}
 
-  ~BlockingRocksDbEngine() override { *destroyed_ = true; }
+  ~BlockingRocksDbEngine() override { destroyed_->store(true, std::memory_order_release); }
 
   bool Put(std::string_view key, sitos::Bytes value) override {
     Wait(gates_->block_put, gates_->put_entered);
-    return engine_->Put(key, value);
+    const bool result = engine_->Put(key, value);
+    Complete(gates_->put_completed);
+    return result;
   }
 
   bool Delete(std::string_view key) override { return engine_->Delete(key); }
 
   bool Get(std::string_view key, const sitos::EntrySink& sink) const override {
-    Wait(gates_->block_get, gates_->get_entered);
-    return engine_->Get(key, sink);
+    const bool designated = key == "seed";
+    if (designated) Wait(gates_->block_explicit_get, gates_->explicit_get_entered);
+    const bool result = engine_->Get(key, sink);
+    if (designated) Complete(gates_->explicit_get_completed);
+    return result;
   }
 
   bool List(std::string_view prefix, const sitos::EntrySink& sink) const override {
     Wait(gates_->block_list, gates_->list_entered);
-    return engine_->List(prefix, sink);
+    const bool result = engine_->List(prefix, sink);
+    Complete(gates_->list_completed);
+    return result;
   }
 
   std::shared_ptr<const sitos::StorageReader> TakeSnapshot() const override {
@@ -124,17 +142,23 @@ class BlockingRocksDbEngine final : public sitos::StorageEngine {
  private:
   void Wait(bool& blocked, int& entered) const {
     std::unique_lock lock(gates_->mutex);
-    if (!blocked) {
-      return;
-    }
+    if (!blocked) return;
     ++entered;
     gates_->condition.notify_all();
     gates_->condition.wait(lock, [&] { return !blocked; });
   }
 
+  void Complete(bool& completed) const {
+    {
+      std::scoped_lock lock(gates_->mutex);
+      completed = true;
+    }
+    gates_->condition.notify_all();
+  }
+
   std::unique_ptr<sitos::RocksDBEngine> engine_;
   std::shared_ptr<GateState> gates_;
-  std::shared_ptr<bool> destroyed_;
+  std::shared_ptr<std::atomic<bool>> destroyed_;
 };
 
 class ScopedRoot {
@@ -192,14 +216,26 @@ class ThreadScope {
     threads_.emplace_back(std::forward<Function>(function));
   }
 
-  void Release() {
+  void ReleasePut() {
     {
       std::scoped_lock lock(gates_->mutex);
       gates_->block_put = false;
-      gates_->block_get = false;
+    }
+    gates_->condition.notify_all();
+  }
+
+  void ReleaseGetAndList() {
+    {
+      std::scoped_lock lock(gates_->mutex);
+      gates_->block_explicit_get = false;
       gates_->block_list = false;
     }
     gates_->condition.notify_all();
+  }
+
+  void Release() {
+    ReleasePut();
+    ReleaseGetAndList();
   }
 
   void JoinAll() {
@@ -219,8 +255,14 @@ bool WaitForMaterialization(std::chrono::milliseconds timeout,
                             const std::shared_ptr<GateState>& gates) {
   std::unique_lock lock(gates->mutex);
   return gates->condition.wait_for(lock, timeout, [&] {
-    return gates->put_entered > 0 && gates->get_entered > 0 && gates->list_entered > 0;
+    return gates->put_entered > 0 && gates->explicit_get_entered > 0 && gates->list_entered > 0;
   });
+}
+
+bool WaitForCompletion(std::chrono::milliseconds timeout, const std::shared_ptr<GateState>& gates,
+                       bool GateState::*completed) {
+  std::unique_lock lock(gates->mutex);
+  return gates->condition.wait_for(lock, timeout, [&] { return gates.get()->*completed; });
 }
 
 bool EnsureDirectory(const std::filesystem::path& path) {
@@ -237,7 +279,7 @@ TEST(RocksDBBufferLifecycleTest, CloseReleasesEngineBeforeReturn) {
   RocksDbTransport transport;
   ScopedRoot root("close");
   auto gates = std::make_shared<GateState>();
-  auto destroyed = std::make_shared<bool>(false);
+  auto destroyed = std::make_shared<std::atomic<bool>>(false);
   sitos::StorageNode node{transport};
   ASSERT_TRUE(node.Start(
       std::make_shared<sitos::InMemoryEngine>(),
@@ -250,35 +292,48 @@ TEST(RocksDBBufferLifecycleTest, CloseReleasesEngineBeforeReturn) {
              std::make_unique<BlockingRocksDbEngine>(std::move(opened).Value(), gates, destroyed));
        }}));
   ASSERT_TRUE(node.CreateSession("session", {.durable_buffers = true}).IsOk());
+  ASSERT_TRUE(transport.PutSample("sitos/buffers/session/durable/seed", {std::byte{3}}).IsOk());
   {
     std::scoped_lock lock(gates->mutex);
     gates->block_put = true;
-    gates->block_get = true;
+    gates->block_explicit_get = true;
     gates->block_list = true;
   }
 
   std::optional<sitos::Result<void>> put_result;
   std::optional<sitos::Result<void>> get_result;
   std::optional<sitos::Result<void>> list_result;
+  std::vector<Reply> get_replies;
+  std::vector<Reply> list_replies;
   ThreadScope threads(gates);
   threads.Start([&] {
-    put_result = transport.PutSample("sitos/buffers/session/durable/key", {std::byte{7}});
+    put_result = transport.PutSample("sitos/buffers/session/durable/written", {std::byte{7}});
   });
   threads.Start([&] {
     get_result = transport.Get(
-        "sitos/buffers/session/durable/key", [](auto, auto, auto) { return true; },
+        "sitos/buffers/session/durable/seed",
+        [&](std::string_view key, std::span<const std::byte> payload, sitos::Encoding encoding) {
+          get_replies.push_back(
+              {std::string(key), {payload.begin(), payload.end()}, std::move(encoding.id)});
+          return true;
+        },
         std::chrono::seconds(1));
   });
   threads.Start([&] {
     list_result = transport.Get(
-        "sitos/buffers/session/durable/**", [](auto, auto, auto) { return true; },
+        "sitos/buffers/session/durable/**",
+        [&](std::string_view key, std::span<const std::byte> payload, sitos::Encoding encoding) {
+          list_replies.push_back(
+              {std::string(key), {payload.begin(), payload.end()}, std::move(encoding.id)});
+          return true;
+        },
         std::chrono::seconds(1));
   });
 
   if (!WaitForMaterialization(std::chrono::seconds(5), gates)) {
     threads.Release();
     threads.JoinAll();
-    ADD_FAILURE() << "Put/Get/List did not all reach the real RocksDB barrier";
+    ADD_FAILURE() << "designated real-engine Put/Get/List operations did not all enter barriers";
     return;
   }
 
@@ -291,11 +346,28 @@ TEST(RocksDBBufferLifecycleTest, CloseReleasesEngineBeforeReturn) {
   const bool closing_seen =
       sitos::storage_node_test_access::StorageNodeTestAccess::WaitForClosing(node, "session");
   const bool close_done_while_blocked = close_done.load(std::memory_order_acquire);
-  threads.Release();
+
+  threads.ReleasePut();
+  if (!WaitForCompletion(std::chrono::seconds(5), gates, &GateState::put_completed)) {
+    threads.Release();
+    threads.JoinAll();
+    ADD_FAILURE() << "real RocksDB PUT did not complete after its gate was released";
+    return;
+  }
+  threads.ReleaseGetAndList();
   threads.JoinAll();
 
+  bool get_completed = false;
+  bool list_completed = false;
+  {
+    std::scoped_lock lock(gates->mutex);
+    get_completed = gates->explicit_get_completed;
+    list_completed = gates->list_completed;
+  }
   EXPECT_TRUE(closing_seen);
   EXPECT_FALSE(close_done_while_blocked);
+  EXPECT_TRUE(get_completed);
+  EXPECT_TRUE(list_completed);
   ASSERT_TRUE(put_result.has_value());
   ASSERT_TRUE(get_result.has_value());
   ASSERT_TRUE(list_result.has_value());
@@ -304,7 +376,24 @@ TEST(RocksDBBufferLifecycleTest, CloseReleasesEngineBeforeReturn) {
   EXPECT_TRUE(get_result->IsOk());
   EXPECT_TRUE(list_result->IsOk());
   EXPECT_TRUE(close_result->IsOk());
-  EXPECT_TRUE(*destroyed);
+  EXPECT_EQ(get_replies.size(), 1u);
+  ASSERT_EQ(get_replies.size(), 1u);
+  EXPECT_EQ(get_replies[0].key, "sitos/buffers/session/durable/seed");
+  EXPECT_EQ(get_replies[0].payload, (std::vector<std::byte>{std::byte{3}}));
+  EXPECT_EQ(get_replies[0].encoding, "zenoh/bytes");
+
+  std::map<std::string, Reply> listed;
+  for (const auto& reply : list_replies) {
+    ASSERT_TRUE(listed.emplace(reply.key, reply).second);
+  }
+  ASSERT_EQ(listed.size(), 2u);
+  EXPECT_EQ(listed.at("sitos/buffers/session/durable/seed").payload,
+            (std::vector<std::byte>{std::byte{3}}));
+  EXPECT_EQ(listed.at("sitos/buffers/session/durable/written").payload,
+            (std::vector<std::byte>{std::byte{7}}));
+  EXPECT_EQ(listed.at("sitos/buffers/session/durable/seed").encoding, "zenoh/bytes");
+  EXPECT_EQ(listed.at("sitos/buffers/session/durable/written").encoding, "zenoh/bytes");
+  EXPECT_TRUE(destroyed->load(std::memory_order_acquire));
   EXPECT_GT(std::filesystem::remove_all(root.Path()), 0u);
   EXPECT_FALSE(std::filesystem::exists(root.Path()));
 }
@@ -328,9 +417,9 @@ TEST(RocksDBBufferLifecycleTest, SameSidRecreationUsesFreshEngine) {
                  return sitos::Result<std::unique_ptr<sitos::StorageEngine>>::ErrFrom(opened);
                }
                return sitos::Result<std::unique_ptr<sitos::StorageEngine>>::Ok(
-                   std::make_unique<BlockingRocksDbEngine>(std::move(opened).Value(),
-                                                           std::make_shared<GateState>(),
-                                                           std::make_shared<bool>(false)));
+                   std::make_unique<BlockingRocksDbEngine>(
+                       std::move(opened).Value(), std::make_shared<GateState>(),
+                       std::make_shared<std::atomic<bool>>(false)));
              }}));
   ASSERT_TRUE(EnsureDirectory(first_root));
   ASSERT_TRUE(node.CreateSession("session", {.durable_buffers = true}).IsOk());

--- a/tests/integration/rocksdb_buffer_lifecycle_test.cpp
+++ b/tests/integration/rocksdb_buffer_lifecycle_test.cpp
@@ -1,114 +1,113 @@
-// Copyright 2026 sitos contributors
-// SPDX-License-Identifier: Apache-2.0
-
-#include "sitos/in_memory_engine.hpp"
-#include "sitos/rocksdb_engine.hpp"
-#include "sitos/storage_node.hpp"
-#include "sitos/transport.hpp"
-
-#include <gtest/gtest.h>
-
-#include <chrono>
-#include <cstddef>
-#include <filesystem>
-#include <functional>
-#include <memory>
-#include <string>
-#include <system_error>
-#include <utility>
-#include <vector>
-
-#include "transport/declaration_handle_test_access.hpp"
-
-namespace {
-
-class RocksDbTransport final : public sitos::Transport {
- public:
-  sitos::Result<void> Put(std::string_view, std::span<const std::byte>, sitos::Encoding,
-                          sitos::PutOptions) override {
-    return sitos::Result<void>::Ok();
-  }
-  sitos::Result<void> Delete(std::string_view, sitos::PutOptions) override {
-    return sitos::Result<void>::Ok();
-  }
-  sitos::Result<void> Get(std::string_view keyexpr, const QueryResultSink& sink,
-                          std::chrono::milliseconds) override {
-    auto query = sitos::TransportQuery::ForTesting(
-        [&](std::string_view key, std::span<const std::byte> payload, sitos::Encoding encoding) {
-          if (sink(key, payload, std::move(encoding))) return sitos::Result<void>::Ok();
-          return sitos::Result<void>::Err(std::make_error_code(std::errc::broken_pipe));
-        });
-    query.keyexpr = std::string(keyexpr);
-    if (queryable_) queryable_(query);
-    return sitos::Result<void>::Ok();
-  }
-  sitos::Result<sitos::Subscription> DeclareSubscriber(
-      std::string_view, std::function<void(const sitos::TransportSample&)> callback) override {
-    subscriber_ = std::move(callback);
-    return sitos::Result<sitos::Subscription>::Ok(
-        sitos::transport_test_access::DeclarationHandleTestAccess::MakeSubscription([] {}));
-  }
-  sitos::Result<sitos::Queryable> DeclareQueryable(
-      std::string_view, std::function<void(sitos::TransportQuery&)> callback) override {
-    queryable_ = std::move(callback);
-    return sitos::Result<sitos::Queryable>::Ok(
-        sitos::transport_test_access::DeclarationHandleTestAccess::MakeQueryable([] {}));
-  }
-
-  void PutSample(std::string key, std::vector<std::byte> payload) {
-    subscriber_(sitos::TransportSample{std::move(key), payload, {"zenoh/bytes"}, std::nullopt,
-                                       sitos::TransportSample::Kind::Put});
-  }
-
- private:
-  std::function<void(const sitos::TransportSample&)> subscriber_;
-  std::function<void(sitos::TransportQuery&)> queryable_;
-};
 
 TEST(RocksDBBufferLifecycleTest, CloseReleasesEngineBeforeReturn) {
   RocksDbTransport transport;
-  const auto root = std::filesystem::temp_directory_path() / "sitos-issue56-rocksdb-close";
-  std::filesystem::remove_all(root);
-  auto base = std::make_shared<sitos::InMemoryEngine>();
+  const auto root = UniqueRoot("close");
+  auto gates = std::make_shared<GateState>();
+  auto destroyed = std::make_shared<bool>(false);
   sitos::StorageNode node{transport};
   ASSERT_TRUE(node.Start(
-      base, {.prefix = "sitos",
-             .durable_buffer_engine_factory = [&](std::string_view) {
-               return sitos::RocksDBEngine::Open((root / "session").string());
-             }}));
+      std::make_shared<sitos::InMemoryEngine>(),
+      {.prefix = "sitos", .durable_buffer_engine_factory = [&](std::string_view sid) {
+         auto opened = sitos::RocksDBEngine::Open((root / std::string(sid)).string());
+         if (!opened.IsOk())
+           return sitos::Result<std::unique_ptr<sitos::StorageEngine>>::ErrFrom(opened);
+         return sitos::Result<std::unique_ptr<sitos::StorageEngine>>::Ok(
+             std::make_unique<BlockingRocksDbEngine>(std::move(opened).Value(), gates, destroyed));
+       }}));
   ASSERT_TRUE(node.CreateSession("session", {.durable_buffers = true}).IsOk());
-  transport.PutSample("sitos/buffers/session/durable/key", {std::byte{7}});
-  ASSERT_TRUE(node.CloseSession("session").IsOk());
+  gates->block_put = true;
+  gates->block_get = true;
+  gates->block_list = true;
+
+  std::thread put(
+      [&] { transport.PutSample("sitos/buffers/session/durable/key", {std::byte{7}}); });
+  std::thread get([&] {
+    transport.Get(
+        "sitos/buffers/session/durable/key", [](auto, auto, auto) { return true; },
+        std::chrono::seconds(1));
+  });
+  std::thread list([&] {
+    transport.Get(
+        "sitos/buffers/session/durable/**", [](auto, auto, auto) { return true; },
+        std::chrono::seconds(1));
+  });
+  {
+    std::unique_lock lock(gates->mutex);
+    gates->condition.wait(lock, [&] {
+      return gates->put_entered > 0 && gates->get_entered > 0 && gates->list_entered > 0;
+    });
+  }
+
+  std::optional<sitos::Result<void>> close_result;
+  std::atomic<bool> close_done = false;
+  std::thread close([&] {
+    close_result = node.CloseSession("session");
+    close_done.store(true, std::memory_order_release);
+  });
+  ASSERT_TRUE(
+      sitos::storage_node_test_access::StorageNodeTestAccess::WaitForClosing(node, "session"));
+  EXPECT_FALSE(close_done.load(std::memory_order_acquire));
+  {
+    std::scoped_lock lock(gates->mutex);
+    gates->block_put = false;
+    gates->block_get = false;
+    gates->block_list = false;
+  }
+  gates->condition.notify_all();
+  put.join();
+  get.join();
+  list.join();
+  close.join();
+  ASSERT_TRUE(close_result.has_value());
+  EXPECT_TRUE(close_result->IsOk());
+  EXPECT_TRUE(*destroyed);
   EXPECT_GT(std::filesystem::remove_all(root), 0u);
   EXPECT_FALSE(std::filesystem::exists(root));
 }
 
 TEST(RocksDBBufferLifecycleTest, SameSidRecreationUsesFreshEngine) {
   RocksDbTransport transport;
-  const auto root = std::filesystem::temp_directory_path() / "sitos-issue56-rocksdb-recreate";
-  std::filesystem::remove_all(root);
+  const auto root = UniqueRoot("recreate");
+  const auto first_root = root / "first";
+  const auto second_root = root / "second";
   auto base = std::make_shared<sitos::InMemoryEngine>();
+  std::vector<std::string> factory_sids;
   int factory_calls = 0;
   sitos::StorageNode node{transport};
   ASSERT_TRUE(node.Start(
-      base, {.prefix = "sitos",
-             .durable_buffer_engine_factory = [&](std::string_view) {
+      base, {.prefix = "sitos", .durable_buffer_engine_factory = [&](std::string_view sid) {
+               factory_sids.emplace_back(sid);
                ++factory_calls;
-               return sitos::RocksDBEngine::Open((root / ("session-" + std::to_string(factory_calls))).string());
+               const auto path = factory_calls == 1 ? first_root : second_root;
+               auto opened = sitos::RocksDBEngine::Open((path / std::string(sid)).string());
+               if (!opened.IsOk())
+                 return sitos::Result<std::unique_ptr<sitos::StorageEngine>>::ErrFrom(opened);
+               return sitos::Result<std::unique_ptr<sitos::StorageEngine>>::Ok(
+                   std::make_unique<BlockingRocksDbEngine>(std::move(opened).Value(),
+                                                           std::make_shared<GateState>(),
+                                                           std::make_shared<bool>(false)));
              }}));
   ASSERT_TRUE(node.CreateSession("session", {.durable_buffers = true}).IsOk());
   transport.PutSample("sitos/buffers/session/durable/key", {std::byte{7}});
   ASSERT_TRUE(node.CloseSession("session").IsOk());
-  ASSERT_TRUE(node.CreateSession("session", {.durable_buffers = true}).IsOk());
-  EXPECT_EQ(factory_calls, 2);
-  EXPECT_EQ(transport.Get("sitos/buffers/session/durable/key",
-                          [](std::string_view, std::span<const std::byte>, sitos::Encoding) {
-                            return true;
-                          },
-                          std::chrono::milliseconds(500))
-                .IsOk());
-  EXPECT_TRUE(node.CloseSession("session").IsOk());
-  std::filesystem::remove_all(root);
-}
+  EXPECT_GT(std::filesystem::remove_all(first_root), 0u);
+  EXPECT_FALSE(std::filesystem::exists(first_root));
 
-}  // namespace
+  ASSERT_TRUE(node.CreateSession("session", {.durable_buffers = true}).IsOk());
+  int replies = 0;
+  ASSERT_TRUE(transport
+                  .Get(
+                      "sitos/buffers/session/durable/key",
+                      [&](std::string_view, std::span<const std::byte>, sitos::Encoding) {
+                        ++replies;
+                        return true;
+                      },
+                      std::chrono::milliseconds(500))
+                  .IsOk());
+  EXPECT_EQ(factory_calls, 2);
+  EXPECT_EQ(factory_sids, (std::vector<std::string>{"session", "session"}));
+  EXPECT_EQ(replies, 0);
+  ASSERT_TRUE(node.CloseSession("session").IsOk());
+  EXPECT_GT(std::filesystem::remove_all(second_root), 0u);
+  EXPECT_FALSE(std::filesystem::exists(second_root));
+}

--- a/tests/integration/rocksdb_buffer_lifecycle_test.cpp
+++ b/tests/integration/rocksdb_buffer_lifecycle_test.cpp
@@ -226,10 +226,17 @@ class ThreadScope {
     gates_->condition.notify_all();
   }
 
-  void ReleaseGetAndList() {
+  void ReleaseGet() {
     {
       std::scoped_lock lock(gates_->mutex);
       gates_->block_explicit_get = false;
+    }
+    gates_->condition.notify_all();
+  }
+
+  void ReleaseList() {
+    {
+      std::scoped_lock lock(gates_->mutex);
       gates_->block_list = false;
     }
     gates_->condition.notify_all();
@@ -237,7 +244,8 @@ class ThreadScope {
 
   void Release() {
     ReleasePut();
-    ReleaseGetAndList();
+    ReleaseGet();
+    ReleaseList();
   }
 
   void JoinAll() {
@@ -354,8 +362,11 @@ TEST(RocksDBBufferLifecycleTest, CloseReleasesEngineBeforeReturn) {
 
   std::optional<sitos::Result<void>> close_result;
   std::atomic<bool> close_done = false;
+  std::atomic<bool> destroyed_at_close_return = false;
   threads.Start([&] {
     close_result = node.CloseSession("session");
+    destroyed_at_close_return.store(destroyed->load(std::memory_order_acquire),
+                                    std::memory_order_release);
     close_done.store(true, std::memory_order_release);
   });
   const bool closing_seen =
@@ -369,7 +380,30 @@ TEST(RocksDBBufferLifecycleTest, CloseReleasesEngineBeforeReturn) {
     ADD_FAILURE() << "real RocksDB PUT did not complete after its gate was released";
     return;
   }
-  threads.ReleaseGetAndList();
+  const bool close_done_after_put = close_done.load(std::memory_order_acquire);
+  const bool destroyed_after_put = destroyed->load(std::memory_order_acquire);
+  EXPECT_FALSE(close_done_after_put);
+  EXPECT_FALSE(destroyed_after_put);
+
+  threads.ReleaseGet();
+  if (!WaitForCompletion(std::chrono::seconds(5), gates, &GateState::explicit_get_completed)) {
+    threads.Release();
+    threads.JoinAll();
+    ADD_FAILURE() << "designated RocksDB Get did not complete after its gate was released";
+    return;
+  }
+  const bool close_done_after_get = close_done.load(std::memory_order_acquire);
+  const bool destroyed_after_get = destroyed->load(std::memory_order_acquire);
+  EXPECT_FALSE(close_done_after_get);
+  EXPECT_FALSE(destroyed_after_get);
+
+  threads.ReleaseList();
+  if (!WaitForCompletion(std::chrono::seconds(5), gates, &GateState::list_completed)) {
+    threads.Release();
+    threads.JoinAll();
+    ADD_FAILURE() << "designated RocksDB List did not complete after its gate was released";
+    return;
+  }
   threads.JoinAll();
 
   bool get_completed = false;
@@ -391,6 +425,7 @@ TEST(RocksDBBufferLifecycleTest, CloseReleasesEngineBeforeReturn) {
   EXPECT_TRUE(get_result->IsOk());
   EXPECT_TRUE(list_result->IsOk());
   EXPECT_TRUE(close_result->IsOk());
+  EXPECT_TRUE(destroyed_at_close_return.load(std::memory_order_acquire));
   EXPECT_EQ(get_replies.size(), 1u);
   ASSERT_EQ(get_replies.size(), 1u);
   EXPECT_EQ(get_replies[0].key, "sitos/buffers/session/durable/seed");

--- a/tests/integration/rocksdb_buffer_lifecycle_test.cpp
+++ b/tests/integration/rocksdb_buffer_lifecycle_test.cpp
@@ -112,9 +112,9 @@ class BlockingRocksDbEngine final : public sitos::StorageEngine {
   ~BlockingRocksDbEngine() override { destroyed_->store(true, std::memory_order_release); }
 
   bool Put(std::string_view key, sitos::Bytes value) override {
-    Wait(gates_->block_put, gates_->put_entered);
+    const bool tracked = Wait(gates_->block_put, gates_->put_entered);
     const bool result = engine_->Put(key, value);
-    Complete(gates_->put_completed);
+    if (tracked) Complete(gates_->put_completed);
     return result;
   }
 
@@ -122,16 +122,17 @@ class BlockingRocksDbEngine final : public sitos::StorageEngine {
 
   bool Get(std::string_view key, const sitos::EntrySink& sink) const override {
     const bool designated = key == "seed";
-    if (designated) Wait(gates_->block_explicit_get, gates_->explicit_get_entered);
+    const bool tracked =
+        designated && Wait(gates_->block_explicit_get, gates_->explicit_get_entered);
     const bool result = engine_->Get(key, sink);
-    if (designated) Complete(gates_->explicit_get_completed);
+    if (tracked) Complete(gates_->explicit_get_completed);
     return result;
   }
 
   bool List(std::string_view prefix, const sitos::EntrySink& sink) const override {
-    Wait(gates_->block_list, gates_->list_entered);
+    const bool tracked = Wait(gates_->block_list, gates_->list_entered);
     const bool result = engine_->List(prefix, sink);
-    Complete(gates_->list_completed);
+    if (tracked) Complete(gates_->list_completed);
     return result;
   }
 
@@ -140,12 +141,13 @@ class BlockingRocksDbEngine final : public sitos::StorageEngine {
   }
 
  private:
-  void Wait(bool& blocked, int& entered) const {
+  bool Wait(bool& blocked, int& entered) const {
     std::unique_lock lock(gates_->mutex);
-    if (!blocked) return;
+    if (!blocked) return false;
     ++entered;
     gates_->condition.notify_all();
     gates_->condition.wait(lock, [&] { return !blocked; });
+    return true;
   }
 
   void Complete(bool& completed) const {
@@ -336,6 +338,19 @@ TEST(RocksDBBufferLifecycleTest, CloseReleasesEngineBeforeReturn) {
     ADD_FAILURE() << "designated real-engine Put/Get/List operations did not all enter barriers";
     return;
   }
+
+  bool put_completed_before_workers = false;
+  bool get_completed_before_workers = false;
+  bool list_completed_before_workers = false;
+  {
+    std::scoped_lock lock(gates->mutex);
+    put_completed_before_workers = gates->put_completed;
+    get_completed_before_workers = gates->explicit_get_completed;
+    list_completed_before_workers = gates->list_completed;
+  }
+  EXPECT_FALSE(put_completed_before_workers);
+  EXPECT_FALSE(get_completed_before_workers);
+  EXPECT_FALSE(list_completed_before_workers);
 
   std::optional<sitos::Result<void>> close_result;
   std::atomic<bool> close_done = false;

--- a/tests/interop/raw_zenoh_buffer_fixture.cpp
+++ b/tests/interop/raw_zenoh_buffer_fixture.cpp
@@ -1,0 +1,190 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <chrono>
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "sitos/in_memory_engine.hpp"
+#include "sitos/param_store.hpp"
+#include "sitos/status.hpp"
+#include "sitos/storage_node.hpp"
+#include "sitos/transport.hpp"
+
+namespace {
+
+using namespace std::chrono_literals;
+
+template <typename T>
+void ReportStartupFailure(std::string_view stage, const sitos::Result<T>& result) {
+  std::cerr << stage << " failed: status=" << static_cast<int>(result.StatusCode());
+  if (!result.Message().empty()) std::cerr << ", message=" << result.Message();
+  const auto& cause = result.Error();
+  if (cause) {
+    std::cerr << ", cause=" << cause.category().name() << ':' << cause.value() << ' '
+              << cause.message();
+  }
+  std::cerr << '\n';
+}
+
+class Protocol final {
+ public:
+  void Reply(std::string_view line) { std::cout << line << std::endl; }
+
+  void Error(std::string_view operation, std::string_view message) {
+    std::cout << "ERROR " << operation << " " << message << std::endl;
+  }
+};
+
+bool PutDpAndConfirm(sitos::ParamStore& store, std::string_view key, double value) {
+  const auto deadline = std::chrono::steady_clock::now() + 5s;
+  while (std::chrono::steady_clock::now() < deadline) {
+    const auto put = store.Put("base", key, value);
+    if (!put.IsOk()) return false;
+    const auto observed = store.Get<double>("base", key);
+    if (observed.IsOk()) return observed.Value() == value;
+    if (observed.StatusCode() != sitos::Status::NotFound) return false;
+  }
+  return false;
+}
+
+bool HandlePutDp(std::istringstream& input, sitos::ParamStore& store, Protocol& protocol) {
+  std::string key;
+  double value = 0.0;
+  std::string trailing;
+  if (!(input >> key >> value) || (input >> trailing) || !std::isfinite(value)) {
+    protocol.Error("PUT_DP", "invalid arguments");
+    return true;
+  }
+  if (!PutDpAndConfirm(store, key, value)) {
+    protocol.Error("PUT_DP", "write was not observed before the deadline");
+    return true;
+  }
+  protocol.Reply("PUT_OK " + key);
+  return true;
+}
+
+bool HandleCreateSession(std::istringstream& input, sitos::StorageNode& node,
+                         Protocol& protocol) {
+  std::string session_id;
+  std::string trailing;
+  if (!(input >> session_id) || (input >> trailing)) {
+    protocol.Error("CREATE_SESSION", "invalid arguments");
+    return true;
+  }
+  const auto created = node.CreateSession(session_id);
+  if (!created.IsOk()) {
+    protocol.Error("CREATE_SESSION", created.Message());
+    return true;
+  }
+  protocol.Reply("SESSION_OK " + session_id);
+  return true;
+}
+
+bool HandleCreateBufferSession(std::istringstream& input, sitos::StorageNode& node,
+                               Protocol& protocol) {
+  std::string session_id;
+  std::string mode = "both";
+  std::string trailing;
+  if (!(input >> session_id)) {
+    protocol.Error("CREATE_BUFFER_SESSION", "invalid arguments");
+    return true;
+  }
+  if (input >> mode && input >> trailing) {
+    protocol.Error("CREATE_BUFFER_SESSION", "invalid arguments");
+    return true;
+  }
+  sitos::SessionOptions options;
+  if (mode == "durable") {
+    options.durable_buffers = true;
+  } else if (mode == "ephemeral") {
+    options.ephemeral_buffers = true;
+  } else if (mode == "both") {
+    options.durable_buffers = true;
+    options.ephemeral_buffers = true;
+  } else if (mode != "none") {
+    protocol.Error("CREATE_BUFFER_SESSION", "invalid mode");
+    return true;
+  }
+  const auto created = node.CreateSession(session_id, options);
+  if (!created.IsOk()) {
+    protocol.Error("CREATE_BUFFER_SESSION", created.Message());
+    return true;
+  }
+  protocol.Reply("BUFFER_SESSION_OK " + session_id);
+  return true;
+}
+
+bool HandleCommand(std::string_view command, sitos::ParamStore& store,
+                   sitos::StorageNode& node, Protocol& protocol) {
+  std::istringstream input{std::string(command)};
+  std::string operation;
+  input >> operation;
+  if (operation == "PUT_DP") return HandlePutDp(input, store, protocol);
+  if (operation == "CREATE_SESSION") return HandleCreateSession(input, node, protocol);
+  if (operation == "CREATE_BUFFER_SESSION") {
+    return HandleCreateBufferSession(input, node, protocol);
+  }
+  if (operation == "STOP") {
+    protocol.Reply("STOPPED");
+    return false;
+  }
+  protocol.Error(operation.empty() ? "COMMAND" : operation, "unsupported command");
+  return true;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  if (argc != 3) return 2;
+  const std::string prefix = argv[1];
+  const std::string port = argv[2];
+  const std::string config =
+      "{mode: 'peer', listen: {endpoints: ['tcp/127.0.0.1:" + port +
+      "']}, scouting: {multicast: {enabled: false}}}";
+
+  auto transport_result = sitos::OpenZenohTransport(config);
+  if (!transport_result.IsOk()) {
+    ReportStartupFailure("OpenZenohTransport", transport_result);
+    return 3;
+  }
+  std::shared_ptr<sitos::Transport> transport(std::move(transport_result).Value());
+  auto engine = std::make_shared<sitos::InMemoryEngine>();
+  sitos::StorageNode node(*transport);
+  const auto start_result = node.Start(
+      engine, {.prefix = prefix,
+               .log_sink = nullptr,
+               .durable_buffer_engine_factory = [](std::string_view) {
+                 return sitos::Result<std::unique_ptr<sitos::StorageEngine>>::Ok(
+                     std::make_unique<sitos::InMemoryEngine>());
+               }});
+  if (!start_result.IsOk()) {
+    ReportStartupFailure("StorageNode::Start", start_result);
+    return 4;
+  }
+
+  sitos::ClientConfig client_config;
+  client_config.prefix = prefix;
+  client_config.query_timeout = 250ms;
+  client_config.log_sink = nullptr;
+  auto store_result = sitos::ParamStore::Open(transport, std::move(client_config));
+  if (!store_result.IsOk()) {
+    ReportStartupFailure("ParamStore::Open", store_result);
+    node.Stop();
+    return 5;
+  }
+  auto store = std::move(store_result).Value();
+
+  Protocol protocol;
+  protocol.Reply("READY " + prefix + " " + port);
+  std::string command;
+  while (std::getline(std::cin, command) && HandleCommand(command, store, node, protocol)) {
+  }
+  node.Stop();
+  return 0;
+}

--- a/tests/interop/raw_zenoh_buffer_fixture.cpp
+++ b/tests/interop/raw_zenoh_buffer_fixture.cpp
@@ -47,6 +47,31 @@ class Protocol final {
   }
 };
 
+class DurableRootCleanup final {
+ public:
+  explicit DurableRootCleanup(std::filesystem::path root) : root_(std::move(root)) {}
+
+  ~DurableRootCleanup() {
+    if (active_) {
+      std::error_code error;
+      std::filesystem::remove_all(root_, error);
+    }
+  }
+
+  bool Cleanup(std::error_code& error) noexcept {
+    if (!active_) return true;
+    std::filesystem::remove_all(root_, error);
+    if (!error) active_ = false;
+    return !error;
+  }
+
+  void Dismiss() noexcept { active_ = false; }
+
+ private:
+  std::filesystem::path root_;
+  bool active_ = true;
+};
+
 bool PutDpAndConfirm(sitos::ParamStore& store, std::string_view key, double value) {
   const auto deadline = std::chrono::steady_clock::now() + 5s;
   while (std::chrono::steady_clock::now() < deadline) {
@@ -200,6 +225,7 @@ int main(int argc, char** argv) {
               << (cleanup_error ? cleanup_error.message() : "not a directory") << '\n';
     return 6;
   }
+  DurableRootCleanup durable_root_cleanup(durable_root);
   sitos::StorageNode node(*transport);
   const auto start_result = node.Start(
       engine, {.prefix = prefix,
@@ -249,5 +275,6 @@ int main(int argc, char** argv) {
     std::cerr << "durable root final cleanup failed: " << cleanup_error.message() << '\n';
     return 6;
   }
+  durable_root_cleanup.Dismiss();
   return 0;
 }

--- a/tests/interop/raw_zenoh_buffer_fixture.cpp
+++ b/tests/interop/raw_zenoh_buffer_fixture.cpp
@@ -3,15 +3,21 @@
 
 #include <chrono>
 #include <cmath>
+#include <filesystem>
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <utility>
 
 #include "sitos/in_memory_engine.hpp"
 #include "sitos/param_store.hpp"
+#if defined(SITOS_WITH_ROCKSDB)
+#include "sitos/rocksdb_engine.hpp"
+#endif
 #include "sitos/status.hpp"
 #include "sitos/storage_node.hpp"
 #include "sitos/transport.hpp"
@@ -69,8 +75,7 @@ bool HandlePutDp(std::istringstream& input, sitos::ParamStore& store, Protocol& 
   return true;
 }
 
-bool HandleCreateSession(std::istringstream& input, sitos::StorageNode& node,
-                         Protocol& protocol) {
+bool HandleCreateSession(std::istringstream& input, sitos::StorageNode& node, Protocol& protocol) {
   std::string session_id;
   std::string trailing;
   if (!(input >> session_id) || (input >> trailing)) {
@@ -120,8 +125,31 @@ bool HandleCreateBufferSession(std::istringstream& input, sitos::StorageNode& no
   return true;
 }
 
-bool HandleCommand(std::string_view command, sitos::ParamStore& store,
-                   sitos::StorageNode& node, Protocol& protocol) {
+bool HandleCloseSession(std::istringstream& input, sitos::StorageNode& node,
+                        const std::filesystem::path& durable_root, Protocol& protocol) {
+  std::string session_id;
+  std::string trailing;
+  if (!(input >> session_id) || (input >> trailing)) {
+    protocol.Error("CLOSE_SESSION", "invalid arguments");
+    return true;
+  }
+  const auto closed = node.CloseSession(session_id);
+  if (!closed.IsOk()) {
+    protocol.Error("CLOSE_SESSION", closed.Message());
+    return true;
+  }
+  std::error_code error;
+  std::filesystem::remove_all(durable_root / session_id, error);
+  if (error) {
+    protocol.Error("CLOSE_SESSION", error.message());
+    return true;
+  }
+  protocol.Reply("CLOSED " + session_id);
+  return true;
+}
+
+bool HandleCommand(std::string_view command, sitos::ParamStore& store, sitos::StorageNode& node,
+                   const std::filesystem::path& durable_root, Protocol& protocol) {
   std::istringstream input{std::string(command)};
   std::string operation;
   input >> operation;
@@ -129,6 +157,9 @@ bool HandleCommand(std::string_view command, sitos::ParamStore& store,
   if (operation == "CREATE_SESSION") return HandleCreateSession(input, node, protocol);
   if (operation == "CREATE_BUFFER_SESSION") {
     return HandleCreateBufferSession(input, node, protocol);
+  }
+  if (operation == "CLOSE_SESSION") {
+    return HandleCloseSession(input, node, durable_root, protocol);
   }
   if (operation == "STOP") {
     protocol.Reply("STOPPED");
@@ -144,9 +175,8 @@ int main(int argc, char** argv) {
   if (argc != 3) return 2;
   const std::string prefix = argv[1];
   const std::string port = argv[2];
-  const std::string config =
-      "{mode: 'peer', listen: {endpoints: ['tcp/127.0.0.1:" + port +
-      "']}, scouting: {multicast: {enabled: false}}}";
+  const std::string config = "{mode: 'peer', listen: {endpoints: ['tcp/127.0.0.1:" + port +
+                             "']}, scouting: {multicast: {enabled: false}}}";
 
   auto transport_result = sitos::OpenZenohTransport(config);
   if (!transport_result.IsOk()) {
@@ -155,13 +185,22 @@ int main(int argc, char** argv) {
   }
   std::shared_ptr<sitos::Transport> transport(std::move(transport_result).Value());
   auto engine = std::make_shared<sitos::InMemoryEngine>();
+  const auto durable_root = std::filesystem::temp_directory_path() /
+                            ("sitos-buffer-" + std::to_string(std::hash<std::string>{}(prefix)));
+  std::error_code cleanup_error;
+  std::filesystem::remove_all(durable_root, cleanup_error);
   sitos::StorageNode node(*transport);
   const auto start_result = node.Start(
       engine, {.prefix = prefix,
                .log_sink = nullptr,
-               .durable_buffer_engine_factory = [](std::string_view) {
+               .durable_buffer_engine_factory = [durable_root](std::string_view sid) {
+#if defined(SITOS_WITH_ROCKSDB)
+                 return sitos::RocksDBEngine::Open((durable_root / std::string(sid)).string());
+#else
+                 static_cast<void>(sid);
                  return sitos::Result<std::unique_ptr<sitos::StorageEngine>>::Ok(
                      std::make_unique<sitos::InMemoryEngine>());
+#endif
                }});
   if (!start_result.IsOk()) {
     ReportStartupFailure("StorageNode::Start", start_result);
@@ -183,8 +222,10 @@ int main(int argc, char** argv) {
   Protocol protocol;
   protocol.Reply("READY " + prefix + " " + port);
   std::string command;
-  while (std::getline(std::cin, command) && HandleCommand(command, store, node, protocol)) {
+  while (std::getline(std::cin, command) &&
+         HandleCommand(command, store, node, durable_root, protocol)) {
   }
   node.Stop();
+  std::filesystem::remove_all(durable_root, cleanup_error);
   return 0;
 }

--- a/tests/interop/raw_zenoh_buffer_fixture.cpp
+++ b/tests/interop/raw_zenoh_buffer_fixture.cpp
@@ -189,13 +189,30 @@ int main(int argc, char** argv) {
                             ("sitos-buffer-" + std::to_string(std::hash<std::string>{}(prefix)));
   std::error_code cleanup_error;
   std::filesystem::remove_all(durable_root, cleanup_error);
+  if (cleanup_error) {
+    std::cerr << "durable root cleanup failed: " << cleanup_error.message() << '\n';
+    return 6;
+  }
+  std::filesystem::create_directories(durable_root, cleanup_error);
+  if (cleanup_error || !std::filesystem::is_directory(durable_root, cleanup_error) ||
+      cleanup_error) {
+    std::cerr << "durable root creation failed: "
+              << (cleanup_error ? cleanup_error.message() : "not a directory") << '\n';
+    return 6;
+  }
   sitos::StorageNode node(*transport);
   const auto start_result = node.Start(
       engine, {.prefix = prefix,
                .log_sink = nullptr,
                .durable_buffer_engine_factory = [durable_root](std::string_view sid) {
 #if defined(SITOS_WITH_ROCKSDB)
-                 return sitos::RocksDBEngine::Open((durable_root / std::string(sid)).string());
+                 auto opened =
+                     sitos::RocksDBEngine::Open((durable_root / std::string(sid)).string());
+                 if (!opened.IsOk()) {
+                   return sitos::Result<std::unique_ptr<sitos::StorageEngine>>::ErrFrom(opened);
+                 }
+                 return sitos::Result<std::unique_ptr<sitos::StorageEngine>>::Ok(
+                     std::unique_ptr<sitos::StorageEngine>(std::move(opened).Value()));
 #else
                  static_cast<void>(sid);
                  return sitos::Result<std::unique_ptr<sitos::StorageEngine>>::Ok(
@@ -226,6 +243,11 @@ int main(int argc, char** argv) {
          HandleCommand(command, store, node, durable_root, protocol)) {
   }
   node.Stop();
+  cleanup_error.clear();
   std::filesystem::remove_all(durable_root, cleanup_error);
+  if (cleanup_error) {
+    std::cerr << "durable root final cleanup failed: " << cleanup_error.message() << '\n';
+    return 6;
+  }
   return 0;
 }

--- a/tests/interop/raw_zenoh_test_support.py
+++ b/tests/interop/raw_zenoh_test_support.py
@@ -187,6 +187,10 @@ class FixtureProcess:
         )
         return sid
 
+    def close_session(self, session_id: str | None = None) -> None:
+        sid = self.session_id if session_id is None else session_id
+        self.command(f"CLOSE_SESSION {sid}", f"CLOSED {sid}")
+
     def open_raw_session(self) -> zenoh.Session:
         config = zenoh.Config.from_json5(
             json.dumps(

--- a/tests/interop/raw_zenoh_test_support.py
+++ b/tests/interop/raw_zenoh_test_support.py
@@ -176,6 +176,17 @@ class FixtureProcess:
             f"CREATE_SESSION {self.session_id}", f"SESSION_OK {self.session_id}"
         )
 
+    def create_buffer_session(
+        self, session_id: str | None = None, mode: str = "both"
+    ) -> str:
+        sid = self.session_id if session_id is None else session_id
+        suffix = "" if mode == "both" else f" {mode}"
+        self.command(
+            f"CREATE_BUFFER_SESSION {sid}{suffix}",
+            f"BUFFER_SESSION_OK {sid}",
+        )
+        return sid
+
     def open_raw_session(self) -> zenoh.Session:
         config = zenoh.Config.from_json5(
             json.dumps(

--- a/tests/interop/test_raw_zenoh_buffer.py
+++ b/tests/interop/test_raw_zenoh_buffer.py
@@ -96,6 +96,20 @@ def test_raw_zenoh_client_can_use_mixed_session_buffers() -> None:
                         b"preview",
                         encoding=zenoh.Encoding("zenoh/bytes"),
                     )
+                post_conflict_completion_key = (
+                    f"{fixture.prefix}/buffers/{session_ids['both']}/durable/post_conflict_completion"
+                )
+                post_conflict_completion_payload = b"post-conflict-completion"
+                session.put(
+                    post_conflict_completion_key,
+                    post_conflict_completion_payload,
+                    encoding=zenoh.Encoding("zenoh/bytes"),
+                )
+                _wait_for_payload(
+                    session,
+                    post_conflict_completion_key,
+                    post_conflict_completion_payload,
+                )
                 for mode in ("durable", "both"):
                     _wait_for_payload(
                         session,
@@ -179,13 +193,16 @@ def test_raw_zenoh_durable_late_join_preserves_distinct_keys() -> None:
             )
         with fixture.open_raw_session() as late:
             replies = _query(late, f"{fixture.prefix}/buffers/{fixture.session_id}/durable/**")
-            assert {reply.key for reply in replies} == {
-                f"{fixture.prefix}/buffers/{fixture.session_id}/durable/a",
-                f"{fixture.prefix}/buffers/{fixture.session_id}/durable/b",
+            assert len(replies) == 2
+            expected = {
+                f"{fixture.prefix}/buffers/{fixture.session_id}/durable/a": (b"a", "zenoh/bytes"),
+                f"{fixture.prefix}/buffers/{fixture.session_id}/durable/b": (b"b", "zenoh/bytes"),
             }
+            actual: dict[str, tuple[bytes, str]] = {}
             for reply in replies:
-                assert reply.encoding == "zenoh/bytes"
-                assert reply.payload == reply.key.rsplit("/", maxsplit=1)[-1].encode()
+                assert reply.key not in actual, f"duplicate durable reply: {reply.key}"
+                actual[reply.key] = (reply.payload, reply.encoding)
+            assert actual == expected
 
 
 def test_raw_zenoh_buffer_interop_fixture_boundaries() -> None:

--- a/tests/interop/test_raw_zenoh_buffer.py
+++ b/tests/interop/test_raw_zenoh_buffer.py
@@ -41,13 +41,16 @@ def test_raw_zenoh_client_can_use_mixed_session_buffers() -> None:
         with fixture.open_raw_session() as session:
             marker_observed = threading.Event()
             live_observed = threading.Event()
+            observed_samples: list[support.WireSample] = []
             live_key = f"{fixture.prefix}/buffers/{session_ids['both']}/ephemeral/live"
             marker_key = f"{fixture.prefix}/buffers/{session_ids['both']}/ephemeral/marker"
 
             def observe(sample: zenoh.Sample) -> None:
-                if str(sample.key_expr) == marker_key:
+                copied = support.copy_sample(sample)
+                observed_samples.append(copied)
+                if copied.key == marker_key:
                     marker_observed.set()
-                if str(sample.key_expr) == live_key:
+                if copied.key == live_key:
                     live_observed.set()
 
             subscriber = session.declare_subscriber(
@@ -62,6 +65,16 @@ def test_raw_zenoh_client_can_use_mixed_session_buffers() -> None:
                     session.put(
                         durable_key,
                         mode.encode(),
+                        encoding=zenoh.Encoding("zenoh/bytes"),
+                    )
+                    session.put(
+                        durable_key,
+                        mode.encode(),
+                        encoding=zenoh.Encoding("zenoh/bytes"),
+                    )
+                    session.put(
+                        durable_key,
+                        b"conflicting-bytes",
                         encoding=zenoh.Encoding("zenoh/bytes"),
                     )
                     session.put(
@@ -111,6 +124,14 @@ def test_raw_zenoh_client_can_use_mixed_session_buffers() -> None:
                     encoding=zenoh.Encoding("zenoh/bytes"),
                 )
                 assert live_observed.wait(5.0)
+                live_samples = [sample for sample in observed_samples if sample.key == live_key]
+                assert live_samples
+                support.assert_wire_sample(
+                    live_samples[-1],
+                    expected_key=live_key,
+                    expected_payload=b"live-preview",
+                    expected_encoding="zenoh/bytes",
+                )
             finally:
                 subscriber.undeclare()
 
@@ -130,17 +151,43 @@ def test_raw_zenoh_durable_late_join_preserves_distinct_keys() -> None:
                 f"{fixture.prefix}/buffers/{fixture.session_id}/durable/a",
                 b"a",
             )
-            with fixture.open_raw_session() as late:
-                replies = _query(late, f"{fixture.prefix}/buffers/{fixture.session_id}/durable/**")
-                assert {reply.key for reply in replies} == {
-                    f"{fixture.prefix}/buffers/{fixture.session_id}/durable/a",
-                    f"{fixture.prefix}/buffers/{fixture.session_id}/durable/b",
-                }
-                for reply in replies:
-                    assert reply.encoding == "zenoh/bytes"
-                    assert reply.payload == reply.key.rsplit("/", maxsplit=1)[-1].encode()
+        with fixture.open_raw_session() as late:
+            replies = _query(late, f"{fixture.prefix}/buffers/{fixture.session_id}/durable/**")
+            assert {reply.key for reply in replies} == {
+                f"{fixture.prefix}/buffers/{fixture.session_id}/durable/a",
+                f"{fixture.prefix}/buffers/{fixture.session_id}/durable/b",
+            }
+            for reply in replies:
+                assert reply.encoding == "zenoh/bytes"
+                assert reply.payload == reply.key.rsplit("/", maxsplit=1)[-1].encode()
 
 
 def test_raw_zenoh_buffer_interop_fixture_boundaries() -> None:
+    import importlib.util
+    from pathlib import Path
+
+    validator_path = Path(__file__).parents[2] / "scripts" / "check_wheel.py"
+    spec = importlib.util.spec_from_file_location("sitos_check_wheel", validator_path)
+    assert spec is not None and spec.loader is not None
+    validator = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(validator)
+    for member in (
+        "sitos/sitos_raw_zenoh_buffer_fixture",
+        "sitos/sitos_raw_zenoh_buffer_fixture.exe",
+    ):
+        with pytest.raises(RuntimeError, match="forbidden wheel entry"):
+            validator.validate_wheel_members([member])
+
     with support.FixtureProcess() as fixture:
         fixture.create_buffer_session()
+        fixture.command(
+            f"CREATE_BUFFER_SESSION {fixture.session_id} invalid",
+            "ERROR CREATE_BUFFER_SESSION invalid mode",
+        )
+        with fixture.open_raw_session() as session:
+            closed_key = f"{fixture.prefix}/buffers/{fixture.session_id}/durable/closed"
+            session.put(closed_key, b"before-close", encoding=zenoh.Encoding("zenoh/bytes"))
+            _wait_for_payload(session, closed_key, b"before-close")
+        fixture.close_session()
+        with fixture.open_raw_session() as session:
+            assert _query(session, closed_key) == []

--- a/tests/interop/test_raw_zenoh_buffer.py
+++ b/tests/interop/test_raw_zenoh_buffer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+import time
 
 import pytest
 import zenoh
@@ -22,14 +23,27 @@ def _query(session: zenoh.Session, key: str) -> list[support.WireSample]:
 
 
 def _wait_for_payload(session: zenoh.Session, key: str, payload: bytes) -> None:
-    replies = _query(session, key)
-    assert len(replies) == 1, f"buffer value was not queryable: {key}"
-    support.assert_wire_sample(
-        replies[0],
-        expected_key=key,
-        expected_payload=payload,
-        expected_encoding="zenoh/bytes",
-    )
+    deadline = time.monotonic() + 5.0
+    last_diagnostic = "no query replies"
+    while time.monotonic() < deadline:
+        try:
+            replies = _query(session, key)
+            if len(replies) == 1:
+                try:
+                    support.assert_wire_sample(
+                        replies[0],
+                        expected_key=key,
+                        expected_payload=payload,
+                        expected_encoding="zenoh/bytes",
+                    )
+                    return
+                except AssertionError as error:
+                    last_diagnostic = str(error)
+            else:
+                last_diagnostic = f"expected one reply, got {len(replies)}"
+        except Exception as error:  # pragma: no cover - diagnostic for transient transport state
+            last_diagnostic = str(error)
+    raise AssertionError(f"buffer value was not queryable before deadline: {key}: {last_diagnostic}")
 
 
 def test_raw_zenoh_client_can_use_mixed_session_buffers() -> None:
@@ -82,6 +96,12 @@ def test_raw_zenoh_client_can_use_mixed_session_buffers() -> None:
                         b"preview",
                         encoding=zenoh.Encoding("zenoh/bytes"),
                     )
+                for mode in ("durable", "both"):
+                    _wait_for_payload(
+                        session,
+                        f"{fixture.prefix}/buffers/{session_ids[mode]}/durable/official",
+                        mode.encode(),
+                    )
                 durable_replies = {
                     mode: _query(
                         session,
@@ -107,9 +127,10 @@ def test_raw_zenoh_client_can_use_mixed_session_buffers() -> None:
                     ) == []
                 invalid_key = f"{fixture.prefix}/buffers/{session_ids['both']}/durable/invalid"
                 session.put(invalid_key, b"invalid", encoding=zenoh.Encoding("zenoh/bytes;sitos.v1"))
-                assert _query(session, invalid_key) == []
                 empty_key = f"{fixture.prefix}/buffers/{session_ids['both']}/durable/empty"
                 session.put(empty_key, b"", encoding=zenoh.Encoding("zenoh/bytes"))
+                _wait_for_payload(session, empty_key, b"")
+                assert _query(session, invalid_key) == []
                 empty_replies = _query(session, empty_key)
                 assert len(empty_replies) == 1
                 support.assert_wire_sample(
@@ -150,6 +171,11 @@ def test_raw_zenoh_durable_late_join_preserves_distinct_keys() -> None:
                 first,
                 f"{fixture.prefix}/buffers/{fixture.session_id}/durable/a",
                 b"a",
+            )
+            _wait_for_payload(
+                first,
+                f"{fixture.prefix}/buffers/{fixture.session_id}/durable/b",
+                b"b",
             )
         with fixture.open_raw_session() as late:
             replies = _query(late, f"{fixture.prefix}/buffers/{fixture.session_id}/durable/**")

--- a/tests/interop/test_raw_zenoh_buffer.py
+++ b/tests/interop/test_raw_zenoh_buffer.py
@@ -1,0 +1,146 @@
+"""Raw Zenoh interoperability contracts for mixed Session buffer routes."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+import zenoh
+
+import raw_zenoh_test_support as support
+
+QUERY_TIMEOUT_SECONDS = 1.0
+
+
+def _query(session: zenoh.Session, key: str) -> list[support.WireSample]:
+    replies: list[support.WireSample] = []
+    for reply in session.get(key, timeout=QUERY_TIMEOUT_SECONDS):
+        assert reply.err is None, f"query failed: {reply.err}"
+        assert reply.ok is not None
+        replies.append(support.copy_sample(reply.ok))
+    return replies
+
+
+def _wait_for_payload(session: zenoh.Session, key: str, payload: bytes) -> None:
+    replies = _query(session, key)
+    assert len(replies) == 1, f"buffer value was not queryable: {key}"
+    support.assert_wire_sample(
+        replies[0],
+        expected_key=key,
+        expected_payload=payload,
+        expected_encoding="zenoh/bytes",
+    )
+
+
+def test_raw_zenoh_client_can_use_mixed_session_buffers() -> None:
+    with support.FixtureProcess() as fixture:
+        session_ids = {
+            mode: fixture.create_buffer_session(f"{fixture.session_id}_{mode}", mode)
+            for mode in ("none", "durable", "ephemeral", "both")
+        }
+        with fixture.open_raw_session() as session:
+            marker_observed = threading.Event()
+            live_observed = threading.Event()
+            live_key = f"{fixture.prefix}/buffers/{session_ids['both']}/ephemeral/live"
+            marker_key = f"{fixture.prefix}/buffers/{session_ids['both']}/ephemeral/marker"
+
+            def observe(sample: zenoh.Sample) -> None:
+                if str(sample.key_expr) == marker_key:
+                    marker_observed.set()
+                if str(sample.key_expr) == live_key:
+                    live_observed.set()
+
+            subscriber = session.declare_subscriber(
+                f"{fixture.prefix}/buffers/{session_ids['both']}/ephemeral/**", observe
+            )
+            try:
+                session.put(marker_key, b"marker", encoding=zenoh.Encoding("zenoh/bytes"))
+                assert marker_observed.wait(5.0)
+                for mode, sid in session_ids.items():
+                    durable_key = f"{fixture.prefix}/buffers/{sid}/durable/official"
+                    ephemeral_key = f"{fixture.prefix}/buffers/{sid}/ephemeral/preview"
+                    session.put(
+                        durable_key,
+                        mode.encode(),
+                        encoding=zenoh.Encoding("zenoh/bytes"),
+                    )
+                    session.put(
+                        ephemeral_key,
+                        b"preview",
+                        encoding=zenoh.Encoding("zenoh/bytes"),
+                    )
+                durable_replies = {
+                    mode: _query(
+                        session,
+                        f"{fixture.prefix}/buffers/{sid}/durable/official",
+                    )
+                    for mode, sid in session_ids.items()
+                }
+                assert len(durable_replies["none"]) == 0
+                assert len(durable_replies["durable"]) == 1
+                assert len(durable_replies["ephemeral"]) == 0
+                assert len(durable_replies["both"]) == 1
+                for mode in ("durable", "both"):
+                    support.assert_wire_sample(
+                        durable_replies[mode][0],
+                        expected_key=f"{fixture.prefix}/buffers/{session_ids[mode]}/durable/official",
+                        expected_payload=mode.encode(),
+                        expected_encoding="zenoh/bytes",
+                    )
+                for mode, sid in session_ids.items():
+                    assert _query(
+                        session,
+                        f"{fixture.prefix}/buffers/{sid}/ephemeral/preview",
+                    ) == []
+                invalid_key = f"{fixture.prefix}/buffers/{session_ids['both']}/durable/invalid"
+                session.put(invalid_key, b"invalid", encoding=zenoh.Encoding("zenoh/bytes;sitos.v1"))
+                assert _query(session, invalid_key) == []
+                empty_key = f"{fixture.prefix}/buffers/{session_ids['both']}/durable/empty"
+                session.put(empty_key, b"", encoding=zenoh.Encoding("zenoh/bytes"))
+                empty_replies = _query(session, empty_key)
+                assert len(empty_replies) == 1
+                support.assert_wire_sample(
+                    empty_replies[0],
+                    expected_key=empty_key,
+                    expected_payload=b"",
+                    expected_encoding="zenoh/bytes",
+                )
+                session.put(
+                    live_key,
+                    b"live-preview",
+                    encoding=zenoh.Encoding("zenoh/bytes"),
+                )
+                assert live_observed.wait(5.0)
+            finally:
+                subscriber.undeclare()
+
+
+def test_raw_zenoh_durable_late_join_preserves_distinct_keys() -> None:
+    with support.FixtureProcess() as fixture:
+        fixture.create_buffer_session()
+        with fixture.open_raw_session() as first:
+            for suffix, payload in (("a", b"a"), ("b", b"b")):
+                first.put(
+                    f"{fixture.prefix}/buffers/{fixture.session_id}/durable/{suffix}",
+                    payload,
+                    encoding=zenoh.Encoding("zenoh/bytes"),
+                )
+            _wait_for_payload(
+                first,
+                f"{fixture.prefix}/buffers/{fixture.session_id}/durable/a",
+                b"a",
+            )
+            with fixture.open_raw_session() as late:
+                replies = _query(late, f"{fixture.prefix}/buffers/{fixture.session_id}/durable/**")
+                assert {reply.key for reply in replies} == {
+                    f"{fixture.prefix}/buffers/{fixture.session_id}/durable/a",
+                    f"{fixture.prefix}/buffers/{fixture.session_id}/durable/b",
+                }
+                for reply in replies:
+                    assert reply.encoding == "zenoh/bytes"
+                    assert reply.payload == reply.key.rsplit("/", maxsplit=1)[-1].encode()
+
+
+def test_raw_zenoh_buffer_interop_fixture_boundaries() -> None:
+    with support.FixtureProcess() as fixture:
+        fixture.create_buffer_session()

--- a/tests/interop/test_raw_zenoh_wheel_boundary.py
+++ b/tests/interop/test_raw_zenoh_wheel_boundary.py
@@ -18,7 +18,12 @@ def _load_wheel_validator():
 
 @pytest.mark.parametrize(
     "member",
-    ["sitos/sitos_raw_zenoh_fixture", "sitos/sitos_raw_zenoh_fixture.exe"],
+    [
+        "sitos/sitos_raw_zenoh_fixture",
+        "sitos/sitos_raw_zenoh_fixture.exe",
+        "sitos/sitos_raw_zenoh_buffer_fixture",
+        "sitos/sitos_raw_zenoh_buffer_fixture.exe",
+    ],
 )
 def test_wheel_validator_rejects_raw_zenoh_fixture(member: str) -> None:
     with pytest.raises(RuntimeError, match="forbidden wheel entry"):

--- a/tests/package/check_clean_install.cmake
+++ b/tests/package/check_clean_install.cmake
@@ -24,3 +24,13 @@ if(_test_libraries)
   list(JOIN _test_libraries "\n  " _test_library_list)
   message(FATAL_ERROR "Test-only libraries were installed:\n  ${_test_library_list}")
 endif()
+
+file(GLOB_RECURSE _raw_fixture_artifacts LIST_DIRECTORIES FALSE
+  "${SITOS_PREFIX}/sitos_raw_zenoh_fixture*"
+  "${SITOS_PREFIX}/sitos_raw_zenoh_buffer_fixture*"
+  "${SITOS_PREFIX}/bin/sitos_raw_zenoh_fixture*"
+  "${SITOS_PREFIX}/bin/sitos_raw_zenoh_buffer_fixture*")
+if(_raw_fixture_artifacts)
+  list(JOIN _raw_fixture_artifacts "\n  " _raw_fixture_list)
+  message(FATAL_ERROR "Raw Zenoh fixture artifacts were installed:\n  ${_raw_fixture_list}")
+endif()

--- a/tests/package/consumer/main.cpp
+++ b/tests/package/consumer/main.cpp
@@ -1,11 +1,16 @@
 #include <cstdint>
+#include <functional>
+#include <memory>
 #include <string>
+#include <string_view>
+#include <type_traits>
 
 #include "sitos/list_sink.hpp"
 #include "sitos/param_concepts.hpp"
 #include "sitos/rocksdb_engine.hpp"
 #include "sitos/session_view.hpp"
 #include "sitos/sitos.hpp"
+#include "sitos/storage_node.hpp"
 
 static_assert(sitos::ParamInput<std::int64_t>);
 static_assert(sitos::SupportedParamType<std::string>);
@@ -23,6 +28,23 @@ concept HasSessionViewPut = requires(T& value) {
   value.Put("key", sitos::ParamValue(std::int64_t{1}));
 };
 static_assert(!HasSessionViewPut<sitos::SessionView>);
+
+using LegacyCreateSession = sitos::Result<void> (sitos::StorageNode::*)(std::string_view);
+using CapabilityCreateSession =
+    sitos::Result<void> (sitos::StorageNode::*)(std::string_view, sitos::SessionOptions);
+static_assert(std::is_same_v<decltype(static_cast<LegacyCreateSession>(
+                                 &sitos::StorageNode::CreateSession)),
+                             LegacyCreateSession>);
+static_assert(std::is_same_v<decltype(static_cast<CapabilityCreateSession>(
+                                 &sitos::StorageNode::CreateSession)),
+                             CapabilityCreateSession>);
+static_assert(requires(sitos::SessionOptions options) {
+  options.durable_buffers;
+  options.ephemeral_buffers;
+});
+static_assert(std::is_same_v<sitos::DurableBufferEngineFactory,
+                             std::function<sitos::Result<std::unique_ptr<sitos::StorageEngine>>(
+                                 std::string_view)>>);
 
 int main(int argc, char** argv) {
   static_cast<void>(sitos::MakeZenohTransport());

--- a/tests/package/consumer/main.cpp
+++ b/tests/package/consumer/main.cpp
@@ -17,34 +17,32 @@ static_assert(sitos::SupportedParamType<std::string>);
 static_assert(sitos::ParamSpanElement<std::uint32_t>);
 
 template <typename T>
-concept HasAttachBase = requires(T& value) {
-  value.AttachBase();
-};
+concept HasAttachBase = requires(T& value) { value.AttachBase(); };
 
 static_assert(!HasAttachBase<sitos::ParamCache>);
 
 template <typename T>
-concept HasSessionViewPut = requires(T& value) {
-  value.Put("key", sitos::ParamValue(std::int64_t{1}));
-};
+concept HasSessionViewPut =
+    requires(T& value) { value.Put("key", sitos::ParamValue(std::int64_t{1})); };
 static_assert(!HasSessionViewPut<sitos::SessionView>);
 
 using LegacyCreateSession = sitos::Result<void> (sitos::StorageNode::*)(std::string_view);
-using CapabilityCreateSession =
-    sitos::Result<void> (sitos::StorageNode::*)(std::string_view, sitos::SessionOptions);
-static_assert(std::is_same_v<decltype(static_cast<LegacyCreateSession>(
-                                 &sitos::StorageNode::CreateSession)),
-                             LegacyCreateSession>);
-static_assert(std::is_same_v<decltype(static_cast<CapabilityCreateSession>(
-                                 &sitos::StorageNode::CreateSession)),
-                             CapabilityCreateSession>);
+using CapabilityCreateSession = sitos::Result<void> (sitos::StorageNode::*)(std::string_view,
+                                                                            sitos::SessionOptions);
+static_assert(
+    std::is_same_v<decltype(static_cast<LegacyCreateSession>(&sitos::StorageNode::CreateSession)),
+                   LegacyCreateSession>);
+static_assert(std::is_same_v<
+              decltype(static_cast<CapabilityCreateSession>(&sitos::StorageNode::CreateSession)),
+              CapabilityCreateSession>);
 static_assert(requires(sitos::SessionOptions options) {
   options.durable_buffers;
   options.ephemeral_buffers;
 });
-static_assert(std::is_same_v<sitos::DurableBufferEngineFactory,
-                             std::function<sitos::Result<std::unique_ptr<sitos::StorageEngine>>(
-                                 std::string_view)>>);
+static_assert(
+    std::is_same_v<
+        sitos::DurableBufferEngineFactory,
+        std::function<sitos::Result<std::unique_ptr<sitos::StorageEngine>>(std::string_view)>>);
 
 int main(int argc, char** argv) {
   static_cast<void>(sitos::MakeZenohTransport());

--- a/tests/package/validate_installed_package.cmake
+++ b/tests/package/validate_installed_package.cmake
@@ -98,3 +98,37 @@ validate_consumer("${_on_moved}" "${_on_consumer}-cmake-root"
   "-DZENOHC_ROOT=${_zenoh_root}")
 validate_consumer("${_on_moved}" "${_on_consumer}-environment-root"
   "-DZENOHC_ROOT_ENV=${_zenoh_root}")
+
+# The final ADR-0032 integration boundary is validated in one combined tree as well. The
+# installed consumer is still configure/build/link-only; runtime RocksDB probes remain owned by
+# the vcpkg validation lane. Standard package jobs omit VCPKG_ROOT and retain their existing
+# Zenoh-only and no-feature lanes.
+if(DEFINED VCPKG_ROOT AND NOT "${VCPKG_ROOT}" STREQUAL "")
+set(_combined_build "${WORK_DIR}/combined-build")
+set(_combined_prefix "${WORK_DIR}/combined-prefix")
+set(_combined_consumer "${WORK_DIR}/combined-consumer")
+run_checked(
+  "${CMAKE_COMMAND}" -S "${SITOS_SOURCE_DIR}" -B "${_combined_build}"
+  -G "${CMAKE_GENERATOR}" -DCMAKE_BUILD_TYPE=Release
+  -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=ON -DSITOS_WITH_ROCKSDB=ON
+  "-DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+  "-DVCPKG_ROOT=${VCPKG_ROOT}" "-DVCPKG_TARGET_TRIPLET=${TRIPLET}"
+  "-DVCPKG_INSTALLED_DIR=${_combined_build}/vcpkg_installed"
+  "-DVCPKG_MANIFEST_FEATURES=rocksdb")
+run_checked("${CMAKE_COMMAND}" --build "${_combined_build}")
+string(CONCAT _combined_test_regex
+  "BufferLateJoinTest|RawZenohClientCanUseMixedSessionBuffers|"
+  "RawZenohDurableLateJoinPreservesDistinctKeys|RawZenohBufferInteropFixtureBoundaries|"
+  "RocksDBBufferLifecycleTest")
+run_checked(
+  "${CMAKE_CTEST_COMMAND}" --test-dir "${_combined_build}" --output-on-failure
+  --no-tests=error -R "${_combined_test_regex}")
+run_checked("${CMAKE_COMMAND}" --install "${_combined_build}" --prefix "${_combined_prefix}")
+validate_clean_install("${_combined_prefix}")
+run_checked("${CMAKE_COMMAND}" -E copy_directory "${_combined_prefix}" "${_combined_prefix}-relocated")
+validate_relocation("${_combined_prefix}-relocated" "${_combined_prefix}" "${_combined_build}")
+validate_consumer("${_combined_prefix}-relocated" "${_combined_consumer}"
+  "-DSITOS_PACKAGE_CONSUMER_WITH_ROCKSDB=ON"
+  "-DRocksDB_DIR=${_combined_build}/vcpkg_installed/${TRIPLET}/share/rocksdb"
+  "-DZENOHC_ROOT=${_combined_build}/_deps/zenohc-src")
+endif()

--- a/tests/package/validate_installed_package.cmake
+++ b/tests/package/validate_installed_package.cmake
@@ -98,37 +98,3 @@ validate_consumer("${_on_moved}" "${_on_consumer}-cmake-root"
   "-DZENOHC_ROOT=${_zenoh_root}")
 validate_consumer("${_on_moved}" "${_on_consumer}-environment-root"
   "-DZENOHC_ROOT_ENV=${_zenoh_root}")
-
-# The final ADR-0032 integration boundary is validated in one combined tree as well. The
-# installed consumer is still configure/build/link-only; runtime RocksDB probes remain owned by
-# the vcpkg validation lane. Standard package jobs omit VCPKG_ROOT and retain their existing
-# Zenoh-only and no-feature lanes.
-if(DEFINED VCPKG_ROOT AND NOT "${VCPKG_ROOT}" STREQUAL "")
-set(_combined_build "${WORK_DIR}/combined-build")
-set(_combined_prefix "${WORK_DIR}/combined-prefix")
-set(_combined_consumer "${WORK_DIR}/combined-consumer")
-run_checked(
-  "${CMAKE_COMMAND}" -S "${SITOS_SOURCE_DIR}" -B "${_combined_build}"
-  -G "${CMAKE_GENERATOR}" -DCMAKE_BUILD_TYPE=Release
-  -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=ON -DSITOS_WITH_ROCKSDB=ON
-  "-DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-  "-DVCPKG_ROOT=${VCPKG_ROOT}" "-DVCPKG_TARGET_TRIPLET=${TRIPLET}"
-  "-DVCPKG_INSTALLED_DIR=${_combined_build}/vcpkg_installed"
-  "-DVCPKG_MANIFEST_FEATURES=rocksdb")
-run_checked("${CMAKE_COMMAND}" --build "${_combined_build}")
-string(CONCAT _combined_test_regex
-  "BufferLateJoinTest|RawZenohClientCanUseMixedSessionBuffers|"
-  "RawZenohDurableLateJoinPreservesDistinctKeys|RawZenohBufferInteropFixtureBoundaries|"
-  "RocksDBBufferLifecycleTest")
-run_checked(
-  "${CMAKE_CTEST_COMMAND}" --test-dir "${_combined_build}" --output-on-failure
-  --no-tests=error -R "${_combined_test_regex}")
-run_checked("${CMAKE_COMMAND}" --install "${_combined_build}" --prefix "${_combined_prefix}")
-validate_clean_install("${_combined_prefix}")
-run_checked("${CMAKE_COMMAND}" -E copy_directory "${_combined_prefix}" "${_combined_prefix}-relocated")
-validate_relocation("${_combined_prefix}-relocated" "${_combined_prefix}" "${_combined_build}")
-validate_consumer("${_combined_prefix}-relocated" "${_combined_consumer}"
-  "-DSITOS_PACKAGE_CONSUMER_WITH_ROCKSDB=ON"
-  "-DRocksDB_DIR=${_combined_build}/vcpkg_installed/${TRIPLET}/share/rocksdb"
-  "-DZENOHC_ROOT=${_combined_build}/_deps/zenohc-src")
-endif()

--- a/tests/vcpkg/validate_vcpkg_provisioning.cmake
+++ b/tests/vcpkg/validate_vcpkg_provisioning.cmake
@@ -91,6 +91,27 @@ run_checked(
   "-DVCPKG_TARGET_TRIPLET=${TRIPLET}"
   "-DVCPKG_INSTALLED_DIR=${_feature_install}")
 run_checked("${CMAKE_COMMAND}" --build "${_sitos_build}")
+
+# Final Issue #56 combined dependency tree: exercise Zenoh and RocksDB together while reusing the
+# pinned vcpkg install. Raw interop dependencies are provisioned by the invoking CI job.
+set(_combined_build "${_work_dir}/sitos-combined-build")
+run_checked(
+  "${CMAKE_COMMAND}" -S "${SITOS_SOURCE_DIR}" -B "${_combined_build}"
+  ${_generator_args} -DCMAKE_BUILD_TYPE=Release
+  -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=ON -DSITOS_WITH_ROCKSDB=ON
+  "-DCMAKE_TOOLCHAIN_FILE=${_toolchain}"
+  "-DVCPKG_MANIFEST_DIR=${SITOS_SOURCE_DIR}"
+  -DVCPKG_MANIFEST_FEATURES=rocksdb
+  "-DVCPKG_TARGET_TRIPLET=${TRIPLET}"
+  "-DVCPKG_INSTALLED_DIR=${_feature_install}")
+run_checked("${CMAKE_COMMAND}" --build "${_combined_build}")
+string(CONCAT _combined_test_regex
+  "BufferLateJoinTest|RawZenohClientCanUseMixedSessionBuffers|"
+  "RawZenohDurableLateJoinPreservesDistinctKeys|RawZenohBufferInteropFixtureBoundaries|"
+  "RocksDBBufferLifecycleTest")
+run_checked(
+  "${CMAKE_CTEST_COMMAND}" --test-dir "${_combined_build}" --output-on-failure
+  --no-tests=error -R "${_combined_test_regex}")
 if(WIN32)
   set(_benchmark_suffix ".exe")
 else()

--- a/tests/vcpkg/validate_vcpkg_provisioning.cmake
+++ b/tests/vcpkg/validate_vcpkg_provisioning.cmake
@@ -106,12 +106,42 @@ run_checked(
   "-DVCPKG_INSTALLED_DIR=${_feature_install}")
 run_checked("${CMAKE_COMMAND}" --build "${_combined_build}")
 string(CONCAT _combined_test_regex
+  "BufferKeyTest|StorageNodeSessionLifecycleTest|SessionViewTest|"
+  "StorageNodeBufferApiTest|StorageNodeBufferLifecycleTest|StorageNodeBufferRoutingTest|"
   "BufferLateJoinTest|RawZenohClientCanUseMixedSessionBuffers|"
   "RawZenohDurableLateJoinPreservesDistinctKeys|RawZenohBufferInteropFixtureBoundaries|"
   "RocksDBBufferLifecycleTest")
 run_checked(
   "${CMAKE_CTEST_COMMAND}" --test-dir "${_combined_build}" --output-on-failure
-  --no-tests=error -R "${_combined_test_regex}")
+  --no-tests=error --timeout 60 -R "${_combined_test_regex}")
+
+set(_combined_prefix "${_work_dir}/sitos-combined-prefix")
+set(_combined_relocated_prefix "${_work_dir}/sitos-combined-relocated-prefix")
+set(_combined_consumer_build "${_work_dir}/sitos-combined-consumer-build")
+run_checked("${CMAKE_COMMAND}" --install "${_combined_build}" --prefix "${_combined_prefix}")
+run_checked(
+  "${CMAKE_COMMAND}" "-DSITOS_PREFIX=${_combined_prefix}"
+  "-DSITOS_INSTALL_LIBDIR=lib"
+  -P "${SITOS_SOURCE_DIR}/tests/package/check_clean_install.cmake")
+run_checked("${CMAKE_COMMAND}" -E copy_directory "${_combined_prefix}" "${_combined_relocated_prefix}")
+run_checked(
+  "${CMAKE_COMMAND}" "-DSITOS_PREFIX=${_combined_relocated_prefix}"
+  "-DSITOS_SOURCE_DIR=${SITOS_SOURCE_DIR}"
+  "-DSITOS_BUILD_DIR=${_combined_build}"
+  "-DORIGINAL_PREFIX=${_combined_prefix}"
+  "-DSITOS_INSTALL_LIBDIR=lib"
+  -P "${SITOS_SOURCE_DIR}/tests/package/check_relocatable.cmake")
+run_checked(
+  "${CMAKE_COMMAND}" -S "${SITOS_SOURCE_DIR}/tests/package/consumer"
+  -B "${_combined_consumer_build}" ${_generator_args} -DCMAKE_BUILD_TYPE=Release
+  -DSITOS_PACKAGE_CONSUMER_WITH_ROCKSDB=ON
+  "-DCMAKE_PREFIX_PATH=${_combined_relocated_prefix}"
+  "-DRocksDB_DIR=${_feature_install}/${TRIPLET}/share/rocksdb"
+  "-DZENOHC_ROOT=${_combined_build}/_deps/zenohc-src"
+  "-DZLIB_LIBRARY=${_zlib_library}"
+  "-DZLIB_INCLUDE_DIR=${_zlib_include_dir}")
+run_checked("${CMAKE_COMMAND}" --build "${_combined_consumer_build}")
+
 if(WIN32)
   set(_benchmark_suffix ".exe")
 else()

--- a/tests/vcpkg/validate_vcpkg_provisioning.cmake
+++ b/tests/vcpkg/validate_vcpkg_provisioning.cmake
@@ -137,7 +137,7 @@ run_checked(
   -DSITOS_PACKAGE_CONSUMER_WITH_ROCKSDB=ON
   "-DCMAKE_PREFIX_PATH=${_combined_relocated_prefix}"
   "-DRocksDB_DIR=${_feature_install}/${TRIPLET}/share/rocksdb"
-  "-DZENOHC_ROOT=${_combined_build}/_deps/zenohc-src"
+  "-Dzenohc_ROOT=${_combined_build}/_deps/zenohc-src"
   "-DZLIB_LIBRARY=${_zlib_library}"
   "-DZLIB_INCLUDE_DIR=${_zlib_include_dir}")
 run_checked("${CMAKE_COMMAND}" --build "${_combined_consumer_build}")


### PR DESCRIPTION
## Summary

Complete the final ADR-0032 integration stage defined by DEC-56-SPLIT-001: process-isolated
raw-Zenoh interoperability, test-only durable late join, RocksDB lifecycle evidence, combined
Zenoh-ON/RocksDB-ON Linux and Windows validation, installed-package consumer validation,
documentation reconciliation, and the final Contract Registry implementation transition.

The reconciliation baseline is merged main
`23bc2a1c244e620d5ca8e75ff744deea4ec63b72`.

ADR-0032 is Accepted, ADR-0014 is superseded, and Issues #139, #140, and #141 have implemented the
key, lifecycle, capability, factory, and deterministic in-process routing stages. Final #56
revalidates that merged baseline at integration boundaries; it does not reimplement or duplicate
those stages.

## Branch

`feat/56-mixed-buffer-integration`

## Prerequisites

- [x] #8: RocksDBEngine
- [x] #12: InMemoryEngine
- [x] #29: process-isolated raw-Zenoh single-value fixture infrastructure
- [x] #121: v0.4 design review
- [x] #133: Accepted ADR-0032
- [x] #139: mixed buffer key contract and implementation-plan reconciliation
- [x] #140: unified SessionRecord and admission lifecycle
- [x] #141: Session capability, factory, routing, and deterministic in-process evidence

All implementation dependencies are merged. Independent freeze review, owner scope freeze, and
implementation authorization are recorded. One-time normal-merge authorization is recorded for the
current exact head.

## Requirements and references

Applicable requirements:

- F03, F04, F10
- N05, N07
- C03, C06
- X01, X03

Normative contract references:

- `docs/adr/0031-cross-platform-vcpkg-foundation.md`
- `docs/adr/0032-mixed-session-buffer-routes.md`
- `docs/adr/0033-rocksdb-engine-snapshot-and-package-boundary.md`
- `docs/01_requirements.md`
- `docs/02_architecture.md` §2 and §4
- `docs/03_wire_protocol.md` §1, §2.2, and §4
- `docs/04_api_cpp.md` §3
- `docs/06_build_test_packaging.md` §5.1.1
- the complete Issue #56 entry in `docs/07_issue_breakdown.md`
- `docs/08_contract_registry.md`
- `docs/09_dependency_policy.md`
- `docs/10_adr_process.md`

Governance references:

- `AGENTS.md`
- `docs/development_workflow.md`
- DEC-56-SPLIT-001

## Decision-comment disposition

- OWNER comments 1-4 are historical pre-ADR intake, correction, and rationale. Accepted ADR-0032
  and the merged normative documents supersede their unresolved or single-route wording.
- DEC-56-SPLIT-001 remains the authority for the four-stage implementation split and final #56
  ownership.
- DEC-56-FACTORY-FAILURE-001, DEC-56-SETUP-FAILURE-001,
  DEC-56-ENCODING-ADMISSION-001, DEC-56-PERSISTENCE-FAILURE-001, and
  DEC-56-PUBLIC-API-001 are merged #140/#141 baseline contracts. Final #56 revalidates them at the
  combined integration/package boundary and does not reopen them.
- DEC-56-STOP-CREATE-001 remains authoritative for admitted-Create-before-Stop linearization and
  the Factory/LogSink re-entry precondition. Its statement that a CreateSession call rejected after
  gate closure returns `Status::Disconnected` is superseded by DEC-140-STOP-STATUS-002 and the
  merged normative documents: both CreateSession overloads return `Status::InvalidArgument`, cause
  `std::errc::invalid_argument`, and an empty message when State is absent or its lifecycle gate is
  already closed.
- ADR-0032's historical deferral of exact factory failure statuses was fulfilled by the owner
  decisions and merged #141 implementation. It is not an open final-stage decision.

## Merged baseline — do not reimplement

- #139 owns `BufferClass`, `KeyKind::Buffer`, `ParsedKey::buffer_class`,
  `BuildBufferKey`, route grammar, and the three `BufferKeyTest.*` contracts.
- #140 owns SessionRecord Creating/Active/Closing transitions, admission, rollback,
  Close/Stop quiescence, and stale SessionView safety.
- #141 owns SessionOptions, DurableBufferEngineFactory, capability admission, bare-byte validation,
  engine-authoritative durable write-once routing, ephemeral non-retention, query selectors,
  failure containment, and the fixed `StorageNodeBuffer*` suites.
- `tests/consumer/storage_node_header_compile.cpp` already verifies the exact legacy and capability
  member-pointer shapes against the build-tree package.
- Existing #8 coverage owns direct RocksDB engine create/reopen behavior. Final #56 adds only
  Session-integrated release ordering and fresh same-SID recreation evidence.
- Final #56 must run the merged #139-#141 tests in the applicable combined trees without copying or
  replacing their deterministic acceptance suites.

The merged integration contract is exact:

- Routes are `<prefix>/buffers/<sid>/durable/<key>` and
  `<prefix>/buffers/<sid>/ephemeral/<key>`.
- A Session may enable neither, durable only, ephemeral only, or both capabilities.
- Buffer PUT admission requires exact `encoding.id == "zenoh/bytes"`. Empty opaque payloads are
  valid. No buffer schema fallback or public Encoding constant is added.
- Durable values are engine-authoritative and write-once. Same-byte retries are idempotent;
  conflicting PUTs retain the first stored bytes. A failed or throwing Put creates no in-memory
  reservation and permits a later retry that rereads the engine.
- Ephemeral values are live-only and create no node-retained state.
- Durable Get/List replies use exact `Encoding{"zenoh/bytes"}`. Engine collection failure produces
  zero replies. Reply dispatch after Session admission release retains the merged #141 semantics.
- Buffer DELETE, batch, fence, snapshot, and control routes remain unsupported.
- Zenoh fanout and StorageNode admission/persistence are not atomic and are not network ACLs.

## Raw-Zenoh interoperability

- [x] Add a buffer-specific C++ fixture executable without changing #29's fixed single-value
      acceptance behavior.
- [x] Reuse #29 `FixtureProcess` safeguards: unique prefix/SID, port-race retry, bounded READY and
      command handshakes, independent stdout/stderr draining, forced-cleanup escalation, diagnostics,
      `RUN_SERIAL`, and a 60-second CTest timeout.
- [x] Preserve one Transport in the C++ fixture process. The StorageNode and any C++ administrative
      writer share that Transport.
- [x] Use one raw zenoh-python Session in the Python process, with multicast scouting disabled and
      an explicit endpoint.
- [x] Before any one-shot live-fanout assertion, establish subscriber-match readiness with a unique,
      bounded valid buffer marker key/value observed by that raw subscriber. The marker is test data
      on an existing value route, not a new control route; the asserted sample uses a different key.
- [x] Inject exactly one host-owned engine for each durable-enabled Session through the production
      factory: InMemoryEngine in the normal Zenoh lane and RocksDBEngine in the combined lane.
- [x] Verify all four capability combinations and both exact canonical routes.
- [x] Verify exact bare `zenoh/bytes`, including an empty payload. Do not reuse
      `CANONICAL_SITOS_ENCODING`.
- [x] Verify byte-exact durable Get/List, same-byte retry, conflicting PUT retention, ephemeral live
      observation, and ephemeral zero-reply query behavior.
- [x] Verify at least one representative noncanonical raw Encoding,
      `zenoh/bytes;sitos.v1`, creates no node query state.
- [x] Verify disabled publications create no node query state.
- [x] For disabled or invalid publications, assert only the node-side zero-query-state result. Do
      not require or reject raw fanout observation because Zenoh fanout is independent and cannot be
      retracted.
- [x] Verify a query initiated after CloseSession has returned produces zero replies.
- [x] Use no fixed sleeps. Readiness, completion, barriers, and cleanup use bounded protocol
      handshakes or deterministic synchronization.

## Test-only durable late join

- [x] Add no production BufferSubscriber and no C++ or Python high-level buffer client API.
- [x] Implement the ADR-0032 reference algorithm only in test support: declare a buffering
      subscriber, synchronously Get and materialize durable replies, merge buffered samples, then
      transition to live delivery.
- [x] Copy callback-scoped sample/reply key and payload bytes while holding the collector mutex, and
      call `Transport::Get` without holding that mutex.
- [x] Under the collector mutex, validate and move the materialized replies plus buffered samples
      into one ordered delivery batch and commit the transition to live; then release the mutex.
- [x] Invoke no external observer while holding the collector mutex. Deliver the moved batch and
      post-transition live samples through one serialized observation boundary so live delivery
      cannot overtake the committed batch.
- [x] Prove materialized replies precede buffered samples and buffered samples precede
      post-transition live samples in the observer sequence.
- [x] Compare the final distinct key-to-bytes set without imposing a total order across publishers.
- [x] Deduplicate byte-identical duplicate observations explicitly and reject conflicting bytes.
- [x] On declaration failure or any initial Get failure, including failure after partial replies,
      discard the candidate, invoke no observer, and clean up deterministically.

## RocksDB lifecycle

- [x] Create each durable engine under a unique host-owned per-Session directory.
- [x] Prove CloseSession waits for admitted durable engine Get/List materialization and PUT work,
      then destroys the engine before returning. Do not strengthen this into waiting for
      post-admission reply dispatch.
- [x] Remove the old directory only after CloseSession returns, including on Windows.
- [x] Recreate the same SID only with a new factory-supplied, logically empty engine and a fresh
      host-owned directory.
- [x] Preserve the Factory/LogSink precondition against synchronous same-node Stop, destruction, or
      another waiting lifecycle operation, including waiting for a task that performs one.
- [x] Claim only orderly release and fresh recreation. Do not claim restart retention, power-loss
      durability, Sync/fsync, or Issue #108 catalog semantics.

## Package and ABI validation

- [x] Revalidate the exact legacy one-argument CreateSession member-pointer shape, the capability
      overload, SessionOptions, and DurableBufferEngineFactory through the relocated installed
      package.
- [x] Preserve source compatibility and require consumer rebuild. Binary ABI compatibility is not
      required for this pre-1.0 aggregate extension.
- [x] Install and relocate a combined Zenoh-ON/RocksDB-ON package on Linux and Windows.
- [x] Configure, build, and link an installed consumer against both reconstructed dependencies.
- [x] Keep installed-consumer validation configure/build/link-only. The consumer may compile and
      link a `RocksDBEngine::Open` call, but it must not be executed.
- [x] Preserve Zenoh-OFF and RocksDB-OFF installed-package independence.
- [x] Extend installed-artifact and wheel guards to reject both raw fixture executable basenames,
      with and without the Windows `.exe` suffix.
- [x] Ensure neither raw fixture executable enters installed production artifacts or wheels.

## Combined CI

- [x] Preserve existing Zenoh-ON/RocksDB-OFF standard Linux and Windows jobs.
- [x] Preserve existing Zenoh-OFF/RocksDB-ON vcpkg jobs, runtime probes, package checks, and isolated
      no-feature validation.
- [x] Reuse ADR-0031's pinned vcpkg checkout and filesystem binary archive in one additional
      combined build tree inside both existing vcpkg jobs.
- [x] Configure each combined tree with Zenoh ON, RocksDB ON, tests ON, the existing official
      triplet, the pinned RocksDB port, and the pinned/default zenoh-c dependency.
- [x] Install `tests/interop/requirements.txt` with `--require-hashes --only-binary=:all:` in both
      combined jobs.
- [x] Build and run the merged #139-#141 acceptance suites and the final late-join, raw interop,
      RocksDB lifecycle, package, clean-install, and relocation validations in both combined jobs.
- [x] Keep `dependency-upgrade.yml` running the InMemory raw buffer wire contract for each selected
      zenoh-c version. Update the workflow only if the new CTest registration is not selected
      automatically.
- [x] Keep all wheel jobs RocksDB-free.

## Fixed acceptance tests

- [x] `BufferLateJoinTest.OrdersMaterializedBufferedAndLiveSamples`
- [x] `BufferLateJoinTest.DurableLateJoinDoesNotLoseDistinctKeys`
- [x] `BufferLateJoinTest.FailureInvokesNoObserverAndCleansUp`
- [x] `RawZenohClientCanUseMixedSessionBuffers`
- [x] `RawZenohDurableLateJoinPreservesDistinctKeys`
- [x] `RawZenohBufferInteropFixtureBoundaries`
- [x] `RocksDBBufferLifecycleTest.CloseReleasesEngineBeforeReturn`
- [x] `RocksDBBufferLifecycleTest.SameSidRecreationUsesFreshEngine`
- [x] Combined installed-consumer configure/build/link validation passes on Linux and Windows.

Each raw behavior contract maps to one pytest scenario and one CTest name. Infrastructure and
artifact-boundary checks remain under the separate `RawZenohBufferInteropFixtureBoundaries` entry.
All CTests use bounded timeouts and remain repeatable.

Validation classification is exact:

- The three `BufferLateJoinTest.*` cases and the three `RawZenoh*` contracts are
  **pre-implementation behavioral RED**. Add each test and the minimum CMake/CTest registration
  needed to execute it first, then capture contemporaneous structured RED evidence before fixture,
  test-support, or production implementation.
- The two `RocksDBBufferLifecycleTest.*` cases are **review-driven regression** for behavior already
  implemented and covered generically by #8/#141. Do not require or fabricate RED for those cases.
  Their execution in the new combined dependency tree is **co-developed integration coverage**.
- Installed-consumer, relocation, combined dependency-tree, and platform-only CI validation is
  **co-developed integration coverage** because the new combined package tree and platform
  scaffolding are part of the executable test environment. Record the first failing executable
  integration result as soon as that environment can run.
- Existing #139-#141 tests and API member-pointer checks are **review-driven regression** evidence
  reused at the final integration boundary; do not relabel their already-merged chronology.
- Workflow-only and documentation-only checks that cannot execute behavior are `N/A`; record the
  reason instead of inventing RED evidence.

A production correction is permitted only for a minimal defect exposed by accepted integration
evidence. Never fabricate RED evidence or rewrite test chronology.

## Expected files

Add:

- `tests/interop/raw_zenoh_buffer_fixture.cpp`
- `tests/interop/test_raw_zenoh_buffer.py`
- `tests/integration/buffer_late_join_test.cpp`
- `tests/integration/rocksdb_buffer_lifecycle_test.cpp`

Modify as required:

- `tests/interop/raw_zenoh_test_support.py`
- `tests/interop/test_raw_zenoh_wheel_boundary.py`
- `tests/CMakeLists.txt`
- `scripts/check_wheel.py`
- `tests/package/check_clean_install.cmake`
- `tests/package/consumer/main.cpp`
- `tests/package/consumer/CMakeLists.txt` only if the combined compile/link target needs a separate
  option or definition
- `tests/vcpkg/validate_vcpkg_provisioning.cmake`
- `.github/workflows/ci.yml`
- `.github/workflows/dependency-upgrade.yml` only if explicit CTest selection is required
- `docs/06_build_test_packaging.md`
- `docs/07_issue_breakdown.md`
- `docs/08_contract_registry.md`
- `docs/09_dependency_policy.md`

The combined RocksDB package/relocation lane is owned by
`tests/vcpkg/validate_vcpkg_provisioning.cmake`; reuse the existing package helpers rather than
adding a second provisioning path.

`docs/02_architecture.md`, `docs/03_wire_protocol.md`, and `docs/04_api_cpp.md` were reconciled by
#139-#141 and should change only if final evidence exposes a concrete factual defect.

Production files may change only for minimal defects exposed by the accepted integration evidence.
Any public API, wire, or semantic expansion requires renewed owner approval and the applicable
scope/ADR process.

## Documentation and Contract Registry transition

- `docs/06_build_test_packaging.md`: preserve all fixed names and document combined
  Zenoh-ON/RocksDB-ON package/test validation.
- `docs/07_issue_breakdown.md`: use the full
  `BufferLateJoinTest.FailureInvokesNoObserverAndCleansUp` name and reconcile final integration
  wording.
- `docs/08_contract_registry.md`: change only the buffer row Implementation from `Planned` to
  `Implemented`.
- `docs/09_dependency_policy.md`: add the InMemory raw buffer contracts to dependency-upgrade
  validation and document the combined dependency boundary.

Registry axes after the final PR:

- Contract: no change, `Normative`
- Implementation: `Planned` → `Implemented`
- Normative spec: no change, ADR-0032
- Design authority: no change, `—`

## Out of scope

- BufferPublisher or production BufferSubscriber APIs
- Python capability, factory, publisher, or subscriber APIs
- Sync, fsync, WAL, Fence, acknowledgement, or publisher-identity semantics from #105-#107
- Per-key DELETE, overwrite, or tombstones
- Retained Session catalogs, restart recovery, orphan handling, or physical deletion retry from
  #108
- HTTP, shared memory, backpressure, chunking, batching, or new third-party dependencies

## Governance

- [x] #139, #140, and #141 merged.
- [x] Independent pre-implementation freeze review completed against main
      `23bc2a1c244e620d5ca8e75ff744deea4ec63b72` and this exact body.
- [x] Owner declares this exact checklist ready and frozen for implementation.
- [ ] Complete behavioral RED gate (not satisfied; governed by published `DEC-56-TDD-EXCEPTION-001`).
- [x] Linux and Windows exact-head combined checks pass.
- [x] Independent exact-head implementation review completed.
- [x] Separate one-time owner merge authorization recorded for the current PR head.


## R1 review remediation and governance

Closes #56

- Base: `23bc2a1c244e620d5ca8e75ff744deea4ec63b72`
- Previous head: `4556486f5e14c5c753c31a330a9d7ba5938949c6`
- Remediation head: `87c2e59269a1c41ff01bd125eab716b6b9ae41be`
- Corrective scope commit: `87c2e59269a1c41ff01bd125eab716b6b9ae41be`
- R1 repair head: `9cdfd5263ae4c21217c6e0bf518c60c9fd2931a7`
- R2 integration head: `8d17c40b43a7bddbc34d32509d9fc15ab610a448`
- Current R2 lifecycle repair head: `cd1f6cbf31a7f78690be781b39bccbeb544d0aa4`
- Scope freeze: `DEC-56-SCOPE-FREEZE-001`
- TDD exception: `DEC-56-TDD-EXCEPTION-001` — https://github.com/tetsuh/sitos/issues/56#issuecomment-5160346739
- Current implementation authorization remains bounded by the frozen scope and this published exception.
- One-time normal-merge authorization for exact head `8111da03cf8e1b4a7775262af4c12f82f714cdbe` is recorded at https://github.com/tetsuh/sitos/pull/146#issuecomment-5161063284; auto-merge, rebase merge, and squash merge remain prohibited.
- CodeRabbit findings are dispositioned at https://github.com/tetsuh/sitos/pull/146#issuecomment-5161098510 with no must-fix item.

### TDD classification

The OWNER-published TDD exception records that the original six-case RED was partial/incorrect and did not satisfy the frozen TDD gate. The original logs remain factual partial evidence only at `/tmp/issue56-red-evidence.txt`, `/tmp/issue56-red-cpp.log`, and `/tmp/issue56-red-raw.log`; they are not claimed as complete RED and must not be fabricated or relabeled. All repaired or newly strengthened assertions in this remediation are review-driven regression. No replacement RED is claimed. RocksDB lifecycle cases remain review-driven regression, and combined package/platform checks remain co-developed integration coverage. Workflow/documentation-only checks are N/A with a reason.

Representative original failure lines are retained:

- `FailureInvokesNoObserverAndCleansUp`: original RED reported `observed.size() Which is: 0` while the then-test expected `1u`, contradicting the frozen no-observer contract.
- Raw baseline: `received 'ERROR CREATE_BUFFER_SESSION unsupported command'`.

### R1 dispositions

- `I56-CI-001` / `PR146-CI-001` — fixed: both `--only-binary=:all:` workflow commands now use folded YAML scalars; workflow syntax is locally parsed successfully. Exact-head CI rerun is required.
- `I56-TDD-001` / `PR146-TDD-001` — accepted under published `DEC-56-TDD-EXCEPTION-001`: original RED remains partial evidence only; corrected assertions are review-driven regression and no replacement RED is claimed.
- `I56-SCOPE-001` / `PR146-PKG-001` — fixed: reverted the unapproved `tests/package/validate_installed_package.cmake` change; combined install/relocation/consumer validation is in authorized `tests/vcpkg/validate_vcpkg_provisioning.cmake`.
- `I56-LATEJOIN-001` / `PR146-LJ-001` — fixed: owned key/payload/encoding records, collector mutex, outside-mutex Get, atomic validation/deduplication/transition, serialized observation boundary, unregister cleanup, declaration/partial-failure/conflict/concurrency/destruction assertions.
- `I56-RAW-001` / `PR146-RAW-001` — fixed in scope: combined builds select RocksDBEngine, fixture has unique host-owned directories and bounded CloseSession, raw tests cover capabilities/routes/retry/conflict/encoding/empty/live/post-close and use one raw session at a time.
- `I56-ROCKS-001` / `PR146-RDB-001` — fixed in scope: real-engine wrapper barriers, unique RAII-owned directories, admitted PUT/Get/List close ordering, destruction observation, fresh same-SID engine and zero-reply assertion. The reconstructed translation unit now passes direct syntax-only compilation; full linkage remains owned by hosted RocksDB lanes.
- `I56-PKG-001` — fixed in scope: invoked vcpkg combined tree now runs inherited and final suites, installs/relocates combined artifacts, and builds the installed consumer with exact API checks.
- `I56-CTEST-001` — fixed: inherited #139–#141 suites are included in combined selection and all new C++ acceptance tests have 60-second timeouts.
- `I56-FMT-001` — fixed: all three new C++ files pass repository clang-format dry-run verification.
- `I56-GOV-001` — fixed in this PR body: all implementation, exact-head hosted-validation, independent-review, and exact-head merge-authorization items supported by current evidence are checked; the complete behavioral RED gate remains explicitly governed by `DEC-56-TDD-EXCEPTION-001`.

### Validation at R1/R2 remediation head

- C++ Zenoh-OFF full local CTest: 344/344 passed.
- C++ Zenoh-ON full local CTest: 399/399 passed.
- Focused late-join selection: 3/3 passed.
- Raw buffer and wheel-boundary tests: 7/7 passed with the buffer fixture.
- ASan/UBSan focused selection: 20/20 passed.
- YAML parser validation: passed for `.github/workflows/ci.yml`.
- `clang-format --dry-run --Werror` passed for all three new C++ files.
- Direct syntax-only compile of `tests/integration/rocksdb_buffer_lifecycle_test.cpp` with project and gtest include trees passed; output `/tmp/rocks-syntax-r2-final.log`.
- Reconstructed file is 360 lines / 12,650 bytes; first and last lines were inspected and contain the complete include/support and test closure.
- Local RocksDB/vcpkg combined execution remains environment-blocked because RocksDB 11.1.2/vcpkg is not installed locally; hosted Linux/Windows exact-head results are required.
- Local TSan remains environment-blocked by `ThreadSanitizer: unexpected memory mapping`.

### Authorized/reverted file accounting

- Reverted: `tests/package/validate_installed_package.cmake` (unapproved additional change).
- Authorized modified/new paths are limited to the frozen expected files plus explicitly authorized `tests/package/consumer/main.cpp`.
- No production source, public API, wire, protocol, or dependency changes were made. `tests/package/validate_installed_package.cmake` is byte-identical to merged main and is not part of the final changed-file set.

## R2 repair status

- Current pushed head: `8111da03cf8e1b4a7775262af4c12f82f714cdbe`
- R5 raw remediation commit: `8111da03cf8e1b4a7775262af4c12f82f714cdbe`
- Latest boundary/timeout commit: `4fd7b428ee3e8f7ea4970a7ceff4bcd79da7480f`
- Focused lifecycle/observer safety commit: `52b9ec377553c53a16de8295b4827cdd31acfd49`
- Latest lifecycle evidence commit: `f1b1b533de0634d09079b143c75156a12f304cc0`
- Completion-tracking fix: `477ea0af71202ff4322ec845677ba9c36ca82603`
- Latest R4 repair commit: `6d70472b34ef1c65077d253fc39e5f9e9b0a672d`.
- The hosted vcpkg Linux/Windows compile blocker at the raw fixture factory is repaired: RocksDB errors are propagated with `ErrFrom`, successful ownership is explicitly upcast to `Result<unique_ptr<StorageEngine>>`, and the host durable root is cleaned, created, validated, and finally removed with deterministic failures.
- The late-join collector now copies callback-scoped data under `collector_mutex_`, separates materialized/buffered collections, commits strict category order, uses RAII observation locking, and drains shared callback admission state after unsubscribe. The fixed-name ordering, mapping/deduplication/conflict, and copied-callback cleanup tests pass locally. The lifecycle test now owns up to four reserved `std::thread` objects, creates/checks distinct first/second roots before Open, and joins safely on early return. Its current evidence gates only explicit Get(`seed`), List, and Put; PUT preflight Get(`written`) is intentionally ungated.
- The external live-boundary callback seam is removed; collector-owned condition state signals the boundary without executing user code under collector_mutex_. All six discovered BufferLateJoinTest cases are generated with TIMEOUT=60, verified through CTest JSON.
- R4 lifecycle proof now releases Put, designated Get, then List independently, with bounded completion checks and destroyed-at-Close-return capture; observer failures defer phase marking until observation unlock.
- R4 validation is substantiated by direct syntax-only compiles, Zenoh-OFF 344/344, Zenoh-ON 399/399, fixed late-join/raw selection 9/9, raw/wheel 7/7, and ASan/UBSan 20/20. The lifecycle source explicitly asserts exact seed Get and seed/written List payload/encoding mappings after PUT completion.
- R4 at `52b9ec3` found timeout/external-callback/body issues; `4fd7b42` closed those. R5 general found the raw completion/late-join exactness gaps, which `8111da0` closes. Corrected default-model R6 returned MERGE from Terra and the general reviewer; Sol found no implementation or validation defect and requested only PR-body checklist reconciliation. Corrected default-model Sol body-only revalidation then returned MERGE. Exact-head hosted validation is complete with 18 successful checks, zero failures, and one intentional optional skip. One-time normal-merge authorization for exact head `8111da03cf8e1b4a7775262af4c12f82f714cdbe` is recorded at https://github.com/tetsuh/sitos/pull/146#issuecomment-5161063284.

### Current governance

- [x] #139, #140, and #141 merged.
- [x] Scope freeze and implementation authorization recorded.
- [ ] Original complete RED gate (not claimed; governed by `DEC-56-TDD-EXCEPTION-001`).
- [x] Linux and Windows exact-head combined checks pass.
- [x] Independent exact-head implementation review completed.
- [x] Separate one-time owner merge authorization recorded for the current PR head.













