### PR TITLE
fix(release): pin initial version (#156)

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -6,6 +6,7 @@
       "release-type": "simple",
       "package-name": "sitos",
       "changelog-path": "CHANGELOG.md",
+      "initial-version": "0.1.0",
       "include-v-in-tag": true,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,

--- a/tests/release/test_release_configuration.py
+++ b/tests/release/test_release_configuration.py
@@ -259,6 +259,7 @@ class ReleaseConfigurationContractTest(unittest.TestCase):
         self.assertEqual(package["release-type"], "simple")
         self.assertEqual(package["package-name"], "sitos")
         self.assertEqual(package["changelog-path"], "CHANGELOG.md")
+        self.assertEqual(package["initial-version"], "0.1.0")
         self.assertIs(package["include-v-in-tag"], True)
         self.assertIs(package["bump-minor-pre-major"], True)
         self.assertIs(package["bump-patch-for-minor-pre-major"], False)


### PR DESCRIPTION
## Summary

- Configure release-please's one-time initial version as `0.1.0`.
- Enforce the approved bootstrap version in the offline release contract.
- Avoid `release-as`, so subsequent versions continue to follow Conventional Commits.

Closes #156

## Frozen Issue Checklist

- [x] The release-please root package explicitly sets `initial-version` to `0.1.0`.
- [x] Offline contract tests fail before the configuration change and pass afterward.
- [x] Existing release and documentation contract tests pass.
- [ ] PR #155 proposes `0.1.0` after the correction is merged to `main`.
- [x] PR #155 remains unmerged until the API is release-ready and separately authorized.
- [x] No tag, GitHub Release, TestPyPI publication, or production PyPI publication is created by this correction.

## RED Evidence

- Command: `python3 -B -m unittest tests.release.test_release_configuration.ReleaseConfigurationContractTest.test_shared_version_and_release_please_config -v`
- Failing test: `test_shared_version_and_release_please_config`
- Expected reason: the release-please package configuration did not define `initial-version`.
- Representative failure: `KeyError: 'initial-version'`

## Verification

- `python3 -B tests/release/test_release_configuration.py -v` — 6 passed
- `python3 -B tests/docs/test_public_documentation.py -v` — 8 passed
- Both suites also passed when invoked from `/tmp`.
- Python compilation, JSON parsing, static no-`release-as` assertions, and `git diff --check` passed.
- Independent read-only validation found no included finding.

## Requirements

- C04: applicable; the release version remains synchronized through the existing release workflow.
- P03: deferred to the separately authorized production release.

## Contract Registry

N/A. This corrects release orchestration and does not change a wire or API contract.

## ADR Needed

No. This implements the already approved first-release version policy.

## Release Boundary

This PR does not authorize merging PR #155, creating a tag or GitHub Release, or publishing to TestPyPI or production PyPI.

## Owner Merge Authorization

- Status: Authorized for normal merge
- Authorized head SHA: `c2be8fba2ce234a2594e82bdffddecfe3bd93bca`
- Owner instruction link: https://github.com/tetsuh/sitos/pull/157#issuecomment-5304280551
