### PR TITLE
docs: add the granary, a preface in verse

### DIFF
--- a/docs/granary.md
+++ b/docs/granary.md
@@ -1,0 +1,51 @@
+# The granary
+
+*A history of parameter plumbing in compute machines, told as verse — why a
+parameter store exists, and what it answers. Off the main path, for whoever
+wanders in.*
+
+---
+
+Before there was a granary, there were addresses.
+Every measure of grain had its numbered shelf,
+recorded in a ledger kept in another room,
+in a spreadsheet, by someone else;
+to store one cup more, you petitioned for shelf-space,
+and were told the shelves were full.
+
+Later the harvest came as one great sack,
+dropped on the threshold at hours no one chose.
+You learned to eat quickly, between deliveries.
+New seed went unplanted — or hid in jars
+labelled only *one*, *two*, *three*, *four*.
+
+There were three doors to the same pantry,
+each with its own key, its own etiquette,
+and a keeper who asked, every time,
+which kind of hunger had brought you.
+
+To see inside your own stores, you forged instruments —
+lanterns that took a season each to build,
+and went dark whenever a shelf was moved;
+in time, the shelves were forbidden to move,
+for the lanterns' sake.
+
+**sitos** is what was carried out of those years:
+one measure, for a pinch of seed
+or the year's whole harvest;
+one door, open to whoever is hungry;
+a larder sealed at the start of the cooking,
+so the cook never wonders what changed mid-flame;
+rations that reach every hearth on the field,
+the same weight in every hand.
+
+Compute is fed, and forgets it was ever hungry.
+That is the whole ambition: that the work
+think about the work,
+and the feeding go without saying.
+
+---
+
+*If you have ever kept parameters at fixed offsets in a shared-memory map,
+or grown a struct only at its tail so nothing older would break — then this
+is your history too. sitos is its harvest.*


### PR DESCRIPTION
## Purpose

Add one quiet literary piece under `docs/` stating why a parameter store
exists — the history of parameter plumbing, told as a granary's history.
Deliberately unlinked from the README and the numbered documents: meant to
be found, not advertised.

## Checklist (from #151)

- [x] `docs/granary.md` added
- [x] Content is original writing; no internal project names, identifiers,
      schemas, or code from any proprietary source (clean-room confirmed)
- [x] English only

Requirement IDs: N/A (no functional surface)
Contract Registry rows: N/A
ADR: not required (documentation; no decision surface)
RED evidence: N/A (documentation; no executable behavior). Validation:
the file renders as plain Markdown and touches no build input.

Closes #151
