### PR TITLE
feat(examples): add C++ quickstart and sitobolon (#31)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,14 @@ jobs:
           python3 -m pip install --break-system-packages --only-binary=:all: \
             --require-hashes -r tests/interop/requirements.txt
 
+      - name: Verify examples require Zenoh
+        run: python tests/examples/test_cpp_examples.py configure-guard --source . --build build/issue31-zenoh-off --generator Ninja
+
       - name: Configure
-        run: cmake --preset dev-linux
+        run: cmake --preset dev-linux -DSITOS_BUILD_EXAMPLES=ON
+
+      - name: Verify example CTest contract
+        run: python tests/examples/test_cpp_examples.py ctest-contract --build build/dev-linux
 
       - name: Build
         run: cmake --build --preset dev-linux
@@ -196,7 +202,9 @@ jobs:
           $vcvars = "$vsPath\VC\Auxiliary\Build\vcvars64.bat"
           $commands = @(
             "call `"$vcvars`""
-            "cmake --preset dev-windows -DPython3_EXECUTABLE=`"$python`""
+            "python tests/examples/test_cpp_examples.py configure-guard --source . --build build/issue31-zenoh-off --generator Ninja"
+            "cmake --preset dev-windows -DPython3_EXECUTABLE=`"$python`" -DSITOS_BUILD_EXAMPLES=ON"
+            "python tests/examples/test_cpp_examples.py ctest-contract --build build/dev-windows"
             "cmake --build --preset dev-windows"
             "ctest --preset dev-windows"
           ) -join " && "

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,10 @@ endif()
 # Only required when building tests or examples that use the transport layer.
 option(SITOS_WITH_ZENOH "Download and link prebuilt zenoh-c" OFF)
 
+if(SITOS_BUILD_EXAMPLES AND NOT SITOS_WITH_ZENOH)
+  message(FATAL_ERROR "SITOS_BUILD_EXAMPLES requires SITOS_WITH_ZENOH=ON")
+endif()
+
 if(SITOS_WITH_ZENOH)
   include(cmake/zenohc.cmake)
 endif()
@@ -194,6 +198,10 @@ endif()
 if(SITOS_BUILD_TESTS)
   enable_testing()
   add_subdirectory(tests)
+endif()
+
+if(SITOS_BUILD_EXAMPLES)
+  add_subdirectory(examples/cpp)
 endif()
 
 if(SITOS_BUILD_BENCHMARKS)

--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -19,7 +19,7 @@ Requirement IDs ([01_requirements.md](01_requirements.md)) are referenced as [F.
  │   │   └──────────────────┘   └───────────────────────┘     │   │
  │   │                                                        │   │
  │  ParamStore (write / List API)                             │   │
- │  SessionController (session creation/destruction)          │   │
+ │  session lifecycle (StorageNode API)                       │   │
  └────────────────────────────────────────────────────────────┘   │
                                                                    │
  ┌─ Subscriber process (e.g., compute worker) ×N ───────────┐      │
@@ -40,7 +40,7 @@ Requirement IDs ([01_requirements.md](01_requirements.md)) are referenced as [F.
 | `StorageNode` | Zenoh queryable/subscriber ↔ engine; owns Session lifecycles | zenoh, StorageEngine |
 | `ParamStore` | Client API: typed Put/Get/List/Delete/Subscribe. Wraps a zenoh session | zenoh |
 | `ParamCache` | Subscriber-side read cache. Initial fetch + delta subscription + zero-copy Get | zenoh |
-| `SessionController` | Session create, snapshot, buffers, and destroy (owner process) | StorageNode |
+| Session lifecycle | Conceptual responsibility inside the StorageNode-owning process; use `StorageNode::CreateSession`, `CloseSession`, and `ActiveSessions` | StorageNode |
 | `SessionView` | Host-process read-only view that resolves session overlay → snapshot | StorageNode |
 
 **Design principle**: `engine/` does not know about zenoh. `ParamStore`/`ParamCache` do not
@@ -147,13 +147,17 @@ Conventions:
    - buffer PUTs → capability admission and durable write-once handling; Zenoh fanout is
      independent [ADR-0032]
    - buffer DELETEs and control routes → reject as unsupported in v0.4
-3. Session lifecycle (via SessionController):
+3. Session lifecycle (a conceptual responsibility implemented inside StorageNode):
    - `CreateSession(sid, options)`: reserve a `Creating` Session record, create the snapshot,
      overlay, metadata, capabilities, and one durable engine through the host factory only when
      enabled; roll back every resource on failure, then transition the record to `Active`
    - `CloseSession(sid)`: transition the record to `Closing`, close its admission gate, wait for
      every admitted callback or operation, destroy its durable engine, and release all other
      resources before returning [F10, ADR-0032]
+
+Earlier diagrams and design discussions may call this responsibility `SessionController`. It is a
+conceptual responsibility inside the process that owns a `StorageNode`, not a public constructible
+C++ type. Applications use the `StorageNode` session methods above.
 
 ### 4.2 Data Structures
 

--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -148,12 +148,14 @@ Conventions:
      independent [ADR-0032]
    - buffer DELETEs and control routes → reject as unsupported in v0.4
 3. Session lifecycle (a conceptual responsibility implemented inside StorageNode):
-   - `CreateSession(sid, options)`: reserve a `Creating` Session record, create the snapshot,
-     overlay, metadata, capabilities, and one durable engine through the host factory only when
-     enabled; roll back every resource on failure, then transition the record to `Active`
-   - `CloseSession(sid)`: transition the record to `Closing`, close its admission gate, wait for
-     every admitted callback or operation, destroy its durable engine, and release all other
-     resources before returning [F10, ADR-0032]
+   - `StorageNode::CreateSession(sid, options)`: reserve a `Creating` Session record, create the
+     snapshot, overlay, metadata, capabilities, and one durable engine through the host factory
+     only when enabled; roll back every resource on failure, then transition to `Active`
+   - `StorageNode::CloseSession(sid)`: transition the record to `Closing`, close its admission
+     gate, wait for admitted callbacks or operations, destroy its durable engine, and release all
+     other resources before returning [F10, ADR-0032]
+   - `StorageNode::ActiveSessions()`: return the active Session ids in unspecified order; return
+     an empty list when the node is stopped.
 
 Earlier diagrams and design discussions may call this responsibility `SessionController`. It is a
 conceptual responsibility inside the process that owns a `StorageNode`, not a public constructible

--- a/docs/06_build_test_packaging.md
+++ b/docs/06_build_test_packaging.md
@@ -342,6 +342,29 @@ repeat the ASan/UBSan configuration with `-DSITOS_WITH_ZENOH=ON` and run the lif
 integration targets. The CI sanitizer job uses zenoh OFF to keep TSan independent of
 zenoh runtime internals.
 
+## 5.3 C++ examples and demo validation
+
+The C++ examples are opt-in: `SITOS_BUILD_EXAMPLES` remains OFF by default, requires
+`SITOS_WITH_ZENOH=ON`, and neither `quickstart` nor `sitobolon` is installed. `quickstart` is an
+in-process public-API tutorial. `sitobolon` is a standalone StorageNode process with an InMemory
+engine by default and an optional RocksDB engine when that support is built; its complete Zenoh
+JSON5 configuration is passed through unchanged.
+
+Example builds register these exact CTests: `CppQuickstartRuns`,
+`SitobolonHelpDocumentsOptions`, `SitobolonRejectsInvalidArguments`, and
+`SitobolonStartsAndStopsCleanly`; `SitobolonRocksDbReleasesPath` is additionally registered with
+RocksDB. Each has a 60-second timeout, and real local Zenoh process tests run serially. Standard
+Linux and Windows jobs run the four non-RocksDB tests. The combined Zenoh+RocksDB vcpkg lanes run
+all five and assert that installation contains neither example executable. The Python driver uses
+only the standard library and bounded process/readiness handling; platform-specific Windows
+console-control evidence is obtained in the hosted Windows job.
+
+Evidence classification is explicit: the five executable/process cases are co-developed integration
+coverage; the examples-enabled/Zenoh-OFF guard is compile/contract RED only when its assertion is
+run before the guard; combined-platform execution is co-developed integration coverage; CI wiring
+and documentation reconciliation are N/A for behavioral RED. This records evidence classes without
+claiming chronology for work that was co-developed.
+
 ## 6. CI (GitHub Actions)
 
 | workflow | Trigger | Contents |

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -578,11 +578,18 @@ raw-Zenoh consumers such as #32 and #56. The accepted ADR-0032 implementation se
 ### #31 C++ examples and demo binary sitobolon
 * Milestone: v0.4
 * References: [00] §4, [06] §1
-* Implementation targets: `examples/cpp/quickstart.cpp`, `examples/cpp/sitobolon.cpp`,
-  `examples/cpp/CMakeLists.txt`
-* Scope: C++ quickstart, standalone StorageNode executable
-  `sitobolon` (engine selected by config file)
-* Acceptance criteria: C++ examples are built and run in CI
+* Implementation targets: `CMakeLists.txt`, `examples/cpp/CMakeLists.txt`,
+  `examples/cpp/quickstart.cpp`, `examples/cpp/sitobolon.cpp`,
+  `tests/examples/test_cpp_examples.py`, and existing CI/vcpkg/docs seams
+* Scope: default-OFF C++ quickstart tutorial and standalone StorageNode executable
+  `sitobolon`, with complete JSON5 pass-through and InMemory/RocksDB engine selection.
+  Examples require Zenoh and are never installed.
+* Acceptance criteria: standard Linux/Windows jobs run the four non-RocksDB CTests;
+  combined Zenoh+RocksDB vcpkg lanes run all five fixed CTests and prove example binaries are absent
+  from the install. The process driver uses bounded, no-sleep readiness and signal cleanup.
+* Evidence: executable/process cases and combined-platform execution are co-developed integration
+  coverage; the configure guard is compile/contract RED only when asserted before implementation;
+  CI wiring and documentation reconciliation are N/A for behavioral RED.
 * Depends on: #15, #18
 
 ### #32 Python examples

--- a/docs/07_issue_breakdown.md
+++ b/docs/07_issue_breakdown.md
@@ -590,7 +590,7 @@ raw-Zenoh consumers such as #32 and #56. The accepted ADR-0032 implementation se
 * Evidence: executable/process cases and combined-platform execution are co-developed integration
   coverage; the configure guard is compile/contract RED only when asserted before implementation;
   CI wiring and documentation reconciliation are N/A for behavioral RED.
-* Depends on: #15, #18
+* Depends on: #8, #15, #18, #19, #121
 
 ### #32 Python examples
 * Milestone: v0.4

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -1,0 +1,46 @@
+add_executable(quickstart quickstart.cpp)
+target_link_libraries(quickstart PRIVATE sitos::sitos)
+sitos_enable_warnings(quickstart)
+sitos_copy_zenohc(quickstart)
+
+add_executable(sitobolon sitobolon.cpp)
+target_link_libraries(sitobolon PRIVATE sitos::sitos)
+if(SITOS_WITH_ROCKSDB)
+  target_compile_definitions(sitobolon PRIVATE SITOS_WITH_ROCKSDB=1)
+endif()
+sitos_enable_warnings(sitobolon)
+sitos_copy_zenohc(sitobolon)
+
+if(SITOS_BUILD_TESTS)
+  find_package(Python3 3.10 REQUIRED COMPONENTS Interpreter)
+  set(_cpp_example_driver "${CMAKE_CURRENT_SOURCE_DIR}/../../tests/examples/test_cpp_examples.py")
+  set(_cpp_example_driver_rocksdb_arg)
+  if(SITOS_WITH_ROCKSDB)
+    set(_cpp_example_driver_rocksdb_arg --rocksdb-built)
+  endif()
+
+  add_test(NAME CppQuickstartRuns COMMAND "$<TARGET_FILE:quickstart>")
+  add_test(NAME SitobolonHelpDocumentsOptions
+    COMMAND "${Python3_EXECUTABLE}" "${_cpp_example_driver}" help
+            --executable "$<TARGET_FILE:sitobolon>")
+  add_test(NAME SitobolonRejectsInvalidArguments
+    COMMAND "${Python3_EXECUTABLE}" "${_cpp_example_driver}" invalid
+            --executable "$<TARGET_FILE:sitobolon>" ${_cpp_example_driver_rocksdb_arg})
+  add_test(NAME SitobolonStartsAndStopsCleanly
+    COMMAND "${Python3_EXECUTABLE}" "${_cpp_example_driver}" lifecycle
+            --executable "$<TARGET_FILE:sitobolon>")
+  set_tests_properties(
+    CppQuickstartRuns SitobolonHelpDocumentsOptions SitobolonRejectsInvalidArguments
+    SitobolonStartsAndStopsCleanly
+    PROPERTIES TIMEOUT 60)
+  set_tests_properties(
+    CppQuickstartRuns SitobolonStartsAndStopsCleanly
+    PROPERTIES RUN_SERIAL TRUE)
+
+  if(SITOS_WITH_ROCKSDB)
+    add_test(NAME SitobolonRocksDbReleasesPath
+      COMMAND "${Python3_EXECUTABLE}" "${_cpp_example_driver}" rocksdb
+              --executable "$<TARGET_FILE:sitobolon>")
+    set_tests_properties(SitobolonRocksDbReleasesPath PROPERTIES TIMEOUT 60 RUN_SERIAL TRUE)
+  endif()
+endif()

--- a/examples/cpp/quickstart.cpp
+++ b/examples/cpp/quickstart.cpp
@@ -1,0 +1,180 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// This tutorial intentionally uses only the installed public umbrella header.
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <sitos/sitos.hpp>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+using namespace std::chrono_literals;
+
+template <typename T>
+void ReportFailure(std::string_view operation, const sitos::Result<T>& result) {
+  std::cerr << operation << " failed (status=" << static_cast<int>(result.StatusCode());
+  if (!result.Message().empty()) std::cerr << ", " << result.Message();
+  if (!result.IsOk()) {
+    const auto& cause = result.Error();
+    if (cause) std::cerr << ", cause=" << cause.category().name() << ':' << cause.value();
+  }
+  std::cerr << ")\n";
+}
+
+std::string RunToken() {
+  const auto ticks =
+      static_cast<std::uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
+  const auto random = static_cast<std::uint64_t>(std::random_device{}());
+  return std::to_string(ticks) + "_" + std::to_string(random);
+}
+
+bool IsValidIdentity(const std::string& prefix, const std::string& sid) {
+  return sitos::IsValidPrefix(prefix) && sitos::IsValidSessionId(sid);
+}
+}  // namespace
+
+int main() {
+  const std::string token = RunToken();
+  const std::string prefix = "sitos/quickstart_" + token;
+  const std::string sid = "quickstart_" + token;
+  if (!IsValidIdentity(prefix, sid)) {
+    std::cerr << "generated example identity was invalid\n";
+    return 1;
+  }
+
+  constexpr std::int64_t expected_scalar = 42;
+  const std::vector<std::byte> expected_lut{std::byte{0x00}, std::byte{0x11}, std::byte{0x7f},
+                                            std::byte{0xff}};
+
+  // Open one Transport. StorageNode borrows it, while the two client objects
+  // share it; using the injected Open overloads avoids opening extra sessions.
+  auto opened_transport = sitos::OpenZenohTransport();
+  if (!opened_transport.IsOk()) {
+    ReportFailure("OpenZenohTransport", opened_transport);
+    return 1;
+  }
+  std::shared_ptr<sitos::Transport> transport(std::move(opened_transport).Value());
+  auto engine = std::make_shared<sitos::InMemoryEngine>();
+  sitos::StorageNode node(*transport);
+  auto started = node.Start(engine, {.prefix = prefix, .log_sink = nullptr});
+  if (!started.IsOk()) {
+    ReportFailure("StorageNode::Start", started);
+    return 1;
+  }
+
+  sitos::ClientConfig client_config;
+  client_config.prefix = prefix;
+  client_config.query_timeout = 200ms;
+  client_config.log_sink = nullptr;
+  auto opened_store = sitos::ParamStore::Open(transport, client_config);
+  if (!opened_store.IsOk()) {
+    ReportFailure("ParamStore::Open", opened_store);
+    node.Stop();
+    return 1;
+  }
+  auto store = std::move(opened_store).Value();
+  auto opened_cache = sitos::ParamCache::Open(transport, client_config);
+  if (!opened_cache.IsOk()) {
+    ReportFailure("ParamCache::Open", opened_cache);
+    node.Stop();
+    return 1;
+  }
+  auto cache = std::move(opened_cache).Value();
+
+  // Put returns after transport submission, not after the node has applied the
+  // value. Submit each value once, then observe both exact values before taking
+  // the session snapshot below.
+  auto scalar_put = store.Put("base", "answer", expected_scalar);
+  if (!scalar_put.IsOk()) {
+    ReportFailure("ParamStore::Put(answer)", scalar_put);
+    node.Stop();
+    return 1;
+  }
+  auto lut_put = store.Put("base", "lut", expected_lut);
+  if (!lut_put.IsOk()) {
+    ReportFailure("ParamStore::Put(lut)", lut_put);
+    node.Stop();
+    return 1;
+  }
+
+  bool observed = false;
+  const auto deadline = std::chrono::steady_clock::now() + 5s;
+  while (std::chrono::steady_clock::now() < deadline) {
+    auto scalar = store.Get<std::int64_t>("base", "answer");
+    auto lut = store.Get<std::vector<std::byte>>("base", "lut");
+    if (scalar.IsOk() && lut.IsOk()) {
+      observed = scalar.Value() == expected_scalar && lut.Value() == expected_lut;
+      break;
+    }
+    if ((!scalar.IsOk() && scalar.StatusCode() != sitos::Status::NotFound) ||
+        (!lut.IsOk() && lut.StatusCode() != sitos::Status::NotFound)) {
+      if (!scalar.IsOk() && scalar.StatusCode() != sitos::Status::NotFound)
+        ReportFailure("ParamStore::Get(answer)", scalar);
+      if (!lut.IsOk() && lut.StatusCode() != sitos::Status::NotFound)
+        ReportFailure("ParamStore::Get(lut)", lut);
+      break;
+    }
+  }
+  if (!observed) {
+    std::cerr << "base values were not observed exactly before the deadline\n";
+    node.Stop();
+    return 1;
+  }
+
+  auto created = node.CreateSession(sid);
+  if (!created.IsOk()) {
+    ReportFailure("StorageNode::CreateSession", created);
+    node.Stop();
+    return 1;
+  }
+  auto attached = cache.Attach(sid);
+  if (!attached.IsOk()) {
+    ReportFailure("ParamCache::Attach", attached);
+    auto closed = node.CloseSession(sid);
+    if (!closed.IsOk()) ReportFailure("StorageNode::CloseSession", closed);
+    node.Stop();
+    return 1;
+  }
+
+  int exit_code = 0;
+  auto cached_scalar = cache.Get<std::int64_t>("answer");
+  if (!cached_scalar.IsOk()) {
+    ReportFailure("ParamCache::Get(answer)", cached_scalar);
+    exit_code = 1;
+  } else if (cached_scalar.Value() != expected_scalar) {
+    std::cerr << "cached scalar did not match\n";
+    exit_code = 1;
+  }
+  auto lut_result = cache.GetSpan<std::byte>("lut");
+  if (!lut_result.IsOk()) {
+    ReportFailure("ParamCache::GetSpan(lut)", lut_result);
+    exit_code = 1;
+  } else {
+    // SpanHandle owns the ParamValue through keepalive. Never retain the span
+    // after this handle is destroyed, even though the bytes are read-only.
+    auto lut_handle = std::move(lut_result).Value();
+    if (lut_handle.span.size() != expected_lut.size() ||
+        !std::equal(lut_handle.span.begin(), lut_handle.span.end(), expected_lut.begin())) {
+      std::cerr << "cached LUT did not match byte-for-byte\n";
+      exit_code = 1;
+    }
+  }
+
+  // Keep this order: Detach first, check CloseSession, and stop the node last.
+  cache.Detach();
+  auto closed = node.CloseSession(sid);
+  if (!closed.IsOk()) {
+    ReportFailure("StorageNode::CloseSession", closed);
+    exit_code = 1;
+  }
+  node.Stop();
+  return exit_code;
+}

--- a/examples/cpp/sitobolon.cpp
+++ b/examples/cpp/sitobolon.cpp
@@ -206,7 +206,8 @@ void SignalHandler(int) {
   const int descriptor = g_signal_pipe;
   if (descriptor >= 0) {
     const char notification = 's';
-    (void)write(descriptor, &notification, 1);
+    const ssize_t write_result = ::write(descriptor, &notification, 1);
+    (void)write_result;
   }
   errno = saved_errno;
 }

--- a/examples/cpp/sitobolon.cpp
+++ b/examples/cpp/sitobolon.cpp
@@ -1,0 +1,379 @@
+// Copyright 2026 sitos contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <sitos/sitos.hpp>
+#ifdef SITOS_WITH_ROCKSDB
+#include <sitos/rocksdb_engine.hpp>
+#endif
+
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#ifdef _WIN32
+#define NOMINMAX
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <csignal>
+#endif
+
+namespace {
+
+struct Options {
+  std::string engine = "inmemory";
+  std::string rocksdb_path;
+  std::string prefix = "sitos";
+  std::optional<std::string> zenoh_config;
+  std::optional<std::string> zenoh_config_file;
+  bool engine_seen = false;
+  bool rocksdb_path_seen = false;
+  bool prefix_seen = false;
+};
+
+void PrintHelp() {
+  std::cout << "Usage: sitobolon --help\n"
+            << "       sitobolon [--engine inmemory|rocksdb] [--rocksdb-path <path>]\n"
+            << "                [--prefix <prefix>]\n"
+            << "                [--zenoh-config <complete-json5> |\n"
+            << "                 --zenoh-config-file <path>]\n\n"
+            << "Options:\n"
+            << "  --engine <inmemory|rocksdb>  Storage engine (default: inmemory).\n"
+            << "  --rocksdb-path <path>        RocksDB path; required for rocksdb.\n"
+            << "  --prefix <prefix>            Valid sitos key prefix (default: sitos).\n"
+            << "  --zenoh-config <complete-json5>\n"
+            << "                               Complete Zenoh JSON5 configuration.\n"
+            << "  --zenoh-config-file <path>   Read a complete Zenoh JSON5 configuration.\n"
+            << "  --help                       Show this help (must be the only argument).\n";
+}
+
+bool ParseOptions(int argc, char** argv, Options& options, std::string& error) {
+  for (int index = 1; index < argc; ++index) {
+    const std::string_view argument = argv[index];
+    if (argument == "--help") {
+      error = "--help must be the sole argument";
+      return false;
+    }
+    auto value = [&](std::string_view name) -> std::optional<std::string> {
+      if (index + 1 >= argc || std::string_view(argv[index + 1]).starts_with("--")) {
+        error = std::string(name) + " requires a value";
+        return std::nullopt;
+      }
+      ++index;
+      return std::string(argv[index]);
+    };
+    if (argument == "--engine") {
+      auto value_text = value(argument);
+      if (!value_text) return false;
+      if (options.engine_seen) {
+        error = "duplicate --engine";
+        return false;
+      }
+      options.engine_seen = true;
+      options.engine = std::move(*value_text);
+    } else if (argument == "--rocksdb-path") {
+      auto value_text = value(argument);
+      if (!value_text) return false;
+      if (options.rocksdb_path_seen) {
+        error = "duplicate --rocksdb-path";
+        return false;
+      }
+      options.rocksdb_path_seen = true;
+      options.rocksdb_path = std::move(*value_text);
+    } else if (argument == "--prefix") {
+      auto value_text = value(argument);
+      if (!value_text) return false;
+      if (options.prefix_seen) {
+        error = "duplicate --prefix";
+        return false;
+      }
+      options.prefix_seen = true;
+      options.prefix = std::move(*value_text);
+    } else if (argument == "--zenoh-config") {
+      auto value_text = value(argument);
+      if (!value_text) return false;
+      if (options.zenoh_config.has_value() || options.zenoh_config_file.has_value()) {
+        error = "Zenoh configuration options are mutually exclusive or duplicated";
+        return false;
+      }
+      options.zenoh_config = std::move(*value_text);
+    } else if (argument == "--zenoh-config-file") {
+      auto value_text = value(argument);
+      if (!value_text) return false;
+      if (options.zenoh_config.has_value() || options.zenoh_config_file.has_value()) {
+        error = "Zenoh configuration options are mutually exclusive or duplicated";
+        return false;
+      }
+      options.zenoh_config_file = std::move(*value_text);
+    } else {
+      error = "unknown option: " + std::string(argument);
+      return false;
+    }
+  }
+  if (options.engine != "inmemory" && options.engine != "rocksdb") {
+    error = "--engine must be inmemory or rocksdb";
+    return false;
+  }
+  if (!sitos::IsValidPrefix(options.prefix)) {
+    error = "--prefix is invalid";
+    return false;
+  }
+  if (options.engine == "rocksdb" && options.rocksdb_path.empty()) {
+    error = "--rocksdb-path is required for rocksdb";
+    return false;
+  }
+  if (options.engine == "inmemory" && options.rocksdb_path_seen) {
+    error = "--rocksdb-path requires --engine rocksdb";
+    return false;
+  }
+#ifndef SITOS_WITH_ROCKSDB
+  if (options.engine == "rocksdb") {
+    error = "rocksdb engine is unavailable in this build";
+    return false;
+  }
+#endif
+  return true;
+}
+
+bool ReadConfig(const std::string& path, std::string& content) {
+  std::ifstream input(path, std::ios::binary);
+  if (!input) return false;
+  content.assign(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+  return !content.empty() && !input.bad();
+}
+
+template <typename T>
+void ReportFailure(std::string_view operation, const sitos::Result<T>& result) {
+  std::cerr << operation << " failed (status=" << static_cast<int>(result.StatusCode());
+  if (!result.Message().empty()) std::cerr << ", " << result.Message();
+  if (!result.IsOk()) {
+    const auto& cause = result.Error();
+    if (cause) std::cerr << ", cause=" << cause.category().name() << ':' << cause.value();
+  }
+  std::cerr << ")\n";
+}
+
+using TransportResult = sitos::Result<std::unique_ptr<sitos::Transport>>;
+
+TransportResult OpenConfiguredTransport(Options& options) {
+  if (options.zenoh_config_file.has_value()) {
+    std::string config;
+    if (!ReadConfig(*options.zenoh_config_file, config)) {
+      return TransportResult::Err(sitos::Status::InvalidArgument,
+                                  "unable to read Zenoh configuration file");
+    }
+    // The borrowed view and its owner end in this scope immediately after the
+    // synchronous factory call. Sitos never retains caller-owned JSON5 bytes.
+    return sitos::OpenZenohTransport(std::string_view(config));
+  }
+  if (options.zenoh_config.has_value()) {
+    std::string config = std::move(*options.zenoh_config);
+    options.zenoh_config.reset();
+    if (config.empty()) {
+      return TransportResult::Err(sitos::Status::InvalidArgument,
+                                  "Zenoh configuration must not be empty");
+    }
+    return sitos::OpenZenohTransport(std::string_view(config));
+  }
+  return sitos::OpenZenohTransport();
+}
+
+#ifdef _WIN32
+HANDLE g_stop_event = nullptr;
+BOOL WINAPI ConsoleHandler(DWORD event) {
+  if (event != CTRL_C_EVENT && event != CTRL_BREAK_EVENT) return FALSE;
+  return g_stop_event != nullptr && SetEvent(g_stop_event) != FALSE;
+}
+#else
+volatile sig_atomic_t g_signal_pipe = -1;
+void SignalHandler(int) {
+  const int saved_errno = errno;
+  const int descriptor = g_signal_pipe;
+  if (descriptor >= 0) {
+    const char notification = 's';
+    (void)write(descriptor, &notification, 1);
+  }
+  errno = saved_errno;
+}
+#endif
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  if (argc == 2 && std::string_view(argv[1]) == "--help") {
+    PrintHelp();
+    return 0;
+  }
+
+  Options options;
+  std::string parse_error;
+  if (!ParseOptions(argc, argv, options, parse_error)) {
+    std::cerr << "invalid arguments: " << parse_error << '\n';
+    return 2;
+  }
+
+  auto opened_transport = OpenConfiguredTransport(options);
+  if (!opened_transport.IsOk()) {
+    ReportFailure("OpenZenohTransport", opened_transport);
+    // A valid complete config can fail here when its selected listen port loses
+    // a bind race. The standard-library driver retries this code only before readiness.
+    return 3;
+  }
+  std::shared_ptr<sitos::Transport> transport(std::move(opened_transport).Value());
+
+  std::shared_ptr<sitos::StorageEngine> engine;
+#ifdef SITOS_WITH_ROCKSDB
+  if (options.engine == "rocksdb") {
+    auto opened_engine = sitos::RocksDBEngine::Open(options.rocksdb_path);
+    if (!opened_engine.IsOk()) {
+      ReportFailure("RocksDBEngine::Open", opened_engine);
+      transport.reset();
+      return 1;
+    }
+    engine = std::shared_ptr<sitos::StorageEngine>(std::move(opened_engine).Value());
+  } else
+#endif
+  {
+    engine = std::make_shared<sitos::InMemoryEngine>();
+  }
+
+  int exit_code = 0;
+  {
+    // StorageNode borrows transport. This scope guarantees destruction order:
+    // node, then the caller's engine, then the shared Transport below.
+    sitos::StorageNode node(*transport);
+#ifdef _WIN32
+    bool handler_registered = false;
+    bool event_created = false;
+    bool handler_ever_registered = false;
+    bool handler_cleanup_failed = false;
+    if (!SetConsoleCtrlHandler(nullptr, FALSE)) {
+      std::cerr << "unable to re-enable Ctrl-C\n";
+      exit_code = 1;
+    } else {
+      g_stop_event = CreateEvent(nullptr, TRUE, FALSE, nullptr);
+      event_created = g_stop_event != nullptr;
+      if (!event_created || !SetConsoleCtrlHandler(ConsoleHandler, TRUE)) {
+        std::cerr << "unable to install console handler\n";
+        if (event_created) {
+          if (SetConsoleCtrlHandler(ConsoleHandler, FALSE)) {
+            CloseHandle(g_stop_event);
+            g_stop_event = nullptr;
+            event_created = false;
+          } else {
+            handler_cleanup_failed = true;
+          }
+        }
+        exit_code = 1;
+      } else {
+        handler_registered = true;
+        handler_ever_registered = true;
+      }
+    }
+#else
+    int signal_pipe[2] = {-1, -1};
+    struct sigaction previous_action {};
+    bool handler_installed = false;
+    if (pipe(signal_pipe) != 0) {
+      std::cerr << "unable to create signal pipe\n";
+      exit_code = 1;
+    } else {
+      const int flags = fcntl(signal_pipe[1], F_GETFL, 0);
+      if (flags < 0 || fcntl(signal_pipe[1], F_SETFL, flags | O_NONBLOCK) != 0) {
+        std::cerr << "unable to configure signal pipe\n";
+        close(signal_pipe[0]);
+        close(signal_pipe[1]);
+        signal_pipe[0] = signal_pipe[1] = -1;
+        exit_code = 1;
+      } else {
+        g_signal_pipe = signal_pipe[1];
+        struct sigaction action {};
+        action.sa_handler = SignalHandler;
+        sigemptyset(&action.sa_mask);
+        action.sa_flags = 0;
+        if (sigaction(SIGINT, &action, &previous_action) != 0) {
+          std::cerr << "unable to install SIGINT handler\n";
+          g_signal_pipe = -1;
+          close(signal_pipe[0]);
+          close(signal_pipe[1]);
+          signal_pipe[0] = signal_pipe[1] = -1;
+          exit_code = 1;
+        } else {
+          handler_installed = true;
+        }
+      }
+    }
+#endif
+
+    if (exit_code == 0) {
+      auto started = node.Start(engine, {.prefix = options.prefix, .log_sink = nullptr});
+      if (!started.IsOk()) {
+        ReportFailure("StorageNode::Start", started);
+        exit_code = 1;
+      } else {
+        std::cout << "SITOBOLON_READY " << options.prefix << std::endl;
+#ifdef _WIN32
+        const DWORD wait_result = WaitForSingleObject(g_stop_event, INFINITE);
+        if (wait_result != WAIT_OBJECT_0) exit_code = 1;
+#else
+        char notification = 0;
+        ssize_t read_result;
+        do {
+          read_result = read(signal_pipe[0], &notification, 1);
+        } while (read_result < 0 && errno == EINTR);
+        if (read_result != 1) exit_code = 1;
+#endif
+      }
+    }
+
+    // All node lifecycle work stays on the main path, outside the handlers.
+    node.Stop();
+#ifdef _WIN32
+    if (handler_registered) {
+      if (!SetConsoleCtrlHandler(ConsoleHandler, FALSE)) {
+        std::cerr << "unable to remove console handler\n";
+        exit_code = 1;
+      } else {
+        handler_registered = false;
+      }
+    }
+    if (event_created && !handler_ever_registered && !handler_cleanup_failed) {
+      CloseHandle(g_stop_event);
+      g_stop_event = nullptr;
+      event_created = false;
+    } else if (handler_registered || handler_cleanup_failed) {
+      // Keep the event reachable by the still-registered handler until process exit.
+      exit_code = 1;
+    }
+    // Once registration succeeded, never close or reset g_stop_event. Even
+    // after successful removal, an in-flight callback may still reference it;
+    // process teardown owns that final handle close.
+#else
+    if (handler_installed) {
+      if (sigaction(SIGINT, &previous_action, nullptr) != 0) {
+        std::cerr << "unable to restore SIGINT handler\n";
+        exit_code = 1;
+      } else {
+        g_signal_pipe = -1;
+        handler_installed = false;
+      }
+    }
+    // Do not close this pipe while a handler could still reference it. The
+    // process exit closes it after restoration; this also covers restore failure.
+#endif
+  }
+
+  // The node is gone before either owner below is reset. This is required for
+  // RocksDB path release and for the StorageNode's borrowed Transport contract.
+  engine.reset();
+  transport.reset();
+  return exit_code;
+}

--- a/examples/cpp/sitobolon.cpp
+++ b/examples/cpp/sitobolon.cpp
@@ -150,16 +150,23 @@ bool ReadConfig(const std::string& path, std::string& content) {
   return !content.empty() && !input.bad();
 }
 
-template <typename T>
-void ReportFailure(std::string_view operation, const sitos::Result<T>& result) {
-  std::cerr << operation << " failed (status=" << static_cast<int>(result.StatusCode());
-  if (!result.Message().empty()) std::cerr << ", " << result.Message();
+const auto ReportFailure = [](std::string_view operation, const auto& result) {
+  std::string line = std::string(operation) +
+                     " failed (status=" + std::to_string(static_cast<int>(result.StatusCode()));
+  const std::string_view message = result.Message();
+  if (!message.empty()) line += ", " + std::string(message);
   if (!result.IsOk()) {
     const auto& cause = result.Error();
-    if (cause) std::cerr << ", cause=" << cause.category().name() << ':' << cause.value();
+    if (cause) {
+      line += ", cause=";
+      line += cause.category().name();
+      line += ':';
+      line += std::to_string(cause.value());
+    }
   }
-  std::cerr << ")\n";
-}
+  line += ')';
+  std::cerr << line << '\n';
+};
 
 using TransportResult = sitos::Result<std::unique_ptr<sitos::Transport>>;
 

--- a/tests/examples/test_cpp_examples.py
+++ b/tests/examples/test_cpp_examples.py
@@ -1,0 +1,614 @@
+"""Standard-library acceptance driver for the C++ examples."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import queue
+import re
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Iterable, TextIO
+
+READY_PREFIX = "SITOBOLON_READY "
+DIAGNOSTIC_LIMIT = 12_000
+PENDING_LIMIT = 4_096
+CHUNK_SIZE = 4_096
+MODE_SECONDS = 45.0
+START_SECONDS = 8.0
+CLEANUP_SECONDS = 4.0
+MIN_LAUNCH_WORK_SECONDS = START_SECONDS * 2.0
+START_ATTEMPTS = 5
+
+
+class ChildExitedBeforeReady(AssertionError):
+    """The child positively closed its pipes before publishing readiness."""
+
+    def __init__(self, returncode: int | None, diagnostics: str) -> None:
+        super().__init__(f"child exited with {returncode} before readiness; {diagnostics}")
+        self.returncode = returncode
+
+
+def _token() -> str:
+    return f"{os.getpid()}_{uuid.uuid4().hex}"
+
+
+def _valid_prefix() -> str:
+    return f"sitos/example_{_token()}"
+
+
+def _port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+def _config() -> tuple[str, str]:
+    marker = f"SITOBOLON_CONFIG_MARKER_{_token()}"
+    # This is a complete Zenoh document, not a fragment for sitobolon to merge.
+    config = (
+        f"// {marker}\n"
+        f'{{"mode":"peer","listen":{{"endpoints":["tcp/127.0.0.1:{_port()}"]}},'
+        '"scouting":{"multicast":{"enabled":false}}}'
+    )
+    return config, marker
+
+
+def _remaining(deadline: float) -> float:
+    return max(0.0, deadline - time.monotonic())
+
+
+def _send_ctrl_c_helper(pid: int) -> int:
+    """Deliver Ctrl-C from a helper attached to the target's private console."""
+    if os.name != "nt":
+        return 2
+    import ctypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.FreeConsole.restype = ctypes.c_int
+    kernel32.AttachConsole.argtypes = [ctypes.c_uint32]
+    kernel32.AttachConsole.restype = ctypes.c_int
+    kernel32.SetConsoleCtrlHandler.argtypes = [ctypes.c_void_p, ctypes.c_int]
+    kernel32.SetConsoleCtrlHandler.restype = ctypes.c_int
+    kernel32.GenerateConsoleCtrlEvent.argtypes = [ctypes.c_uint32, ctypes.c_uint32]
+    kernel32.GenerateConsoleCtrlEvent.restype = ctypes.c_int
+    kernel32.GetLastError.restype = ctypes.c_uint32
+    invalid_handle = 6  # ERROR_INVALID_HANDLE: helper simply had no inherited console.
+    if not kernel32.FreeConsole() and ctypes.get_last_error() != invalid_handle:
+        return 1
+    if not kernel32.AttachConsole(pid):
+        return 1
+    if not kernel32.SetConsoleCtrlHandler(None, 1):
+        kernel32.FreeConsole()
+        return 1
+    generated = kernel32.GenerateConsoleCtrlEvent(0, 0)  # CTRL_C_EVENT, process group 0.
+    detached = kernel32.FreeConsole()
+    if not generated or not detached:
+        return 1
+    return 0
+
+
+def _send_ctrl_c(pid: int, deadline: float) -> None:
+    timeout = min(START_SECONDS, _remaining(deadline))
+    if timeout <= 0:
+        raise AssertionError("insufficient time to invoke Ctrl-C helper")
+    result = _run(
+        [sys.executable, str(Path(__file__).resolve()), "send-ctrl-c", str(pid)],
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"Ctrl-C helper failed: {result.stdout + result.stderr!r}")
+
+
+class Child:
+    """Own a child, drain bounded binary chunks, and always reap it."""
+
+    def __init__(
+        self,
+        argv: list[str],
+        marker: str,
+        *,
+        new_group: bool = False,
+        windows_event: str | None = None,
+    ) -> None:
+        flags = 0
+        if os.name == "nt":
+            if windows_event == "ctrl-c":
+                flags = subprocess.CREATE_NEW_CONSOLE
+            elif windows_event == "ctrl-break" or new_group:
+                flags = subprocess.CREATE_NEW_PROCESS_GROUP
+        self.process = subprocess.Popen(
+            argv,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+            creationflags=flags,
+        )
+        self.lines: queue.Queue[str | None] = queue.Queue(maxsize=16)
+        self._out_tail = bytearray()
+        self._err_tail = bytearray()
+        self._marker = marker.encode("utf-8")
+        self._out_marker_tail = bytearray()
+        self._err_marker_tail = bytearray()
+        self._forbidden_seen = False
+        self._lock = threading.Lock()
+        self._threads: list[threading.Thread] = []
+        self._stdout_stream = self.process.stdout
+        self._stderr_stream = self.process.stderr
+        try:
+            if self._stdout_stream is None or self._stderr_stream is None:
+                raise RuntimeError("child output pipes were not created")
+            candidates = [
+                threading.Thread(target=self._stdout, args=(self._stdout_stream,), daemon=True),
+                threading.Thread(target=self._stderr, args=(self._stderr_stream,), daemon=True),
+            ]
+            for thread in candidates:
+                thread.start()
+                # Append only after start succeeds; _join never joins an
+                # unstarted thread when setup is interrupted.
+                self._threads.append(thread)
+        except BaseException:
+            self.cleanup()
+            raise
+
+    @property
+    def forbidden_seen(self) -> bool:
+        with self._lock:
+            return self._forbidden_seen
+
+    def _record(self, target: bytearray, scan_tail: bytearray, chunk: bytes) -> None:
+        with self._lock:
+            probe = bytes(scan_tail) + chunk
+            if self._marker in probe:
+                self._forbidden_seen = True
+            keep = max(0, len(self._marker) - 1)
+            scan_tail[:] = probe[-keep:] if keep else b""
+            target.extend(chunk)
+            if len(target) > DIAGNOSTIC_LIMIT:
+                del target[: len(target) - DIAGNOSTIC_LIMIT]
+
+    def _publish(self, line: str) -> None:
+        try:
+            self.lines.put_nowait(line)
+        except queue.Full:
+            # A bounded queue deliberately drops excess noise. The diagnostic
+            # tail still records it, and readiness cannot be inferred from it.
+            pass
+
+    def _stdout(self, stream: TextIO) -> None:
+        pending = b""
+        discarding = False
+        try:
+            while True:
+                chunk = stream.read(CHUNK_SIZE)
+                if not chunk:
+                    break
+                self._record(self._out_tail, self._out_marker_tail, chunk)
+                if discarding:
+                    newline = chunk.find(b"\n")
+                    if newline < 0:
+                        continue
+                    chunk = chunk[newline + 1 :]
+                    discarding = False
+                pending += chunk
+                while b"\n" in pending:
+                    raw, pending = pending.split(b"\n", 1)
+                    self._publish(raw[:PENDING_LIMIT].rstrip(b"\r").decode("utf-8", "replace"))
+                if len(pending) > PENDING_LIMIT:
+                    self._publish("<stdout line exceeded bounded pending storage>")
+                    pending = b""
+                    discarding = True
+            if pending:
+                self._publish(pending[:PENDING_LIMIT].rstrip(b"\r").decode("utf-8", "replace"))
+        finally:
+            self._publish(None)
+
+    def _stderr(self, stream: TextIO) -> None:
+        while True:
+            chunk = stream.read(CHUNK_SIZE)
+            if not chunk:
+                return
+            self._record(self._err_tail, self._err_marker_tail, chunk)
+
+    def diagnostics(self) -> str:
+        with self._lock:
+            stdout = bytes(self._out_tail).decode("utf-8", "replace")
+            stderr = bytes(self._err_tail).decode("utf-8", "replace")
+            marker = self._forbidden_seen
+        return f"stdout={stdout!r} stderr={stderr!r} forbidden_marker={marker}"
+
+    def ready(self, prefix: str, deadline: float) -> None:
+        expected = READY_PREFIX + prefix
+        while True:
+            timeout = _remaining(deadline)
+            if timeout <= 0:
+                raise AssertionError(f"readiness timeout; {self.diagnostics()}")
+            try:
+                line = self.lines.get(timeout=timeout)
+            except queue.Empty as error:
+                raise AssertionError(f"readiness timeout; {self.diagnostics()}") from error
+            if line is None:
+                code = self.process.poll()
+                raise ChildExitedBeforeReady(code, self.diagnostics())
+            if line != expected:
+                raise AssertionError(f"unexpected stdout line {line!r}; {self.diagnostics()}")
+            return
+
+    def stop(self, event: int | str | None, deadline: float) -> None:
+        if self.process.poll() is None:
+            if event == "ctrl-c":
+                _send_ctrl_c(self.process.pid, deadline)
+            elif event == "ctrl-break":
+                self.process.send_signal(signal.CTRL_BREAK_EVENT)
+            else:
+                self.process.send_signal(signal.SIGINT if event is None else event)
+        self.wait_zero(deadline)
+
+    def wait_zero(self, deadline: float) -> None:
+        try:
+            self.process.wait(timeout=_remaining(deadline))
+        except subprocess.TimeoutExpired as error:
+            self.cleanup()
+            raise AssertionError(f"child did not stop; {self.diagnostics()}") from error
+        if self.process.returncode != 0:
+            raise AssertionError(f"child returned {self.process.returncode}; {self.diagnostics()}")
+        self._join(deadline)
+
+    def _terminate(self, deadline: float) -> None:
+        if self.process.poll() is None:
+            self.process.terminate()
+        try:
+            self.process.wait(timeout=max(0.1, min(2.0, _remaining(deadline))))
+        except subprocess.TimeoutExpired:
+            self.process.kill()
+            try:
+                self.process.wait(timeout=max(0.1, min(2.0, _remaining(deadline))))
+            except subprocess.TimeoutExpired as error:
+                raise AssertionError("child could not be reaped after kill") from error
+        if self.process.poll() is None:
+            raise AssertionError("child remained unreaped after termination")
+
+    def _join(self, deadline: float) -> None:
+        timeout = max(0.1, min(1.0, _remaining(deadline)))
+        for thread in self._threads:
+            thread.join(timeout=timeout)
+            if thread.is_alive():
+                raise AssertionError("output drainer did not terminate")
+
+    def cleanup(self) -> None:
+        # Cleanup owns an independent positive reserve, never the expired work
+        # deadline. The 45-second mode budget plus this reserve stays below CTest 60.
+        deadline = time.monotonic() + CLEANUP_SECONDS
+        if self.process.poll() is None:
+            self._terminate(deadline)
+        self._join(deadline)
+        for stream in (self._stdout_stream, self._stderr_stream):
+            if stream is not None:
+                stream.close()
+
+
+def _run(argv: list[str], *, timeout: float = 8.0) -> subprocess.CompletedProcess[bytes]:
+    try:
+        return subprocess.run(argv, capture_output=True, timeout=timeout, check=False)
+    except subprocess.TimeoutExpired as error:
+        raise AssertionError(f"command timed out: {argv!r}") from error
+
+
+def _assert_no_ready(result: subprocess.CompletedProcess[bytes]) -> None:
+    output = result.stdout + result.stderr
+    assert READY_PREFIX.encode() not in output, result
+
+
+def configure_guard(args: argparse.Namespace) -> int:
+    build = Path(args.build)
+    if build.exists():
+        import shutil
+
+        shutil.rmtree(build)
+    result = _run(
+        [
+            args.cmake,
+            "-S",
+            args.source,
+            "-B",
+            str(build),
+            "-G",
+            args.generator,
+            "-DSITOS_BUILD_EXAMPLES=ON",
+            "-DSITOS_WITH_ZENOH=OFF",
+            "-DSITOS_BUILD_TESTS=OFF",
+        ],
+        timeout=30.0,
+    )
+    output = result.stdout + result.stderr
+    expected = b"SITOS_BUILD_EXAMPLES requires SITOS_WITH_ZENOH=ON"
+    if result.returncode == 0 or expected not in output:
+        raise AssertionError(
+            f"configure guard mismatch (exit={result.returncode}); output={output!r}"
+        )
+    return 0
+
+
+def _help(executable: str) -> int:
+    result = _run([executable, "--help"])
+    assert result.returncode == 0, result
+    _assert_no_ready(result)
+    text = result.stdout.decode("utf-8", "replace")
+    section = text.split("Options:\n", 1)[-1]
+    entries = re.findall(r"^  (--[a-z][a-z-]*)(?:\s|$)", section, re.MULTILINE)
+    expected = {
+        "--engine",
+        "--rocksdb-path",
+        "--prefix",
+        "--zenoh-config",
+        "--zenoh-config-file",
+        "--help",
+    }
+    assert set(entries) == expected and len(entries) == len(expected), entries
+    assert "inmemory|rocksdb" in text, text
+    return 0
+
+
+def _invalid(executable: str, argv: tuple[str, ...], forbidden: tuple[bytes, ...], deadline: float) -> None:
+    timeout = min(8.0, _remaining(deadline))
+    result = _run([executable, *argv], timeout=timeout)
+    assert result.returncode != 0, (argv, result)
+    _assert_no_ready(result)
+    output = result.stdout + result.stderr
+    for fragment in forbidden:
+        assert fragment not in output, (argv, fragment, result)
+
+
+def invalid_arguments(executable: str, rocksdb_built: bool) -> int:
+    deadline = time.monotonic() + MODE_SECONDS
+    with tempfile.TemporaryDirectory(prefix="sitos-example-invalid-") as root:
+        root_path = Path(root)
+        unreadable = root_path / "missing.json5"
+        empty = root_path / "empty.json5"
+        empty.touch()
+        direct_marker = "DIRECT_SECRET_" + _token()
+        file_marker = "FILE_SECRET_" + _token()
+        duplicate_marker = "DUPLICATE_SECRET_" + _token()
+        direct_json = '{"mode":"peer","secret":"' + direct_marker + '"'
+        file_json = '{"mode":"peer","secret":"' + file_marker + '"'
+        duplicate_json = '{"mode":"peer","secret":"' + duplicate_marker + '"}'
+        malformed = root_path / "malformed.json5"
+        malformed.write_text(file_json, encoding="utf-8")
+        cases: list[tuple[tuple[str, ...], tuple[bytes, ...]]] = []
+
+        def add(*argv: str, forbidden: tuple[str, ...] = ()) -> None:
+            cases.append((tuple(argv), tuple(item.encode("utf-8") for item in forbidden)))
+
+        add("--unknown")
+        add("--help", "--unknown")
+        add("--help", "--help")
+        add("--help", "--engine", "inmemory")
+        add("--help", "--rocksdb-path", "db")
+        add("--help", "--prefix", "sitos/x")
+        add("--help", "--zenoh-config", direct_json,
+            forbidden=(direct_json, direct_marker))
+        add("--help", "--zenoh-config-file", str(malformed),
+            forbidden=(file_json, file_marker))
+        add("--engine")
+        add("--engine", "bogus")
+        add("--engine", "inmemory", "--engine", "inmemory")
+        add("--prefix")
+        add("--prefix", "bad prefix")
+        add("--prefix", "sitos//x")
+        add("--prefix", "sitos?x")
+        add("--prefix", "sitos/x", "--prefix", "sitos/y")
+        add("--rocksdb-path")
+        add("--rocksdb-path", "")
+        add("--rocksdb-path", str(root_path / "db"), "--rocksdb-path", "db2")
+        add("--rocksdb-path", str(root_path / "db"))
+        add("--engine", "inmemory", "--rocksdb-path", "")
+        add("--engine", "inmemory", "--rocksdb-path", str(root_path / "db"))
+        add("--zenoh-config")
+        add("--zenoh-config", "")
+        add("--zenoh-config-file")
+        add("--zenoh-config", duplicate_json, "--zenoh-config", duplicate_json,
+            forbidden=(duplicate_json, duplicate_marker))
+        add("--zenoh-config-file", str(empty), "--zenoh-config-file", str(malformed),
+            forbidden=(file_json, file_marker))
+        add("--zenoh-config", duplicate_json, "--zenoh-config-file", str(malformed),
+            forbidden=(duplicate_json, duplicate_marker, file_json, file_marker))
+        add("--zenoh-config-file", str(malformed), "--zenoh-config", direct_json,
+            forbidden=(file_json, file_marker, direct_json, direct_marker))
+        add("--zenoh-config-file", str(unreadable))
+        add("--zenoh-config-file", str(empty))
+        add("--zenoh-config", direct_json, forbidden=(direct_json, direct_marker))
+        add("--zenoh-config-file", str(malformed), forbidden=(file_json, file_marker))
+        if rocksdb_built:
+            add("--engine", "rocksdb")
+        else:
+            rocksdb_path = root_path / "db-off"
+            add("--engine", "rocksdb", "--rocksdb-path", str(rocksdb_path))
+        for argv, forbidden in cases:
+            _invalid(executable, argv, forbidden, deadline)
+        if not rocksdb_built:
+            assert not rocksdb_path.exists(), rocksdb_path
+    return 0
+
+
+def _launch(
+    executable: str,
+    config_file: bool,
+    *,
+    prefix: str,
+    deadline: float,
+    db: Path | None = None,
+    event: int | str | None = None,
+) -> None:
+    fixed_args = ["--engine", "rocksdb", "--rocksdb-path", str(db)] if db else []
+    for attempt in range(START_ATTEMPTS):
+        if _remaining(deadline) < MIN_LAUNCH_WORK_SECONDS:
+            raise AssertionError("insufficient lifecycle work budget for another child")
+        config, marker = _config()
+        argv = [executable, "--prefix", prefix, *fixed_args]
+        temporary_path: Path | None = None
+        if config_file:
+            temporary = tempfile.NamedTemporaryFile(
+                "w", suffix=".json5", delete=False, encoding="utf-8"
+            )
+            temporary.write(config)
+            temporary.close()
+            temporary_path = Path(temporary.name)
+            argv += ["--zenoh-config-file", str(temporary_path)]
+        else:
+            argv += ["--zenoh-config", config]
+        child = Child(
+            argv,
+            marker,
+            new_group=(event == "ctrl-break"),
+            windows_event=event if isinstance(event, str) else None,
+        )
+        try:
+            try:
+                child.ready(prefix, min(deadline, time.monotonic() + START_SECONDS))
+            except ChildExitedBeforeReady as error:
+                child.cleanup()
+                # A failed attempt is fully reaped before either retry or raise;
+                # a leaked marker is never allowed to disappear with the child.
+                assert not child.forbidden_seen, child.diagnostics()
+                if error.returncode == 3 and attempt + 1 < START_ATTEMPTS:
+                    continue
+                raise
+            except BaseException:
+                child.cleanup()
+                assert not child.forbidden_seen, child.diagnostics()
+                raise
+            try:
+                child.stop(event, min(deadline, time.monotonic() + START_SECONDS))
+            except BaseException:
+                child.cleanup()
+                assert not child.forbidden_seen, child.diagnostics()
+                raise
+            assert not child.forbidden_seen, child.diagnostics()
+            # Successful stop does not resend a signal; explicitly close the
+            # already-reaped streams and drainer threads.
+            child.cleanup()
+            return
+        finally:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
+
+
+def lifecycle(executable: str) -> int:
+    deadline = time.monotonic() + MODE_SECONDS
+    events = ["ctrl-c", "ctrl-break"] if os.name == "nt" else [signal.SIGINT]
+    for config_file in (False, True):
+        for event in events:
+            for _ in range(2 if os.name == "nt" else 1):
+                _launch(executable, config_file, prefix=_valid_prefix(), deadline=deadline, event=event)
+    return 0
+
+
+def rocksdb_lifecycle(executable: str) -> int:
+    deadline = time.monotonic() + MODE_SECONDS
+    with tempfile.TemporaryDirectory(prefix="sitos-example-rocksdb-") as root:
+        path = Path(root) / "database"
+        _launch(executable, False, prefix=_valid_prefix(), deadline=deadline, db=path)
+        _launch(executable, True, prefix=_valid_prefix(), deadline=deadline, db=path)
+        import shutil
+
+        shutil.rmtree(path)
+        assert not path.exists()
+    return 0
+
+
+def ctest_contract(args: argparse.Namespace) -> int:
+    result = _run([args.ctest, "--test-dir", args.build, "--show-only=json-v1"], timeout=15.0)
+    assert result.returncode == 0, result
+    payload = json.loads(result.stdout.decode("utf-8"))
+    expected = {
+        "CppQuickstartRuns",
+        "SitobolonHelpDocumentsOptions",
+        "SitobolonRejectsInvalidArguments",
+        "SitobolonStartsAndStopsCleanly",
+    }
+    if args.rocksdb_built:
+        expected.add("SitobolonRocksDbReleasesPath")
+
+    graph = payload.get("backtraceGraph", {})
+    files = graph.get("files", [])
+    nodes = graph.get("nodes", [])
+    source_file = str(Path("examples/cpp/CMakeLists.txt").resolve())
+
+    def registration_files(backtrace: int) -> set[str]:
+        found: set[str] = set()
+        seen: set[int] = set()
+        while isinstance(backtrace, int) and backtrace not in seen and backtrace < len(nodes):
+            seen.add(backtrace)
+            node = nodes[backtrace]
+            file_index = node.get("file")
+            if isinstance(file_index, int) and file_index < len(files):
+                found.add(str(Path(files[file_index]).resolve()))
+            backtrace = node.get("parent")
+        return found
+
+    registered_from_examples = {
+        test["name"]
+        for test in payload.get("tests", [])
+        if source_file in registration_files(test.get("backtrace"))
+    }
+    assert registered_from_examples == expected, (registered_from_examples, expected)
+    serial = {"CppQuickstartRuns", "SitobolonStartsAndStopsCleanly"}
+    if args.rocksdb_built:
+        serial.add("SitobolonRocksDbReleasesPath")
+    for test in payload["tests"]:
+        if test["name"] not in expected:
+            continue
+        properties = {item["name"]: item["value"] for item in test.get("properties", [])}
+        assert properties.get("TIMEOUT") == 60.0, (test["name"], properties)
+        assert (properties.get("RUN_SERIAL") is True) == (test["name"] in serial), (test["name"], properties)
+    return 0
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument(
+        "mode",
+        choices=("configure-guard", "help", "invalid", "lifecycle", "rocksdb", "ctest-contract", "send-ctrl-c"),
+    )
+    parser.add_argument("helper_pid", nargs="?")
+    parser.add_argument("--executable")
+    parser.add_argument("--rocksdb-built", action="store_true")
+    parser.add_argument("--source", default=".")
+    parser.add_argument("--build", default="build/issue31-guard")
+    parser.add_argument("--generator", default="Ninja")
+    parser.add_argument("--cmake", default="cmake")
+    parser.add_argument("--ctest", default="ctest")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    if args.mode == "configure-guard":
+        return configure_guard(args)
+    if args.mode == "ctest-contract":
+        return ctest_contract(args)
+    if args.mode == "send-ctrl-c":
+        if args.helper_pid is None or os.name != "nt":
+            return 2
+        return _send_ctrl_c_helper(int(args.helper_pid))
+    if not args.executable:
+        parser.error("--executable is required for this mode")
+    if args.mode == "help":
+        return _help(args.executable)
+    if args.mode == "invalid":
+        return invalid_arguments(args.executable, args.rocksdb_built)
+    if args.mode == "lifecycle":
+        return lifecycle(args.executable)
+    return rocksdb_lifecycle(args.executable)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (AssertionError, OSError, subprocess.SubprocessError) as error:
+        print(f"example validation failed: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/tests/examples/test_cpp_examples.py
+++ b/tests/examples/test_cpp_examples.py
@@ -326,7 +326,7 @@ def configure_guard(args: argparse.Namespace) -> int:
             "-DSITOS_WITH_ZENOH=OFF",
             "-DSITOS_BUILD_TESTS=OFF",
         ],
-        timeout=30.0,
+        timeout=90.0,
     )
     output = result.stdout + result.stderr
     expected = b"SITOS_BUILD_EXAMPLES requires SITOS_WITH_ZENOH=ON"
@@ -513,10 +513,11 @@ def lifecycle(executable: str) -> int:
 
 def rocksdb_lifecycle(executable: str) -> int:
     deadline = time.monotonic() + MODE_SECONDS
+    event: int | str = "ctrl-break" if os.name == "nt" else signal.SIGINT
     with tempfile.TemporaryDirectory(prefix="sitos-example-rocksdb-") as root:
         path = Path(root) / "database"
-        _launch(executable, False, prefix=_valid_prefix(), deadline=deadline, db=path)
-        _launch(executable, True, prefix=_valid_prefix(), deadline=deadline, db=path)
+        _launch(executable, False, prefix=_valid_prefix(), deadline=deadline, db=path, event=event)
+        _launch(executable, True, prefix=_valid_prefix(), deadline=deadline, db=path, event=event)
         import shutil
 
         shutil.rmtree(path)

--- a/tests/examples/test_cpp_examples.py
+++ b/tests/examples/test_cpp_examples.py
@@ -237,6 +237,12 @@ class Child:
                 raise AssertionError(f"readiness timeout; {self.diagnostics()}") from error
             if line is None:
                 code = self.process.poll()
+                if code is None:
+                    try:
+                        waited_code = self.process.wait(timeout=_remaining(deadline))
+                    except subprocess.TimeoutExpired:
+                        waited_code = None
+                    code = waited_code if waited_code is not None else self.process.returncode
                 raise ChildExitedBeforeReady(code, self.diagnostics())
             if line != expected:
                 raise AssertionError(f"unexpected stdout line {line!r}; {self.diagnostics()}")

--- a/tests/vcpkg/validate_vcpkg_provisioning.cmake
+++ b/tests/vcpkg/validate_vcpkg_provisioning.cmake
@@ -20,6 +20,10 @@ function(run_checked)
   endif()
 endfunction()
 
+# The combined acceptance driver is an existing test dependency. Resolve it in
+# this outer validator and pass the exact interpreter into the combined cache.
+find_package(Python3 3.10 REQUIRED COMPONENTS Interpreter)
+
 set(_manifest "${SITOS_SOURCE_DIR}/vcpkg.json")
 if(NOT EXISTS "${_manifest}")
   message(FATAL_ERROR
@@ -98,7 +102,8 @@ set(_combined_build "${_work_dir}/sitos-combined-build")
 run_checked(
   "${CMAKE_COMMAND}" -S "${SITOS_SOURCE_DIR}" -B "${_combined_build}"
   ${_generator_args} -DCMAKE_BUILD_TYPE=Release
-  -DSITOS_BUILD_TESTS=ON -DSITOS_WITH_ZENOH=ON -DSITOS_WITH_ROCKSDB=ON
+  -DSITOS_BUILD_TESTS=ON -DSITOS_BUILD_EXAMPLES=ON -DSITOS_WITH_ZENOH=ON -DSITOS_WITH_ROCKSDB=ON
+  "-DPython3_EXECUTABLE=${Python3_EXECUTABLE}"
   "-DCMAKE_TOOLCHAIN_FILE=${_toolchain}"
   "-DVCPKG_MANIFEST_DIR=${SITOS_SOURCE_DIR}"
   -DVCPKG_MANIFEST_FEATURES=rocksdb
@@ -110,10 +115,16 @@ string(CONCAT _combined_test_regex
   "StorageNodeBufferApiTest|StorageNodeBufferLifecycleTest|StorageNodeBufferRoutingTest|"
   "BufferLateJoinTest|RawZenohClientCanUseMixedSessionBuffers|"
   "RawZenohDurableLateJoinPreservesDistinctKeys|RawZenohBufferInteropFixtureBoundaries|"
-  "RocksDBBufferLifecycleTest")
+  "RocksDBBufferLifecycleTest|CppQuickstartRuns|SitobolonHelpDocumentsOptions|"
+  "SitobolonRejectsInvalidArguments|SitobolonStartsAndStopsCleanly|"
+  "SitobolonRocksDbReleasesPath")
 run_checked(
   "${CMAKE_CTEST_COMMAND}" --test-dir "${_combined_build}" --output-on-failure
   --no-tests=error --timeout 60 -R "${_combined_test_regex}")
+run_checked(
+  "${Python3_EXECUTABLE}"
+  "${SITOS_SOURCE_DIR}/tests/examples/test_cpp_examples.py"
+  ctest-contract --build "${_combined_build}" --rocksdb-built)
 
 set(_combined_prefix "${_work_dir}/sitos-combined-prefix")
 set(_combined_relocated_prefix "${_work_dir}/sitos-combined-relocated-prefix")
@@ -123,6 +134,12 @@ run_checked(
   "${CMAKE_COMMAND}" "-DSITOS_PREFIX=${_combined_prefix}"
   "-DSITOS_INSTALL_LIBDIR=lib"
   -P "${SITOS_SOURCE_DIR}/tests/package/check_clean_install.cmake")
+file(GLOB_RECURSE _installed_examples LIST_DIRECTORIES false
+  "${_combined_prefix}/quickstart" "${_combined_prefix}/quickstart.exe"
+  "${_combined_prefix}/sitobolon" "${_combined_prefix}/sitobolon.exe")
+if(_installed_examples)
+  message(FATAL_ERROR "Combined install unexpectedly contains example executables: ${_installed_examples}")
+endif()
 run_checked("${CMAKE_COMMAND}" -E copy_directory "${_combined_prefix}" "${_combined_relocated_prefix}")
 run_checked(
   "${CMAKE_COMMAND}" "-DSITOS_PREFIX=${_combined_relocated_prefix}"


### PR DESCRIPTION
## Summary

- Add a self-contained one-Transport C++ quickstart using public APIs only.
- Add the standalone `sitobolon` StorageNode demo with exact CLI, complete JSON5 pass-through, InMemory/RocksDB selection, and signal-driven cleanup.
- Add bounded standard-library process acceptance, standard Linux/Windows example builds, combined vcpkg coverage, non-install checks, and synchronized documentation.

Closes #31

## Frozen scope checklist

### C++ quickstart

- [x] Add `examples/cpp/quickstart.cpp` as a heavily commented, self-contained tutorial.
- [x] Open exactly one Zenoh `Transport`, convert it to shared ownership, and inject that same Transport into one `StorageNode`, one `ParamStore`, and one `ParamCache`.
- [x] Use `InMemoryEngine`, a run-unique valid prefix, and a run-unique valid Session id.
- [x] Put one typed scalar and one BYTES LUT into `base`; because Put is submission-only, use a bounded Get observation boundary before `CreateSession` rather than assuming Put return means node application.
- [x] Demonstrate the public sequence: observed base values → `StorageNode::CreateSession` → `ParamCache::Attach` → typed `Get` → byte-exact `GetSpan<std::byte>`.
- [x] Keep the returned `SpanHandle` alive while using its span and explain in tutorial comments that the span must not outlive its `keepalive` owner.
- [x] Clean up in order with `ParamCache::Detach`, `StorageNode::CloseSession`, and `StorageNode::Stop`; return nonzero with concise diagnostics on any failed operation.
- [x] Use only installed/public headers and APIs. Do not launch or connect to `sitobolon`, open multiple same-process Zenoh sessions, use private headers, call a nonexistent `StorageNode::engine()`, or introduce a public `SessionController` type.

### `sitobolon` demo process

- [x] Add `examples/cpp/sitobolon.cpp` as a standalone StorageNode development/demo process, not a remote Session controller and not a new control protocol.
- [x] Implement the exact CLI frozen below without adding another parser library.
- [x] Select `InMemoryEngine` by default or `RocksDBEngine` only when RocksDB support is built.
- [x] Pass an absent or complete JSON5 document to `OpenZenohTransport`; never parse, merge, persist, log, or reproduce JSON5 content in sitos diagnostics, and release any caller-owned configuration buffer after `OpenZenohTransport` returns.
- [x] Emit the exact local-process readiness line `SITOBOLON_READY <prefix>` only after Transport creation, engine creation, and `StorageNode::Start` all succeed.
- [x] Handle POSIX SIGINT and both Windows console Ctrl-C and Ctrl-Break by publishing only a minimal stop signal from the handler and performing `StorageNode::Stop`, engine destruction, and all I/O on the main execution path.
- [x] Exit zero after normal signal-driven shutdown; exit nonzero after invalid arguments or startup failure, with failure-safe cleanup and no readiness line on failure.
- [x] Add no stdin command protocol, HTTP endpoint, Zenoh lifecycle-control route, daemon dependency, or remote Session-management API.

### Build, validation, and documentation

- [x] Add `examples/cpp/CMakeLists.txt`; build `quickstart` and `sitobolon` only when `SITOS_BUILD_EXAMPLES=ON`.
- [x] Keep `SITOS_BUILD_EXAMPLES` default `OFF`; require `SITOS_WITH_ZENOH=ON` with a clear configure-time error when examples are enabled.
- [x] Link examples through `sitos::sitos`, enable repository warning policy, and stage the existing Zenoh runtime as required on Windows.
- [x] Do not install the examples or change normal library/package/wheel installation defaults.
- [x] Add a standard-library Python process driver with bounded stdout/stderr draining, readiness waits, process waits, signal delivery, and failure cleanup; use no fixed sleeps.
- [x] Build and run the RocksDB-OFF example acceptance tests in the existing Linux and Windows build jobs.
- [x] Build examples and run the RocksDB acceptance case in both existing combined Zenoh-ON/RocksDB-ON vcpkg lanes; add no workflow or provisioning path.
- [x] Give every example CTest `TIMEOUT 60`; use `RUN_SERIAL TRUE` for tests that open real local Zenoh sessions.
- [x] Clarify in `docs/02_architecture.md` that `SessionController` is only a conceptual responsibility inside the StorageNode-owning process and that the public API is `StorageNode::CreateSession`, `CloseSession`, and `ActiveSessions`.
- [x] Synchronize example build/validation documentation and the #31 entry in `docs/06_build_test_packaging.md` and `docs/07_issue_breakdown.md`.


## Requirements

- F01, F02, F05, F10
- N04, N05, N06
- X02, X03, X04

## Acceptance verification

- `CppQuickstartRuns`: passed locally
- `SitobolonHelpDocumentsOptions`: passed locally
- `SitobolonRejectsInvalidArguments`: passed locally
- `SitobolonStartsAndStopsCleanly`: passed locally; repeat 5/5
- `SitobolonRocksDbReleasesPath`: passed in both combined vcpkg lanes
- Full local CTest: 403/403 passed
- Exact CTest metadata contract: passed
- Install absence proof: passed
- Native Windows Ctrl-C/Ctrl-Break and combined Linux/Windows vcpkg: passed on exact head

## TDD / evidence classification

### Genuine compile/contract RED

- Command: `python3 tests/examples/test_cpp_examples.py configure-guard --source . --build build/issue31-zenoh-off --generator Ninja`
- Failing check: `configure-guard`
- Expected reason: before the root guard existed, examples ON with Zenoh OFF incorrectly configured successfully.
- Representative line: `example validation failed: configure guard mismatch (exit=0); stdout='-- Configuring done ...'`
- Chronology: the driver assertion was written and run before the root CMake guard; evidence is preserved at `/tmp/issue31-red-evidence.txt` in the implementation session.

### Other classifications

- Five executable/process cases: co-developed integration coverage
- Combined platform execution: co-developed integration coverage
- CI wiring and documentation: N/A for behavioral RED
- No behavioral RED was fabricated from missing executable targets.

## Validation performed

- Fresh Debug Zenoh-ON/RocksDB-OFF configure and build
- Exact four non-RocksDB CTests: 4/4
- Full CTest: 403/403
- Lifecycle repeat: 5/5
- Configure guard GREEN
- Python syntax, C++ clang-format dry-run, YAML parse, `git diff --check`
- Changed-path audit: exact ten frozen paths
- Installed-tree search: no `quickstart[.exe]` or `sitobolon[.exe]`

## Architecture / contracts

- ADR: not required under `DEC-31-BUILD-ADR-001`; this realizes the existing default-OFF examples surface without changing option/default/dependency/platform/install/public-contract boundaries.
- Contract Registry: N/A; no public wire surface or stable remote identifier is added.
- Public API/wire/dependencies: unchanged.
- Examples remain default OFF and are not installed.

## Review and merge authority

- Exact-head R3 independent reviews: Sol `MERGE`, Terra `MERGE`, General `MERGE`
- Exact-head hosted status: 18 passed, 1 optional skipped, 0 failed/pending
- [x] Exact-head hosted checks complete
- [x] Exact-head independent PR review complete
- [ ] Owner merge authorization recorded for the current exact PR head

Auto-merge and rebase merge are prohibited. Merge authorization remains separate.

