### PR TITLE
docs(adr): define ADR index authority (#159)

### DIFF
--- a/docs/00_overview.md
+++ b/docs/00_overview.md
@@ -79,19 +79,20 @@ repository as a general-purpose library not limited to CT reconstruction.
 | [07_issue_breakdown.md](07_issue_breakdown.md) | Public | Milestones and proposed issue breakdown |
 | [08_contract_registry.md](08_contract_registry.md) | Public | Public contract registry: index of wire surfaces and stable identifiers |
 | [09_dependency_policy.md](09_dependency_policy.md) | Public | Dependency and zenoh compatibility policy |
-| [10_adr_process.md](10_adr_process.md) | Public | ADR writing and operation rules (to be moved to docs/adr/README.md) |
+| [10_adr_process.md](10_adr_process.md) | Public | Canonical ADR writing and operation rules |
+| [adr/README.md](adr/README.md) | Public | Sole comprehensive maintained ADR index |
 | [CONTRIBUTING.md](../CONTRIBUTING.md) | Public | Canonical branching strategy, TiDD, TDD, and contribution workflow |
 
 All documents listed above are public Markdown maintained in the sitos repository. Design and
 operations documents live under `docs/`; the contributor workflow lives at the repository root.
 Public documents must not contain references to non-public documents.
 
-## 6. Record of Major Decisions (ADR Summary)
+## 6. Historical Record of Initial Major Decisions (D1-D13)
 
-The operation rules are in [10_adr_process.md](10_adr_process.md). At repository
-creation, D1 through D13 are filed in English as individual ADRs under
-`docs/adr/0001` through `0013`; after that, this table is maintained as an
-index to the ADRs.
+The operation rules are in [10_adr_process.md](10_adr_process.md). This table is the
+historical D1 through D13 summary from repository creation; it is not a comprehensive ADR index.
+The sole comprehensive maintained ADR index is [adr/README.md](adr/README.md). Update this summary
+only when the high-level project overview itself changes.
 
 | # | Decision | Rationale |
 |---|---|---|

--- a/docs/10_adr_process.md
+++ b/docs/10_adr_process.md
@@ -1,8 +1,8 @@
 # sitos — ADR Process
 
-Rules for writing and operating ADRs (Architecture Decision Records) in the
-sitos repository. Public document. In issue #1, this will be moved as
-`docs/adr/README.md`.
+Canonical rules for writing and operating ADRs (Architecture Decision Records) in the
+sitos repository. The sole comprehensive maintained ADR index is
+[adr/README.md](adr/README.md).
 
 ## 1. Purpose
 
@@ -15,7 +15,7 @@ sitos repository. Public document. In issue #1, this will be moved as
 
 ```
 docs/adr/
-  README.md                     # These rules (English)
+  README.md                     # Comprehensive maintained ADR index
   template.md                   # Template (§5)
   0001-use-zenoh-as-transport.md
   0002-embedded-storage-node.md
@@ -123,12 +123,18 @@ When in doubt, discuss “whether an ADR is needed” in PR review using the
 4. When implementation AI performs work, always include related ADRs in the
    prompt context
 
-## 8. Initial ADR Set
+## 8. Initial ADR Set and Index Maintenance
 
 At repository creation (issue #1), file D1 through D13 from
 [00_overview.md](00_overview.md) §6 as the following individual ADRs in English
-(Status: Accepted). After that, maintain the table in 00_overview §6 as an
-index to the ADRs.
+(Status: Accepted).
+
+Every ADR PR must update the sole comprehensive maintained index in
+[adr/README.md](adr/README.md), whose repository-root path is `docs/adr/README.md`. The index
+records each ADR's number, link, canonical H1 title, and normalized status; the numbered ADR file
+remains authoritative for its own status.
+[00_overview.md](00_overview.md) §6 is the historical D1 through D13 summary, not a comprehensive
+ADR index, and requires an update only when the high-level project overview itself changes.
 
 | ADR | Origin | Proposed title |
 |---|---|---|

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,40 +1,43 @@
 # Architecture Decision Records (ADRs)
 
-This directory contains the ADRs for sitos.
-See [docs/10_adr_process.md](../10_adr_process.md) for the process.
+This file is the sole comprehensive maintained ADR index for sitos. Every ADR PR must update this
+index. See [docs/10_adr_process.md](../10_adr_process.md) for the canonical process.
 
-| ADR | Title |
-|-----|-------|
-| [0001](0001-use-zenoh-as-the-transport-layer.md) | Use zenoh as the transport layer |
-| [0002](0002-implement-an-embedded-storage-node.md) | Implement an embedded storage node instead of zenoh storage-manager |
-| [0003](0003-ship-in-memory-and-rocksdb-engines.md) | Ship InMemory and RocksDB engines; do not adopt LevelDB |
-| [0004](0004-expose-engine-native-snapshots.md) | Expose engine-native snapshots through the zenoh key space |
-| [0005](0005-name-the-project-sitos.md) | Name the project sitos |
-| [0006](0006-cpp20-core-with-python-bindings.md) | C++20 core with Python bindings |
-| [0007](0007-adopt-legacy-compatible-payload-v1.md) | Adopt legacy-compatible payload v1 with Encoding-based versioning |
-| [0008](0008-license-under-apache-2.0.md) | License under Apache-2.0 |
-| [0009](0009-english-as-the-repository-language.md) | English as the repository language |
-| [0010](0010-use-nanobind-for-python-bindings.md) | Use nanobind for Python bindings |
-| [0011](0011-develop-in-public-from-day-one.md) | Develop in public from day one |
-| [0012](0012-google-cpp-style-with-100-column-limit.md) | Google C++ style with 100-column limit |
-| [0013](0013-default-to-zenoh-scouting-with-explicit-endpoint-override.md) | Default to zenoh scouting with explicit endpoint override |
-| [0014](0014-session-scoped-buffers.md) | Session-scoped buffers *(superseded by ADR-0032)* |
-| [0015](0015-optional-http-gateway-component.md) | Ship an optional HTTP gateway component on cpp-httplib *(superseded by ADR-0027)* |
-| [0016](0016-use-canonical-zenoh-bytes-encodings.md) | Use canonical zenoh bytes encodings |
-| [0017](0017-atomic-storage-node-lifecycle.md) | Use atomic, quiescent StorageNode lifecycle transitions |
-| [0018](0018-use-zenoh-valid-batch-key-segment.md) | Use a zenoh-valid batch key segment |
-| [0019](0019-client-result-status-configuration.md) | Additive client result and configuration foundation |
-| [0020](0020-synchronously-complete-transport-get.md) | Synchronously complete Transport Get requests |
-| [0021](0021-resolve-installed-zenoh-dependency.md) | Resolve installed Zenoh dependencies without fetching or bundling |
-| [0022](0022-make-param-cache-session-only.md) | Make ParamCache session-only |
-| [0023](0023-param-cache-consistency-and-lifetime.md) | Define ParamCache consistency and lifetime boundary |
-| [0024](0024-opt-in-google-benchmark-build-boundary.md) | Keep Google Benchmark opt-in and outside installed packages |
-| [0025](0025-session-view-lifetime-and-composite-read-consistency.md) | Define SessionView lifetime and composite-read consistency |
-| [0026](0026-python-wheel-build-and-native-runtime.md) | Define the Python wheel build and bundled native-runtime boundary |
-| [0027](0027-keep-http-control-planes-in-host-applications.md) | Keep HTTP control planes in host applications |
-| [0028](0028-unify-acknowledged-operation-results.md) | Unify acknowledged operation results |
-| [0029](0029-define-same-publisher-fence-ordering.md) | Define same-publisher Fence ordering |
-| [0030](0030-param-store-subscription-lifetime-and-delivery.md) | Define ParamStore subscription lifetime and delivery semantics |
-| [0031](0031-cross-platform-vcpkg-foundation.md) | Establish a cross-platform vcpkg foundation |
-| [0032](0032-mixed-session-buffer-routes.md) | Mixed durable/ephemeral session buffer routes |
-| [0033](0033-rocksdb-engine-snapshot-and-package-boundary.md) | Define the RocksDB engine, snapshot, and installed-package boundary |
+Each numbered ADR file is authoritative for its own status. This table mirrors the normalized
+status so the offline documentation contract can detect index drift.
+
+| ADR | Title | Status |
+|---|---|---|
+| [0001](0001-use-zenoh-as-the-transport-layer.md) | Use zenoh as the transport layer | Accepted |
+| [0002](0002-implement-an-embedded-storage-node.md) | Implement an embedded storage node instead of zenoh storage-manager | Accepted |
+| [0003](0003-ship-in-memory-and-rocksdb-engines.md) | Ship InMemory and RocksDB engines; do not adopt LevelDB | Accepted |
+| [0004](0004-expose-engine-native-snapshots.md) | Expose engine-native snapshots through the zenoh key space | Accepted |
+| [0005](0005-name-the-project-sitos.md) | Name the project sitos | Accepted |
+| [0006](0006-cpp20-core-with-python-bindings.md) | C++20 core with Python bindings | Accepted |
+| [0007](0007-adopt-legacy-compatible-payload-v1.md) | Adopt legacy-compatible payload v1 with Encoding-based versioning | Accepted |
+| [0008](0008-license-under-apache-2.0.md) | License under Apache-2.0 | Accepted |
+| [0009](0009-english-as-the-repository-language.md) | English as the repository language | Accepted |
+| [0010](0010-use-nanobind-for-python-bindings.md) | Use nanobind for Python bindings | Accepted |
+| [0011](0011-develop-in-public-from-day-one.md) | Develop in public from day one | Accepted |
+| [0012](0012-google-cpp-style-with-100-column-limit.md) | Google C++ style with 100-column limit | Accepted |
+| [0013](0013-default-to-zenoh-scouting-with-explicit-endpoint-override.md) | Default to zenoh scouting with explicit endpoint override | Accepted |
+| [0014](0014-session-scoped-buffers.md) | Add a session-scoped, disk-backed buffers key space | Superseded by ADR-0032 |
+| [0015](0015-optional-http-gateway-component.md) | Ship an optional HTTP gateway component on cpp-httplib | Superseded by ADR-0027 |
+| [0016](0016-use-canonical-zenoh-bytes-encodings.md) | Use canonical zenoh bytes encodings | Accepted |
+| [0017](0017-atomic-storage-node-lifecycle.md) | Use atomic, quiescent StorageNode lifecycle transitions | Accepted |
+| [0018](0018-use-zenoh-valid-batch-key-segment.md) | Use a zenoh-valid batch key segment | Accepted |
+| [0019](0019-client-result-status-configuration.md) | Additive client result and configuration foundation | Accepted |
+| [0020](0020-synchronously-complete-transport-get.md) | Synchronously complete Transport Get requests | Accepted |
+| [0021](0021-resolve-installed-zenoh-dependency.md) | Resolve installed Zenoh dependencies without fetching or bundling | Accepted |
+| [0022](0022-make-param-cache-session-only.md) | Make ParamCache session-only | Accepted |
+| [0023](0023-param-cache-consistency-and-lifetime.md) | Define ParamCache consistency and lifetime boundary | Accepted |
+| [0024](0024-opt-in-google-benchmark-build-boundary.md) | Keep Google Benchmark opt-in and outside installed packages | Accepted |
+| [0025](0025-session-view-lifetime-and-composite-read-consistency.md) | Define SessionView lifetime and composite-read consistency | Accepted |
+| [0026](0026-python-wheel-build-and-native-runtime.md) | Define the Python wheel build and bundled native-runtime boundary | Accepted |
+| [0027](0027-keep-http-control-planes-in-host-applications.md) | Keep HTTP control planes in host applications | Accepted |
+| [0028](0028-unify-acknowledged-operation-results.md) | Unify acknowledged operation results | Accepted |
+| [0029](0029-define-same-publisher-fence-ordering.md) | Define same-publisher Fence ordering | Accepted |
+| [0030](0030-param-store-subscription-lifetime-and-delivery.md) | Define ParamStore subscription lifetime and delivery semantics | Accepted |
+| [0031](0031-cross-platform-vcpkg-foundation.md) | Establish a cross-platform vcpkg foundation | Accepted |
+| [0032](0032-mixed-session-buffer-routes.md) | Define mixed durable and ephemeral session buffer routes | Accepted |
+| [0033](0033-rocksdb-engine-snapshot-and-package-boundary.md) | Define the RocksDB engine, snapshot, and installed-package boundary | Accepted |

--- a/tests/docs/test_public_documentation.py
+++ b/tests/docs/test_public_documentation.py
@@ -61,6 +61,22 @@ class _OrdinarySegment:
     first_line: int
 
 
+@dataclass(frozen=True)
+class _AdrRecord:
+    number: str
+    filename: str
+    title: str
+    status: str
+
+
+@dataclass(frozen=True)
+class _AdrIndexEntry:
+    number: str
+    filename: str
+    title: str
+    status: str
+
+
 _FENCE_OPEN = re.compile(r"^( {0,3})(`{3,}|~{3,})(.*)$")
 _REFERENCE_DEFINITION = re.compile(r"^ {0,3}\[[^\n]*\]:")
 _MULTILINE_LINK = re.compile(
@@ -70,6 +86,20 @@ _AUTOLINK = re.compile(r"<[A-Za-z][A-Za-z0-9+.-]*:[^<>\n]*>")
 _RAW_LINK_HTML = re.compile(r"<(?i:a|img)(?=[\t\n\v\f\r />])")
 _LINK_TOKEN = re.compile(r"(!?)\[([^\[\]\\\n]*)\]\(([^()\\\t\n\v\f\r ]+)\)")
 _BRACKET_RUN = re.compile(r"`+")
+_ADR_FILENAME = re.compile(r"^(?P<number>[0-9]{4})-[a-z0-9.-]+\.md$")
+_ADR_HEADING = re.compile(r"^# ADR-(?P<number>[0-9]{4}): (?P<title>.+)$")
+_ADR_INDEX_ROW = re.compile(
+    r"^\| \[(?P<number>[0-9]{4})\]\((?P<filename>[^)]+)\) "
+    r"\| (?P<title>[^|]+) \| (?P<status>[^|]+) \|$"
+)
+_ADR_SECTION_STATUS = re.compile(r"(?ms)^## Status\s*\n\s*(?P<status>[^\n]+)")
+_ADR_LEGACY_STATUS = re.compile(r"(?m)^- Status:\s*(?P<status>[^\n]+)")
+_ADR_SIMPLE_STATUS = re.compile(
+    r"^(?P<status>Proposed|Accepted|Rejected|Deprecated)(?: — [0-9]{4}-[0-9]{2}-[0-9]{2})?$"
+)
+_ADR_SUPERSEDED_STATUS = re.compile(
+    r"^(?P<status>Superseded by ADR-[0-9]{4})(?: — [0-9]{4}-[0-9]{2}-[0-9]{2})?$"
+)
 
 
 def _physical_lines(text: str) -> list[str]:
@@ -316,6 +346,108 @@ def validate_destination(token: MarkdownToken, root: Path) -> Path | None:
     return resolve_local_target(token, root)
 
 
+def _normalize_adr_status(raw: str, source: Path) -> str:
+    status = raw.strip()
+    for pattern in (_ADR_SIMPLE_STATUS, _ADR_SUPERSEDED_STATUS):
+        match = pattern.fullmatch(status)
+        if match is not None:
+            return match.group("status")
+    raise DocumentationContractError(f"{source}: unsupported ADR status {status!r}")
+
+
+def _adr_records(root: Path) -> list[_AdrRecord]:
+    records: list[_AdrRecord] = []
+    for path in sorted((root / "docs/adr").glob("[0-9][0-9][0-9][0-9]-*.md")):
+        filename_match = _ADR_FILENAME.fullmatch(path.name)
+        if filename_match is None:
+            raise DocumentationContractError(f"{path}: malformed ADR filename")
+        text = path.read_text(encoding="utf-8")
+        lines = text.splitlines()
+        heading_match = _ADR_HEADING.fullmatch(lines[0] if lines else "")
+        if heading_match is None:
+            raise DocumentationContractError(f"{path}: malformed ADR H1")
+        if heading_match.group("number") != filename_match.group("number"):
+            raise DocumentationContractError(f"{path}: ADR filename and H1 number differ")
+        status_match = _ADR_SECTION_STATUS.search(text) or _ADR_LEGACY_STATUS.search(text)
+        if status_match is None:
+            raise DocumentationContractError(f"{path}: missing ADR status")
+        records.append(
+            _AdrRecord(
+                number=filename_match.group("number"),
+                filename=path.name,
+                title=heading_match.group("title"),
+                status=_normalize_adr_status(status_match.group("status"), path),
+            )
+        )
+    if not records:
+        raise DocumentationContractError("docs/adr: no numbered ADR files found")
+    return records
+
+
+def _adr_index_entries(root: Path) -> list[_AdrIndexEntry]:
+    path = root / "docs/adr/README.md"
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if "| ADR | Title | Status |" not in lines:
+        raise DocumentationContractError(f"{path}: missing ADR/Title/Status index header")
+    entries: list[_AdrIndexEntry] = []
+    for line_number, line in enumerate(lines, start=1):
+        if not line.startswith("| ["):
+            continue
+        match = _ADR_INDEX_ROW.fullmatch(line)
+        if match is None:
+            raise DocumentationContractError(f"{path}:{line_number}: malformed ADR index row")
+        entries.append(
+            _AdrIndexEntry(
+                number=match.group("number"),
+                filename=match.group("filename"),
+                title=match.group("title").strip(),
+                status=match.group("status").strip(),
+            )
+        )
+    if not entries:
+        raise DocumentationContractError(f"{path}: ADR index is empty")
+    return entries
+
+
+def validate_adr_index(root: Path) -> None:
+    """Require a complete, ordered ADR index whose metadata matches each ADR."""
+    records = _adr_records(root)
+    entries = _adr_index_entries(root)
+    expected_numbers = [record.number for record in records]
+    actual_numbers = [entry.number for entry in entries]
+    if actual_numbers != sorted(actual_numbers):
+        raise DocumentationContractError("docs/adr/README.md: ADR rows are not numerically ordered")
+    if len(actual_numbers) != len(set(actual_numbers)):
+        raise DocumentationContractError("docs/adr/README.md: duplicate ADR number")
+    filenames = [entry.filename for entry in entries]
+    if len(filenames) != len(set(filenames)):
+        raise DocumentationContractError("docs/adr/README.md: duplicate ADR target")
+    if actual_numbers != expected_numbers:
+        raise DocumentationContractError(
+            "docs/adr/README.md: ADR numbers do not match the repository inventory"
+        )
+
+    records_by_filename = {record.filename: record for record in records}
+    if set(filenames) != set(records_by_filename):
+        raise DocumentationContractError(
+            "docs/adr/README.md: ADR targets do not match the repository inventory"
+        )
+    for entry in entries:
+        record = records_by_filename[entry.filename]
+        if entry.number != record.number:
+            raise DocumentationContractError(
+                f"docs/adr/README.md: index number for {entry.filename} does not match"
+            )
+        if entry.title != record.title:
+            raise DocumentationContractError(
+                f"docs/adr/README.md: index title for ADR-{record.number} does not match"
+            )
+        if entry.status != record.status:
+            raise DocumentationContractError(
+                f"docs/adr/README.md: index status for ADR-{record.number} does not match"
+            )
+
+
 def markdown_corpus(root: Path) -> list[Path]:
     paths = {root / "README.md", root / "CONTRIBUTING.md", root / "AGENTS.md"}
     paths.update((root / ".github").glob("**/*.md"))
@@ -485,6 +617,69 @@ continues here``
 
 
 class PublicDocumentationTest(unittest.TestCase):
+    def test_adr_index_contract(self) -> None:
+        validate_adr_index(ROOT)
+        adr_index = (ROOT / "docs/adr/README.md").read_text(encoding="utf-8")
+        overview = (ROOT / "docs/00_overview.md").read_text(encoding="utf-8")
+        process = (ROOT / "docs/10_adr_process.md").read_text(encoding="utf-8")
+        self.assertIn("sole comprehensive maintained ADR index", adr_index)
+        self.assertIn("historical D1 through D13 summary", overview)
+        self.assertIn("not a comprehensive ADR index", overview)
+        self.assertIn("Every ADR PR must update", process)
+        self.assertIn("docs/adr/README.md", process)
+
+    def test_adr_index_contract_rejects_metadata_drift(self) -> None:
+        valid_index = """# Architecture Decision Records (ADRs)
+
+| ADR | Title | Status |
+|---|---|---|
+| [0001](0001-first-decision.md) | First decision | Accepted |
+| [0002](0002-second-decision.md) | Second decision | Superseded by ADR-0001 |
+"""
+        mutations = {
+            "missing": valid_index.replace(
+                "| [0002](0002-second-decision.md) | Second decision | "
+                "Superseded by ADR-0001 |\n",
+                "",
+            ),
+            "extra": valid_index
+            + "| [0003](0003-extra-decision.md) | Extra decision | Proposed |\n",
+            "duplicate": valid_index.replace(
+                "| [0002](0002-second-decision.md)",
+                "| [0001](0001-first-decision.md)",
+            ),
+            "misordered": valid_index.replace(
+                "| [0001](0001-first-decision.md) | First decision | Accepted |\n"
+                "| [0002](0002-second-decision.md) | Second decision | "
+                "Superseded by ADR-0001 |\n",
+                "| [0002](0002-second-decision.md) | Second decision | "
+                "Superseded by ADR-0001 |\n"
+                "| [0001](0001-first-decision.md) | First decision | Accepted |\n",
+            ),
+            "misnumbered": valid_index.replace("[0002]", "[0003]"),
+            "mistitled": valid_index.replace("Second decision", "Stale title"),
+            "stale status": valid_index.replace(
+                "Superseded by ADR-0001", "Accepted"
+            ),
+        }
+        for name, index in mutations.items():
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                adr_directory = root / "docs/adr"
+                adr_directory.mkdir(parents=True)
+                (adr_directory / "README.md").write_text(index, encoding="utf-8")
+                (adr_directory / "0001-first-decision.md").write_text(
+                    "# ADR-0001: First decision\n\n## Status\n\n"
+                    "Accepted — 2026-01-01\n",
+                    encoding="utf-8",
+                )
+                (adr_directory / "0002-second-decision.md").write_text(
+                    "# ADR-0002: Second decision\n\n- Status: Superseded by ADR-0001\n",
+                    encoding="utf-8",
+                )
+                with self.assertRaises(DocumentationContractError):
+                    validate_adr_index(root)
+
     def test_public_markdown_links(self) -> None:
         scanned = scan_corpus(ROOT)
         legacy = (ROOT / "docs/development_workflow.md").resolve(strict=True)

--- a/tests/docs/test_public_documentation.py
+++ b/tests/docs/test_public_documentation.py
@@ -88,6 +88,7 @@ _LINK_TOKEN = re.compile(r"(!?)\[([^\[\]\\\n]*)\]\(([^()\\\t\n\v\f\r ]+)\)")
 _BRACKET_RUN = re.compile(r"`+")
 _ADR_FILENAME = re.compile(r"^(?P<number>[0-9]{4})-[a-z0-9.-]+\.md$")
 _ADR_HEADING = re.compile(r"^# ADR-(?P<number>[0-9]{4}): (?P<title>.+)$")
+_ADR_INDEX_ROW_CANDIDATE = re.compile(r"^ {0,3}\| \[")
 _ADR_INDEX_ROW = re.compile(
     r"^\| \[(?P<number>[0-9]{4})\]\((?P<filename>[^)]+)\) "
     r"\| (?P<title>[^|]+) \| (?P<status>[^|]+) \|$"
@@ -391,7 +392,7 @@ def _adr_index_entries(root: Path) -> list[_AdrIndexEntry]:
         raise DocumentationContractError(f"{path}: missing ADR/Title/Status index header")
     entries: list[_AdrIndexEntry] = []
     for line_number, line in enumerate(lines, start=1):
-        if not line.startswith("| ["):
+        if _ADR_INDEX_ROW_CANDIDATE.match(line) is None:
             continue
         match = _ADR_INDEX_ROW.fullmatch(line)
         if match is None:
@@ -647,6 +648,13 @@ class PublicDocumentationTest(unittest.TestCase):
             "duplicate": valid_index.replace(
                 "| [0002](0002-second-decision.md)",
                 "| [0001](0001-first-decision.md)",
+            ),
+            "indented duplicate": valid_index.replace(
+                "| [0002](0002-second-decision.md) | Second decision | "
+                "Superseded by ADR-0001 |\n",
+                "| [0002](0002-second-decision.md) | Second decision | "
+                "Superseded by ADR-0001 |\n"
+                " | [0001](0001-first-decision.md) | First decision | Accepted |\n",
             ),
             "misordered": valid_index.replace(
                 "| [0001](0001-first-decision.md) | First decision | Accepted |\n"

--- a/tests/docs/test_public_documentation.py
+++ b/tests/docs/test_public_documentation.py
@@ -86,7 +86,9 @@ _AUTOLINK = re.compile(r"<[A-Za-z][A-Za-z0-9+.-]*:[^<>\n]*>")
 _RAW_LINK_HTML = re.compile(r"<(?i:a|img)(?=[\t\n\v\f\r />])")
 _LINK_TOKEN = re.compile(r"(!?)\[([^\[\]\\\n]*)\]\(([^()\\\t\n\v\f\r ]+)\)")
 _BRACKET_RUN = re.compile(r"`+")
-_ADR_FILENAME = re.compile(r"^(?P<number>[0-9]{4})-[a-z0-9.-]+\.md$")
+_ADR_FILENAME = re.compile(
+    r"^(?P<number>[0-9]{4})-[a-z0-9]+(?:[-.][a-z0-9]+)*\.md$"
+)
 _ADR_HEADING = re.compile(r"^# ADR-(?P<number>[0-9]{4}): (?P<title>.+)$")
 _ADR_INDEX_HEADER = "| ADR | Title | Status |"
 _ADR_INDEX_SEPARATOR = "|---|---|---|"
@@ -725,20 +727,21 @@ class PublicDocumentationTest(unittest.TestCase):
                     validate_adr_index(root)
 
     def test_adr_index_contract_rejects_malformed_numeric_filenames(self) -> None:
-        valid_index = """# Architecture Decision Records (ADRs)
-
-| ADR | Title | Status |
-|---|---|---|
-| [0001](0001-first-decision.md) | First decision | Accepted |
-"""
-        for filename in ("0034.md", "0034_bad.md"):
+        for filename in (
+            "0034.md",
+            "0034_bad.md",
+            "0034--bad.md",
+            "0034-bad..name.md",
+        ):
             with self.subTest(filename=filename), tempfile.TemporaryDirectory() as temporary:
                 root = Path(temporary)
                 adr_directory = root / "docs/adr"
                 adr_directory.mkdir(parents=True)
-                (adr_directory / "README.md").write_text(valid_index, encoding="utf-8")
-                (adr_directory / "0001-first-decision.md").write_text(
-                    "# ADR-0001: First decision\n\n## Status\n\nAccepted\n",
+                (adr_directory / "README.md").write_text(
+                    "# Architecture Decision Records (ADRs)\n\n"
+                    "| ADR | Title | Status |\n"
+                    "|---|---|---|\n"
+                    f"| [0034]({filename}) | Hidden decision | Proposed |\n",
                     encoding="utf-8",
                 )
                 (adr_directory / filename).write_text(

--- a/tests/docs/test_public_documentation.py
+++ b/tests/docs/test_public_documentation.py
@@ -88,7 +88,8 @@ _LINK_TOKEN = re.compile(r"(!?)\[([^\[\]\\\n]*)\]\(([^()\\\t\n\v\f\r ]+)\)")
 _BRACKET_RUN = re.compile(r"`+")
 _ADR_FILENAME = re.compile(r"^(?P<number>[0-9]{4})-[a-z0-9.-]+\.md$")
 _ADR_HEADING = re.compile(r"^# ADR-(?P<number>[0-9]{4}): (?P<title>.+)$")
-_ADR_INDEX_ROW_CANDIDATE = re.compile(r"^ {0,3}\| \[")
+_ADR_INDEX_HEADER = "| ADR | Title | Status |"
+_ADR_INDEX_SEPARATOR = "|---|---|---|"
 _ADR_INDEX_ROW = re.compile(
     r"^\| \[(?P<number>[0-9]{4})\]\((?P<filename>[^)]+)\) "
     r"\| (?P<title>[^|]+) \| (?P<status>[^|]+) \|$"
@@ -388,15 +389,28 @@ def _adr_records(root: Path) -> list[_AdrRecord]:
 def _adr_index_entries(root: Path) -> list[_AdrIndexEntry]:
     path = root / "docs/adr/README.md"
     lines = path.read_text(encoding="utf-8").splitlines()
-    if "| ADR | Title | Status |" not in lines:
+    header_indexes = [
+        index for index, line in enumerate(lines) if line == _ADR_INDEX_HEADER
+    ]
+    if not header_indexes:
         raise DocumentationContractError(f"{path}: missing ADR/Title/Status index header")
+    if len(header_indexes) != 1:
+        raise DocumentationContractError(f"{path}: duplicate ADR/Title/Status index header")
+    header_index = header_indexes[0]
+    separator_index = header_index + 1
+    if separator_index >= len(lines) or lines[separator_index] != _ADR_INDEX_SEPARATOR:
+        raise DocumentationContractError(f"{path}: malformed ADR index separator")
+
     entries: list[_AdrIndexEntry] = []
-    for line_number, line in enumerate(lines, start=1):
-        if _ADR_INDEX_ROW_CANDIDATE.match(line) is None:
-            continue
+    for line_index in range(separator_index + 1, len(lines)):
+        line = lines[line_index]
+        if not line.strip():
+            break
         match = _ADR_INDEX_ROW.fullmatch(line)
         if match is None:
-            raise DocumentationContractError(f"{path}:{line_number}: malformed ADR index row")
+            raise DocumentationContractError(
+                f"{path}:{line_index + 1}: malformed ADR index row"
+            )
         entries.append(
             _AdrIndexEntry(
                 number=match.group("number"),
@@ -656,6 +670,10 @@ class PublicDocumentationTest(unittest.TestCase):
                 "Superseded by ADR-0001 |\n"
                 " | [0001](0001-first-decision.md) | First decision | Accepted |\n",
             ),
+            "alternate cell whitespace": valid_index
+            + "|  [0001](0001-first-decision.md) | First decision | Accepted |\n",
+            "omitted leading pipe": valid_index
+            + "[0001](0001-first-decision.md) | First decision | Accepted |\n",
             "misordered": valid_index.replace(
                 "| [0001](0001-first-decision.md) | First decision | Accepted |\n"
                 "| [0002](0002-second-decision.md) | Second decision | "

--- a/tests/docs/test_public_documentation.py
+++ b/tests/docs/test_public_documentation.py
@@ -359,7 +359,7 @@ def _normalize_adr_status(raw: str, source: Path) -> str:
 
 def _adr_records(root: Path) -> list[_AdrRecord]:
     records: list[_AdrRecord] = []
-    for path in sorted((root / "docs/adr").glob("[0-9][0-9][0-9][0-9]-*.md")):
+    for path in sorted((root / "docs/adr").glob("[0-9]*.md")):
         filename_match = _ADR_FILENAME.fullmatch(path.name)
         if filename_match is None:
             raise DocumentationContractError(f"{path}: malformed ADR filename")
@@ -411,12 +411,18 @@ def _adr_index_entries(root: Path) -> list[_AdrIndexEntry]:
             raise DocumentationContractError(
                 f"{path}:{line_index + 1}: malformed ADR index row"
             )
+        title = match.group("title")
+        status = match.group("status")
+        if title != title.strip() or status != status.strip():
+            raise DocumentationContractError(
+                f"{path}:{line_index + 1}: malformed ADR index row"
+            )
         entries.append(
             _AdrIndexEntry(
                 number=match.group("number"),
                 filename=match.group("filename"),
-                title=match.group("title").strip(),
-                status=match.group("status").strip(),
+                title=title,
+                status=status,
             )
         )
     if not entries:
@@ -674,6 +680,18 @@ class PublicDocumentationTest(unittest.TestCase):
             + "|  [0001](0001-first-decision.md) | First decision | Accepted |\n",
             "omitted leading pipe": valid_index
             + "[0001](0001-first-decision.md) | First decision | Accepted |\n",
+            "title leading whitespace": valid_index.replace(
+                "| Second decision |", "|  Second decision |"
+            ),
+            "title trailing whitespace": valid_index.replace(
+                "Second decision |", "Second decision  |"
+            ),
+            "status leading whitespace": valid_index.replace(
+                "| Superseded by ADR-0001 |", "|  Superseded by ADR-0001 |"
+            ),
+            "status trailing whitespace": valid_index.replace(
+                "Superseded by ADR-0001 |", "Superseded by ADR-0001  |"
+            ),
             "misordered": valid_index.replace(
                 "| [0001](0001-first-decision.md) | First decision | Accepted |\n"
                 "| [0002](0002-second-decision.md) | Second decision | "
@@ -701,6 +719,30 @@ class PublicDocumentationTest(unittest.TestCase):
                 )
                 (adr_directory / "0002-second-decision.md").write_text(
                     "# ADR-0002: Second decision\n\n- Status: Superseded by ADR-0001\n",
+                    encoding="utf-8",
+                )
+                with self.assertRaises(DocumentationContractError):
+                    validate_adr_index(root)
+
+    def test_adr_index_contract_rejects_malformed_numeric_filenames(self) -> None:
+        valid_index = """# Architecture Decision Records (ADRs)
+
+| ADR | Title | Status |
+|---|---|---|
+| [0001](0001-first-decision.md) | First decision | Accepted |
+"""
+        for filename in ("0034.md", "0034_bad.md"):
+            with self.subTest(filename=filename), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                adr_directory = root / "docs/adr"
+                adr_directory.mkdir(parents=True)
+                (adr_directory / "README.md").write_text(valid_index, encoding="utf-8")
+                (adr_directory / "0001-first-decision.md").write_text(
+                    "# ADR-0001: First decision\n\n## Status\n\nAccepted\n",
+                    encoding="utf-8",
+                )
+                (adr_directory / filename).write_text(
+                    "# ADR-0034: Hidden decision\n\n## Status\n\nProposed\n",
                     encoding="utf-8",
                 )
                 with self.assertRaises(DocumentationContractError):


### PR DESCRIPTION
## Summary

Closes #159

- Designate `docs/adr/README.md` as the sole comprehensive maintained ADR index.
- Keep `docs/00_overview.md` section 6 as the historical D1-D13 summary and `docs/10_adr_process.md` as the canonical process.
- Add an offline contract that dynamically validates ADR inventory, ordering, paths, titles, and normalized statuses.
- Preserve every numbered ADR file as the authority for its own status.

## Requirements

Reference requirement IDs from docs/01_requirements.md (F/N/C/P/X):

N/A — repository documentation governance only.

## Contract Registry

Affected contract-registry row(s) (docs/08_contract_registry.md) with their status transition
(`Contract` / `Implementation` / `none`), or `N/A` if no contract is touched:

N/A — no stable public, wire, storage, API, or operational contract changes.

## Frozen Issue Checklist

Copy the frozen Issue checklist here and track progress only in this PR:

- [x] `docs/adr/README.md` is explicitly the sole comprehensive maintained ADR index.
- [x] `docs/00_overview.md`, `docs/10_adr_process.md`, and `docs/adr/README.md` prescribe the frozen responsibilities without contradiction.
- [x] Every ADR path, number, canonical title, and normalized status is represented accurately and exactly once.
- [x] No ADR decision text or status is changed.
- [x] Future ADR Issues can identify `docs/adr/README.md` as their required index update without an owner exception.
- [x] The offline ADR index regression rejects missing, duplicate, misordered, misnumbered, mistitled, and stale-status rows.
- [x] All offline public-documentation tests and `git diff --check` pass.

## Acceptance Criteria Verification

```text
python3 tests/docs/test_public_documentation.py -v
Ran 10 tests in 0.075s
OK

(cd /tmp && python3 /home/hayate/git/sitos/tests/docs/test_public_documentation.py -v)
Ran 10 tests in 0.077s
OK

python3 -m py_compile tests/docs/test_public_documentation.py
git diff --check
# passed with no output
```

Two fresh-context read-only reviews passed without blockers. The final diff contains only the four frozen files and modifies no numbered ADR file.

## RED-phase Evidence

- Command: `python3 tests/docs/test_public_documentation.py -v`
- Failing test name: `test_adr_index_contract`
- Expected failure reason: the pre-change comprehensive index lacked the required Status column and frozen authority wording.
- Representative failure-message line: `DocumentationContractError: /home/hayate/git/sitos/docs/adr/README.md: missing ADR/Title/Status index header`
- Complete CI-log link (only when the excerpt is insufficient): N/A

## ADR Needed?

An ADR is required when docs/10_adr_process.md §6 applies. §6 includes introducing a second
surface that overlaps an existing contract-registry row (registry Rule 2).

- [x] No
- [ ] Yes — ADR PR: #

This PR reconciles existing documentation governance and does not introduce an architecture decision.

## Owner Merge Authorization

Complete this section only after the owner authorizes this exact PR head. Leave the status as
`Pending` when opening or updating the PR.

- Status: Pending
- Authorized head SHA:
- Owner instruction link:

Authorization is one-time, expires after a new commit or new blocking finding, and never enables
auto-merge.
