### PR TITLE
fix(python): harden example STOP cleanup (#163)

### DIFF
--- a/examples/python/quickstart.py
+++ b/examples/python/quickstart.py
@@ -426,7 +426,7 @@ def _cleanup(
             error = ack_errors.get(label)
             if error is not None:
                 failures.append(f"cleanup {label}: {error}")
-            elif label not in exempt and process.exitcode != 0:
+            elif process.exitcode != 0:
                 failures.append(
                     f"cleanup {label}: {label}: "
                     f"graceful cleanup exit {process.exitcode}"
@@ -478,9 +478,6 @@ def _run_failure(
             f"SITOS_EXAMPLE_TEST_FAILURE cache {value['pid']} {value['message']}",
             file=sys.stderr,
         )
-        process.join(1.0)
-        if process.is_alive() or process.exitcode != 0:
-            raise WorkerFailure("cache failure worker did not exit cleanly")
         failures = _cleanup(
             children,
             time.monotonic() + CLEANUP_SECONDS,

--- a/examples/python/quickstart.py
+++ b/examples/python/quickstart.py
@@ -316,11 +316,12 @@ def _cleanup(
         # Start every public close()/stop() before waiting for any one role.
         for label, process, connection in records:
             require_ack = label not in exempt
-            if require_ack and not process.is_alive():
+            alive = process.is_alive()
+            if require_ack and not alive:
                 ack_errors[label] = WorkerFailure(
                     f"{label}: no STOP acknowledgement; exit {process.exitcode}"
                 )
-            if connection is None or not process.is_alive():
+            if connection is None or not alive:
                 continue
             try:
                 connection.send(("STOP", ()))

--- a/examples/python/quickstart.py
+++ b/examples/python/quickstart.py
@@ -16,15 +16,11 @@ from typing import Any, Callable
 
 WORK_SECONDS = 30.0
 FAILURE_SECONDS = 15.0
-CHILD_GRACEFUL_STOP_SECONDS = 5.0
+# Cleanup sends STOP to every child before sharing one monotonic deadline.
+# The final second is reserved for process-wide terminate and kill phases.
+CLEANUP_SECONDS = 19.0
 TERMINATE_RESERVE_SECONDS = 0.5
 KILL_RESERVE_SECONDS = 0.5
-CHILD_CLEANUP_SECONDS = (
-    CHILD_GRACEFUL_STOP_SECONDS
-    + TERMINATE_RESERVE_SECONDS
-    + KILL_RESERVE_SECONDS
-)
-CLEANUP_SECONDS = 19.0
 FAILURE_ENV = "SITOS_EXAMPLE_TEST_FAIL"
 FAILURE_VALUE = "cache-before-open"
 FAILURE_MESSAGE = "test-injected cache startup failure"
@@ -163,6 +159,33 @@ def _cache_worker(connection: Connection, prefix: str, sid: str, key: str) -> No
             connection.close()
 
 
+def _poll_packet(
+    connection: Connection,
+    process: multiprocessing.Process,
+    label: str,
+    wait: float,
+) -> tuple[str, Any] | None:
+    try:
+        ready = connection.poll(wait)
+    except (BrokenPipeError, EOFError, OSError) as error:
+        raise WorkerFailure(
+            f"{label}: pipe poll failed; exit {process.exitcode}: {error}"
+        ) from error
+    if ready:
+        try:
+            status, value = connection.recv()
+        except (BrokenPipeError, EOFError, OSError) as error:
+            raise WorkerFailure(
+                f"{label}: pipe receive failed; exit {process.exitcode}: {error}"
+            ) from error
+        if status == "ERROR":
+            raise WorkerFailure(f"{label}: {value}")
+        return status, value
+    if not process.is_alive():
+        raise WorkerFailure(f"{label}: exited with {process.exitcode}")
+    return None
+
+
 def _wait_packet(
     connection: Connection,
     process: multiprocessing.Process,
@@ -171,24 +194,11 @@ def _wait_packet(
 ) -> tuple[str, Any]:
     while time.monotonic() < deadline:
         wait = min(0.05, max(0.0, deadline - time.monotonic()))
-        try:
-            ready = connection.poll(wait)
-        except (BrokenPipeError, EOFError, OSError) as error:
-            raise WorkerFailure(
-                f"{label}: pipe poll failed; exit {process.exitcode}: {error}"
-            ) from error
-        if ready:
-            try:
-                status, value = connection.recv()
-            except (BrokenPipeError, EOFError, OSError) as error:
-                raise WorkerFailure(
-                    f"{label}: pipe receive failed; exit {process.exitcode}: {error}"
-                ) from error
-            if status == "ERROR":
-                raise WorkerFailure(f"{label}: {value}")
-            return status, value
-        if not process.is_alive():
-            raise WorkerFailure(f"{label}: exited with {process.exitcode}")
+        packet = _poll_packet(connection, process, label, wait)
+        if time.monotonic() > deadline:
+            raise TimeoutError(f"timed out waiting for {label}")
+        if packet is not None:
+            return packet
     raise TimeoutError(f"timed out waiting for {label}")
 
 
@@ -237,67 +247,19 @@ def _stop(
     require_ack: bool = True,
     allow_forced: bool = False,
 ) -> None:
-    ack_error: BaseException | None = None
-    escalation_errors: list[str] = []
-    forced = False
-    now = time.monotonic()
-    graceful_deadline = max(
-        now,
-        deadline - TERMINATE_RESERVE_SECONDS - KILL_RESERVE_SECONDS,
+    failures = _cleanup(
+        [(label, process, connection)],
+        deadline,
+        exempt=set() if require_ack else {label},
+        allow_forced=allow_forced,
     )
-    terminate_deadline = max(
-        graceful_deadline,
-        deadline - KILL_RESERVE_SECONDS,
-    )
-    try:
-        if require_ack and not process.is_alive():
-            ack_error = WorkerFailure(
-                f"{label}: no STOP acknowledgement; exit {process.exitcode}"
-            )
-        if connection is not None and process.is_alive():
-            try:
-                connection.send(("STOP", ()))
-                status, value = _wait_packet(
-                    connection,
-                    process,
-                    label,
-                    graceful_deadline,
-                )
-                if status != "OK" or value != "":
-                    raise WorkerFailure(f"{label}: invalid STOP response {status}: {value}")
-            except BaseException as error:
-                if require_ack:
-                    ack_error = WorkerFailure(
-                        f"{label}: STOP handshake failed; exit {process.exitcode}: {error}"
-                    )
-        _join_until(process, graceful_deadline)
-        if process.is_alive():
-            forced = True
-            try:
-                process.terminate()
-            except BaseException as error:
-                escalation_errors.append(f"terminate failed: {error}")
-            _join_until(process, terminate_deadline)
-        if process.is_alive() and hasattr(process, "kill"):
-            forced = True
-            try:
-                process.kill()
-            except BaseException as error:
-                escalation_errors.append(f"kill failed: {error}")
-        _join_until(process, deadline)
-        if process.is_alive():
-            details = (
-                f"; {'; '.join(escalation_errors)}" if escalation_errors else ""
-            )
-            raise WorkerFailure(f"{label}: child survived cleanup{details}")
-        if not (allow_forced and forced):
-            if ack_error is not None:
-                raise ack_error
-            if require_ack and process.exitcode != 0:
-                raise WorkerFailure(f"{label}: graceful cleanup exit {process.exitcode}")
-    finally:
-        if connection is not None:
-            connection.close()
+    if failures:
+        prefix = f"cleanup {label}: "
+        messages = [
+            failure[len(prefix) :] if failure.startswith(prefix) else failure
+            for failure in failures
+        ]
+        raise WorkerFailure("; ".join(messages))
 
 
 def _spawn(
@@ -323,27 +285,159 @@ def _spawn(
 
 
 def _cleanup(
-    children: list[tuple[str, multiprocessing.Process, Connection]],
+    children: list[
+        tuple[str, multiprocessing.Process, Connection | None]
+    ],
     deadline: float,
     *,
     exempt: set[str] | None = None,
     allow_forced: bool = False,
 ) -> list[str]:
-    failures = []
+    records = list(reversed(children))
+    failures: list[str] = []
     exempt = exempt or set()
-    for label, process, connection in reversed(children):
-        child_deadline = min(deadline, time.monotonic() + CHILD_CLEANUP_SECONDS)
-        try:
-            _stop(
-                process,
-                connection,
-                label,
-                child_deadline,
-                require_ack=label not in exempt,
-                allow_forced=allow_forced,
+    ack_errors: dict[str, BaseException] = {}
+    stop_sent: set[str] = set()
+    forced: set[str] = set()
+    escalation_errors: dict[str, list[str]] = {
+        label: [] for label, _process, _connection in records
+    }
+    now = time.monotonic()
+    graceful_deadline = max(
+        now,
+        deadline - TERMINATE_RESERVE_SECONDS - KILL_RESERVE_SECONDS,
+    )
+    terminate_deadline = max(
+        graceful_deadline,
+        deadline - KILL_RESERVE_SECONDS,
+    )
+
+    try:
+        # Start every public close()/stop() before waiting for any one role.
+        for label, process, connection in records:
+            require_ack = label not in exempt
+            if require_ack and not process.is_alive():
+                ack_errors[label] = WorkerFailure(
+                    f"{label}: no STOP acknowledgement; exit {process.exitcode}"
+                )
+            if connection is None or not process.is_alive():
+                continue
+            try:
+                connection.send(("STOP", ()))
+                stop_sent.add(label)
+            except BaseException as error:
+                if require_ack:
+                    ack_errors[label] = WorkerFailure(
+                        f"{label}: STOP handshake failed; "
+                        f"exit {process.exitcode}: {error}"
+                    )
+
+        # Poll all pending responses fairly under the shared deadline. One
+        # round consumes at most 50 ms, independent of the child count.
+        pending = [
+            (label, process, connection)
+            for label, process, connection in records
+            if label in stop_sent and connection is not None
+        ]
+        while pending and time.monotonic() < graceful_deadline:
+            next_pending: list[
+                tuple[str, multiprocessing.Process, Connection]
+            ] = []
+            wait_share = min(
+                0.05 / len(pending),
+                max(0.0, graceful_deadline - time.monotonic()),
             )
-        except BaseException as error:
-            failures.append(f"cleanup {label}: {error}")
+            for label, process, connection in pending:
+                remaining = graceful_deadline - time.monotonic()
+                if remaining <= 0.0:
+                    next_pending.append((label, process, connection))
+                    continue
+                try:
+                    packet = _poll_packet(
+                        connection,
+                        process,
+                        label,
+                        min(wait_share, remaining),
+                    )
+                    if time.monotonic() > graceful_deadline:
+                        next_pending.append((label, process, connection))
+                        continue
+                    if packet is None:
+                        next_pending.append((label, process, connection))
+                        continue
+                    status, value = packet
+                    if status != "OK" or value != "":
+                        raise WorkerFailure(
+                            f"{label}: invalid STOP response {status}: {value}"
+                        )
+                except BaseException as error:
+                    if label not in exempt:
+                        ack_errors[label] = WorkerFailure(
+                            f"{label}: STOP handshake failed; "
+                            f"exit {process.exitcode}: {error}"
+                        )
+            pending = next_pending
+        for label, process, _connection in pending:
+            if label not in exempt:
+                error = TimeoutError(f"timed out waiting for {label}")
+                ack_errors[label] = WorkerFailure(
+                    f"{label}: STOP handshake failed; "
+                    f"exit {process.exitcode}: {error}"
+                )
+
+        for _label, process, _connection in records:
+            _join_until(process, graceful_deadline)
+
+        # Escalate each phase for all survivors before waiting, so one stalled
+        # child cannot consume another child's terminate or kill opportunity.
+        for label, process, _connection in records:
+            if not process.is_alive():
+                continue
+            forced.add(label)
+            try:
+                process.terminate()
+            except BaseException as error:
+                escalation_errors[label].append(f"terminate failed: {error}")
+        for _label, process, _connection in records:
+            _join_until(process, terminate_deadline)
+
+        for label, process, _connection in records:
+            if not process.is_alive() or not hasattr(process, "kill"):
+                continue
+            forced.add(label)
+            try:
+                process.kill()
+            except BaseException as error:
+                escalation_errors[label].append(f"kill failed: {error}")
+        for _label, process, _connection in records:
+            _join_until(process, deadline)
+
+        for label, process, _connection in records:
+            if process.is_alive():
+                details = escalation_errors[label]
+                suffix = f"; {'; '.join(details)}" if details else ""
+                failures.append(
+                    f"cleanup {label}: {label}: child survived cleanup{suffix}"
+                )
+                continue
+            if allow_forced and label in forced:
+                continue
+            error = ack_errors.get(label)
+            if error is not None:
+                failures.append(f"cleanup {label}: {error}")
+            elif label not in exempt and process.exitcode != 0:
+                failures.append(
+                    f"cleanup {label}: {label}: "
+                    f"graceful cleanup exit {process.exitcode}"
+                )
+    finally:
+        for label, _process, connection in records:
+            if connection is None:
+                continue
+            try:
+                connection.close()
+            except BaseException as error:
+                failures.append(f"cleanup {label}: pipe close failed: {error}")
     return failures
 
 

--- a/examples/python/quickstart.py
+++ b/examples/python/quickstart.py
@@ -16,8 +16,15 @@ from typing import Any, Callable
 
 WORK_SECONDS = 30.0
 FAILURE_SECONDS = 15.0
-CLEANUP_SECONDS = 7.0
-CHILD_CLEANUP_SECONDS = 2.0
+CHILD_GRACEFUL_STOP_SECONDS = 5.0
+TERMINATE_RESERVE_SECONDS = 0.5
+KILL_RESERVE_SECONDS = 0.5
+CHILD_CLEANUP_SECONDS = (
+    CHILD_GRACEFUL_STOP_SECONDS
+    + TERMINATE_RESERVE_SECONDS
+    + KILL_RESERVE_SECONDS
+)
+CLEANUP_SECONDS = 19.0
 FAILURE_ENV = "SITOS_EXAMPLE_TEST_FAIL"
 FAILURE_VALUE = "cache-before-open"
 FAILURE_MESSAGE = "test-injected cache startup failure"
@@ -231,7 +238,17 @@ def _stop(
     allow_forced: bool = False,
 ) -> None:
     ack_error: BaseException | None = None
+    escalation_errors: list[str] = []
     forced = False
+    now = time.monotonic()
+    graceful_deadline = max(
+        now,
+        deadline - TERMINATE_RESERVE_SECONDS - KILL_RESERVE_SECONDS,
+    )
+    terminate_deadline = max(
+        graceful_deadline,
+        deadline - KILL_RESERVE_SECONDS,
+    )
     try:
         if require_ack and not process.is_alive():
             ack_error = WorkerFailure(
@@ -244,7 +261,7 @@ def _stop(
                     connection,
                     process,
                     label,
-                    min(deadline, time.monotonic() + 0.6),
+                    graceful_deadline,
                 )
                 if status != "OK" or value != "":
                     raise WorkerFailure(f"{label}: invalid STOP response {status}: {value}")
@@ -253,17 +270,26 @@ def _stop(
                     ack_error = WorkerFailure(
                         f"{label}: STOP handshake failed; exit {process.exitcode}: {error}"
                     )
-        _join_until(process, min(deadline, time.monotonic() + 0.4))
+        _join_until(process, graceful_deadline)
         if process.is_alive():
             forced = True
-            process.terminate()
-            _join_until(process, min(deadline, time.monotonic() + 0.4))
+            try:
+                process.terminate()
+            except BaseException as error:
+                escalation_errors.append(f"terminate failed: {error}")
+            _join_until(process, terminate_deadline)
         if process.is_alive() and hasattr(process, "kill"):
             forced = True
-            process.kill()
+            try:
+                process.kill()
+            except BaseException as error:
+                escalation_errors.append(f"kill failed: {error}")
         _join_until(process, deadline)
         if process.is_alive():
-            raise WorkerFailure(f"{label}: child survived cleanup")
+            details = (
+                f"; {'; '.join(escalation_errors)}" if escalation_errors else ""
+            )
+            raise WorkerFailure(f"{label}: child survived cleanup{details}")
         if not (allow_forced and forced):
             if ack_error is not None:
                 raise ack_error

--- a/tests/examples/test_python_examples.py
+++ b/tests/examples/test_python_examples.py
@@ -126,30 +126,38 @@ class _FakeConnection:
         packet_at: float | None = None,
         packet: tuple[str, object] = ("OK", ""),
         send_error: BaseException | None = None,
+        poll_overshoot: float = 0.0,
     ) -> None:
         self.clock = clock
         self.packet_at = packet_at
         self.packet = packet
         self.send_error = send_error
+        self.poll_overshoot = poll_overshoot
         self.sent: list[object] = []
+        self.send_times: list[float] = []
         self.closed = False
         self.received = False
+        self.recv_times: list[float] = []
 
     def send(self, value: object) -> None:
         if self.send_error is not None:
             raise self.send_error
         self.sent.append(value)
+        self.send_times.append(self.clock.now)
 
     def poll(self, wait: float = 0.0) -> bool:
+        actual_wait = wait + self.poll_overshoot
+        self.poll_overshoot = 0.0
         if self.packet_at is not None and not self.received:
-            if self.packet_at <= self.clock.now + wait:
+            if self.packet_at <= self.clock.now + actual_wait:
                 self.clock.advance(self.packet_at - self.clock.now)
                 return True
-        self.clock.advance(wait)
+        self.clock.advance(actual_wait)
         return False
 
     def recv(self) -> tuple[str, object]:
         self.received = True
+        self.recv_times.append(self.clock.now)
         return self.packet
 
     def close(self) -> None:
@@ -606,24 +614,91 @@ class PythonExampleContractTest(unittest.TestCase):
                 SendFailure(), process, "writer put", time.monotonic() + 1.0, "PUT"
             )
 
-    def test_cleanup_accepts_delayed_ack_within_graceful_budget(self) -> None:
+    def test_cleanup_requests_all_stops_before_shared_deadline_wait(self) -> None:
         quickstart = _load_quickstart()
         clock = _FakeClock()
-        process = _FakeProcess(clock, natural_exit_at=4.8)
-        connection = _FakeConnection(clock, packet_at=4.75)
+        writer = _FakeProcess(clock, natural_exit_at=5.8)
+        writer_connection = _FakeConnection(clock, packet_at=5.7)
+        cache = _FakeProcess(clock, natural_exit_at=0.2)
+        cache_connection = _FakeConnection(clock, packet_at=0.1)
 
         with mock.patch.object(quickstart.time, "monotonic", clock.monotonic):
             failures = quickstart._cleanup(
-                [("writer", process, connection)], deadline=10.0
+                [
+                    ("writer", writer, writer_connection),
+                    ("cache", cache, cache_connection),
+                ],
+                deadline=19.0,
             )
 
         self.assertEqual(failures, [])
-        self.assertFalse(process.is_alive())
-        self.assertEqual(process.exitcode, 0)
-        self.assertEqual(process.terminate_calls, 0)
-        self.assertEqual(process.kill_calls, 0)
-        self.assertEqual(connection.sent, [("STOP", ())])
-        self.assertTrue(connection.closed)
+        self.assertEqual(writer_connection.send_times, [0.0])
+        self.assertEqual(cache_connection.send_times, [0.0])
+        for process, connection in (
+            (writer, writer_connection),
+            (cache, cache_connection),
+        ):
+            self.assertFalse(process.is_alive())
+            self.assertEqual(process.exitcode, 0)
+            self.assertEqual(process.terminate_calls, 0)
+            self.assertEqual(process.kill_calls, 0)
+            self.assertEqual(connection.sent, [("STOP", ())])
+            self.assertTrue(connection.closed)
+
+    def test_cleanup_polls_pending_acknowledgements_fairly(self) -> None:
+        quickstart = _load_quickstart()
+        clock = _FakeClock()
+        writer = _FakeProcess(clock, natural_exit_at=0.3)
+        writer_connection = _FakeConnection(clock, packet_at=0.2)
+        cache = _FakeProcess(clock)
+        cache_connection = _FakeConnection(clock)
+
+        with mock.patch.object(quickstart.time, "monotonic", clock.monotonic):
+            failures = quickstart._cleanup(
+                [
+                    ("writer", writer, writer_connection),
+                    ("cache", cache, cache_connection),
+                ],
+                deadline=2.0,
+            )
+
+        self.assertEqual(len(failures), 1)
+        self.assertRegex(failures[0], r"cleanup cache:.*timed out waiting")
+        self.assertEqual(len(writer_connection.recv_times), 1)
+        self.assertLessEqual(writer_connection.recv_times[0], 0.25)
+        self.assertFalse(writer.is_alive())
+        self.assertEqual(writer.terminate_calls, 0)
+        self.assertEqual(cache.terminate_calls, 1)
+        self.assertFalse(cache.is_alive())
+        self.assertTrue(writer_connection.closed)
+        self.assertTrue(cache_connection.closed)
+
+    def test_wait_packet_rejects_ack_observed_after_deadline(self) -> None:
+        quickstart = _load_quickstart()
+        clock = _FakeClock()
+        process = _FakeProcess(clock)
+        connection = _FakeConnection(clock, packet_at=1.0)
+        clock.advance(1.01)
+
+        with self.assertRaisesRegex(TimeoutError, r"timed out waiting for writer"):
+            with mock.patch.object(quickstart.time, "monotonic", clock.monotonic):
+                quickstart._wait_packet(connection, process, "writer", 1.0)
+
+        self.assertFalse(connection.received)
+
+        clock = _FakeClock()
+        process = _FakeProcess(clock)
+        connection = _FakeConnection(
+            clock,
+            packet_at=1.01,
+            poll_overshoot=0.02,
+        )
+        clock.advance(0.99)
+        with self.assertRaisesRegex(TimeoutError, r"timed out waiting for writer"):
+            with mock.patch.object(quickstart.time, "monotonic", clock.monotonic):
+                quickstart._wait_packet(connection, process, "writer", 1.0)
+        self.assertTrue(connection.received)
+        self.assertAlmostEqual(clock.now, 1.01)
 
     def test_stop_reports_exit_pipe_and_invalid_ack_failures(self) -> None:
         quickstart = _load_quickstart()
@@ -1073,7 +1148,9 @@ def _contract_methods(case: str) -> tuple[str, ...]:
         "test_process_examples_declare_lifecycle_contract",
         "test_pipe_failures_keep_stage_and_exit_diagnostics",
         "test_near_expiry_does_not_spawn_a_coordinator",
-        "test_cleanup_accepts_delayed_ack_within_graceful_budget",
+        "test_cleanup_requests_all_stops_before_shared_deadline_wait",
+        "test_cleanup_polls_pending_acknowledgements_fairly",
+        "test_wait_packet_rejects_ack_observed_after_deadline",
         "test_stop_reports_exit_pipe_and_invalid_ack_failures",
         "test_stop_exhaustion_reaps_and_reports_missing_ack",
         "test_stop_allowed_fallback_reaps_after_terminate_or_kill",

--- a/tests/examples/test_python_examples.py
+++ b/tests/examples/test_python_examples.py
@@ -569,6 +569,96 @@ class PythonExampleContractTest(unittest.TestCase):
         self.assertEqual(result.returncode, 124)
         popen.assert_not_called()
 
+    def test_failure_cleanup_uses_single_shared_deadline(self) -> None:
+        quickstart = _load_quickstart()
+        clock = _FakeClock()
+
+        class IdentifiedProcess(_FakeProcess):
+            def __init__(self, pid: int) -> None:
+                super().__init__(clock)
+                self.pid = pid
+
+        workers = [
+            (IdentifiedProcess(101), _FakeConnection(clock)),
+            (IdentifiedProcess(102), _FakeConnection(clock)),
+            (IdentifiedProcess(103), _FakeConnection(clock)),
+        ]
+        spawned = iter(workers)
+        cleanup_deadlines: list[float] = []
+
+        def cleanup(
+            children: list[tuple[str, _FakeProcess, _FakeConnection]],
+            deadline: float,
+            *,
+            exempt: set[str] | None = None,
+            allow_forced: bool = False,
+        ) -> list[str]:
+            self.assertEqual(
+                [label for label, _process, _connection in children],
+                ["node", "writer", "cache"],
+            )
+            self.assertEqual(exempt, {"cache"})
+            self.assertTrue(allow_forced)
+            cleanup_deadlines.append(deadline)
+            for _label, process, _connection in children:
+                process._alive = False
+                process._exitcode = 0
+            return []
+
+        stderr = io.StringIO()
+        with (
+            mock.patch.object(quickstart.time, "monotonic", clock.monotonic),
+            mock.patch.object(
+                quickstart.multiprocessing, "get_context", return_value=object()
+            ),
+            mock.patch.object(
+                quickstart, "_spawn", side_effect=lambda *_args: next(spawned)
+            ),
+            mock.patch.object(quickstart, "_wait", return_value=None),
+            mock.patch.object(
+                quickstart,
+                "_wait_packet",
+                return_value=(
+                    "TEST_FAILURE",
+                    {"pid": 103, "message": quickstart.FAILURE_MESSAGE},
+                ),
+            ),
+            mock.patch.object(quickstart, "_cleanup", side_effect=cleanup),
+            contextlib.redirect_stderr(stderr),
+        ):
+            result = quickstart._run_failure(
+                "test/prefix",
+                writer_target=lambda *_args: None,
+                writer_args_factory=lambda _sid, _key: (),
+                cache_target=lambda *_args: None,
+                cache_args_factory=lambda _sid, _key: (),
+            )
+
+        self.assertEqual(result, 70, stderr.getvalue())
+        self.assertEqual(cleanup_deadlines, [quickstart.CLEANUP_SECONDS])
+        self.assertEqual(workers[2][0].join_calls, [])
+        self.assertIn(quickstart.FAILURE_CLEANUP_LINE, stderr.getvalue())
+
+    def test_exempt_cleanup_still_reports_abnormal_exit(self) -> None:
+        quickstart = _load_quickstart()
+        clock = _FakeClock()
+        process = _FakeProcess(clock, alive=False, exitcode=7)
+        connection = _FakeConnection(clock)
+
+        with mock.patch.object(quickstart.time, "monotonic", clock.monotonic):
+            failures = quickstart._cleanup(
+                [("cache", process, connection)],
+                deadline=2.0,
+                exempt={"cache"},
+                allow_forced=True,
+            )
+
+        self.assertEqual(
+            failures,
+            ["cleanup cache: cache: graceful cleanup exit 7"],
+        )
+        self.assertTrue(connection.closed)
+
     def test_raw_primary_and_cleanup_failures_are_both_preserved(self) -> None:
         with self.assertRaisesRegex(
             RuntimeError, r"raw failed; raw peer cleanup: cleanup failed"
@@ -1291,6 +1381,8 @@ def _contract_methods(case: str) -> tuple[str, ...]:
         "test_process_examples_declare_lifecycle_contract",
         "test_pipe_failures_keep_stage_and_exit_diagnostics",
         "test_near_expiry_does_not_spawn_a_coordinator",
+        "test_failure_cleanup_uses_single_shared_deadline",
+        "test_exempt_cleanup_still_reports_abnormal_exit",
         "test_cleanup_requests_all_stops_before_shared_deadline_wait",
         "test_cleanup_reports_exit_between_liveness_check_and_stop",
         "test_cleanup_rejects_ack_observed_after_shared_deadline",

--- a/tests/examples/test_python_examples.py
+++ b/tests/examples/test_python_examples.py
@@ -645,6 +645,149 @@ class PythonExampleContractTest(unittest.TestCase):
             self.assertEqual(connection.sent, [("STOP", ())])
             self.assertTrue(connection.closed)
 
+    def test_cleanup_reports_exit_between_liveness_check_and_stop(self) -> None:
+        quickstart = _load_quickstart()
+        clock = _FakeClock()
+
+        class ExitBetweenChecksProcess(_FakeProcess):
+            def __init__(self) -> None:
+                super().__init__(clock)
+                self.is_alive_calls = 0
+
+            def is_alive(self) -> bool:
+                self.is_alive_calls += 1
+                if self.is_alive_calls == 1:
+                    return True
+                self._alive = False
+                self._exitcode = 0
+                return False
+
+        process = ExitBetweenChecksProcess()
+        connection = _FakeConnection(clock)
+
+        with mock.patch.object(quickstart.time, "monotonic", clock.monotonic):
+            failures = quickstart._cleanup(
+                [("writer", process, connection)],
+                deadline=2.0,
+            )
+
+        self.assertEqual(len(failures), 1)
+        self.assertRegex(failures[0], r"cleanup writer:.*exited with 0")
+        self.assertEqual(connection.sent, [("STOP", ())])
+        self.assertTrue(connection.closed)
+
+    def test_cleanup_rejects_ack_observed_after_shared_deadline(self) -> None:
+        quickstart = _load_quickstart()
+        clock = _FakeClock()
+        process = _FakeProcess(clock, natural_exit_at=1.01)
+        connection = _FakeConnection(
+            clock,
+            packet_at=1.01,
+            poll_overshoot=0.96,
+        )
+
+        with mock.patch.object(quickstart.time, "monotonic", clock.monotonic):
+            failures = quickstart._cleanup(
+                [("writer", process, connection)],
+                deadline=2.0,
+            )
+
+        self.assertEqual(len(failures), 1)
+        self.assertRegex(failures[0], r"cleanup writer:.*timed out waiting")
+        self.assertTrue(connection.received)
+        self.assertAlmostEqual(clock.now, 1.01)
+        self.assertFalse(process.is_alive())
+        self.assertEqual(process.terminate_calls, 0)
+        self.assertEqual(process.kill_calls, 0)
+        self.assertTrue(connection.closed)
+
+    def test_cleanup_escalates_and_reaps_all_survivors_by_phase(self) -> None:
+        quickstart = _load_quickstart()
+        clock = _FakeClock()
+        events: list[str] = []
+
+        class DeferredKillProcess(_FakeProcess):
+            def __init__(self, label: str) -> None:
+                super().__init__(
+                    clock,
+                    terminate_exits=False,
+                    kill_exits=False,
+                )
+                self.label = label
+                self.kill_requested = False
+
+            def terminate(self) -> None:
+                self.terminate_calls += 1
+                events.append(f"terminate:{self.label}")
+
+            def kill(self) -> None:
+                self.kill_calls += 1
+                self.kill_requested = True
+                events.append(f"kill:{self.label}")
+
+            def join(self, timeout: float) -> None:
+                self.join_calls.append(timeout)
+                phase = "kill" if self.kill_requested else "terminate"
+                events.append(f"{phase}-join:{self.label}")
+                if self.kill_requested:
+                    self._alive = False
+                    self._exitcode = -9
+                    clock.advance(min(timeout, 0.01))
+                else:
+                    clock.advance(timeout)
+
+        writer = DeferredKillProcess("writer")
+        cache = DeferredKillProcess("cache")
+        writer_connection = _FakeConnection(clock)
+        cache_connection = _FakeConnection(clock)
+
+        with mock.patch.object(quickstart.time, "monotonic", clock.monotonic):
+            failures = quickstart._cleanup(
+                [
+                    ("writer", writer, writer_connection),
+                    ("cache", cache, cache_connection),
+                ],
+                deadline=2.0,
+                allow_forced=True,
+            )
+
+        self.assertEqual(failures, [])
+        first_terminate_join = min(
+            index
+            for index, event in enumerate(events)
+            if event.startswith("terminate-join:")
+        )
+        last_terminate = max(
+            index
+            for index, event in enumerate(events)
+            if event.startswith("terminate:")
+        )
+        first_kill_join = min(
+            index
+            for index, event in enumerate(events)
+            if event.startswith("kill-join:")
+        )
+        last_kill = max(
+            index for index, event in enumerate(events) if event.startswith("kill:")
+        )
+        self.assertLess(last_terminate, first_terminate_join)
+        self.assertLess(last_kill, first_kill_join)
+        for process, connection in (
+            (writer, writer_connection),
+            (cache, cache_connection),
+        ):
+            self.assertFalse(process.is_alive())
+            self.assertEqual(process.terminate_calls, 1)
+            self.assertEqual(process.kill_calls, 1)
+            self.assertTrue(
+                any(
+                    event == f"kill-join:{process.label}"
+                    for event in events
+                )
+            )
+            self.assertTrue(connection.closed)
+        self.assertLessEqual(clock.now, 2.0 + 1e-9)
+
     def test_cleanup_polls_pending_acknowledgements_fairly(self) -> None:
         quickstart = _load_quickstart()
         clock = _FakeClock()
@@ -1149,6 +1292,9 @@ def _contract_methods(case: str) -> tuple[str, ...]:
         "test_pipe_failures_keep_stage_and_exit_diagnostics",
         "test_near_expiry_does_not_spawn_a_coordinator",
         "test_cleanup_requests_all_stops_before_shared_deadline_wait",
+        "test_cleanup_reports_exit_between_liveness_check_and_stop",
+        "test_cleanup_rejects_ack_observed_after_shared_deadline",
+        "test_cleanup_escalates_and_reaps_all_survivors_by_phase",
         "test_cleanup_polls_pending_acknowledgements_fairly",
         "test_wait_packet_rejects_ack_observed_after_deadline",
         "test_stop_reports_exit_pipe_and_invalid_ack_failures",

--- a/tests/examples/test_python_examples.py
+++ b/tests/examples/test_python_examples.py
@@ -41,6 +41,131 @@ MARKERS = {
 CASE_SECONDS = 60.0
 
 
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += max(0.0, seconds)
+
+
+class _FakeProcess:
+    def __init__(
+        self,
+        clock: _FakeClock,
+        *,
+        alive: bool = True,
+        exitcode: int = 0,
+        natural_exit_at: float | None = None,
+        terminate_exits: bool = True,
+        kill_exits: bool = True,
+        terminate_error: BaseException | None = None,
+        kill_error: BaseException | None = None,
+    ) -> None:
+        self.clock = clock
+        self._alive = alive
+        self._exitcode = None if alive else exitcode
+        self.natural_exit_at = natural_exit_at
+        self.natural_exitcode = exitcode
+        self.terminate_exits = terminate_exits
+        self.kill_exits = kill_exits
+        self.terminate_error = terminate_error
+        self.kill_error = kill_error
+        self.terminate_calls = 0
+        self.kill_calls = 0
+        self.join_calls: list[float] = []
+
+    def _refresh(self) -> None:
+        if (
+            self._alive
+            and self.natural_exit_at is not None
+            and self.clock.now >= self.natural_exit_at
+        ):
+            self._alive = False
+            self._exitcode = self.natural_exitcode
+
+    @property
+    def exitcode(self) -> int | None:
+        self._refresh()
+        return self._exitcode
+
+    def is_alive(self) -> bool:
+        self._refresh()
+        return self._alive
+
+    def join(self, timeout: float) -> None:
+        self.join_calls.append(timeout)
+        self.clock.advance(timeout)
+        self._refresh()
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+        if self.terminate_error is not None:
+            raise self.terminate_error
+        if self.terminate_exits:
+            self._alive = False
+            self._exitcode = -15
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        if self.kill_error is not None:
+            raise self.kill_error
+        if self.kill_exits:
+            self._alive = False
+            self._exitcode = -9
+
+
+class _FakeConnection:
+    def __init__(
+        self,
+        clock: _FakeClock,
+        *,
+        packet_at: float | None = None,
+        packet: tuple[str, object] = ("OK", ""),
+        send_error: BaseException | None = None,
+    ) -> None:
+        self.clock = clock
+        self.packet_at = packet_at
+        self.packet = packet
+        self.send_error = send_error
+        self.sent: list[object] = []
+        self.closed = False
+        self.received = False
+
+    def send(self, value: object) -> None:
+        if self.send_error is not None:
+            raise self.send_error
+        self.sent.append(value)
+
+    def poll(self, wait: float = 0.0) -> bool:
+        if self.packet_at is not None and not self.received:
+            if self.packet_at <= self.clock.now + wait:
+                self.clock.advance(self.packet_at - self.clock.now)
+                return True
+        self.clock.advance(wait)
+        return False
+
+    def recv(self) -> tuple[str, object]:
+        self.received = True
+        return self.packet
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _load_quickstart() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "sitos_example_quickstart_contract", REQUIRED["quickstart"]
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def _import_roots(path: Path) -> set[str]:
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     roots: set[str] = set()
@@ -481,6 +606,179 @@ class PythonExampleContractTest(unittest.TestCase):
                 SendFailure(), process, "writer put", time.monotonic() + 1.0, "PUT"
             )
 
+    def test_cleanup_accepts_delayed_ack_within_graceful_budget(self) -> None:
+        quickstart = _load_quickstart()
+        clock = _FakeClock()
+        process = _FakeProcess(clock, natural_exit_at=4.8)
+        connection = _FakeConnection(clock, packet_at=4.75)
+
+        with mock.patch.object(quickstart.time, "monotonic", clock.monotonic):
+            failures = quickstart._cleanup(
+                [("writer", process, connection)], deadline=10.0
+            )
+
+        self.assertEqual(failures, [])
+        self.assertFalse(process.is_alive())
+        self.assertEqual(process.exitcode, 0)
+        self.assertEqual(process.terminate_calls, 0)
+        self.assertEqual(process.kill_calls, 0)
+        self.assertEqual(connection.sent, [("STOP", ())])
+        self.assertTrue(connection.closed)
+
+    def test_stop_reports_exit_pipe_and_invalid_ack_failures(self) -> None:
+        quickstart = _load_quickstart()
+
+        clock = _FakeClock()
+        process = _FakeProcess(clock, alive=False, exitcode=9)
+        connection = _FakeConnection(clock)
+        with self.assertRaisesRegex(
+            quickstart.WorkerFailure, r"no STOP acknowledgement; exit 9"
+        ):
+            with mock.patch.object(quickstart.time, "monotonic", clock.monotonic):
+                quickstart._stop(process, connection, "writer", 2.0)
+        self.assertFalse(process.is_alive())
+        self.assertTrue(connection.closed)
+
+        clock = _FakeClock()
+        process = _FakeProcess(clock, natural_exit_at=0.2)
+        connection = _FakeConnection(clock)
+        with self.assertRaisesRegex(
+            quickstart.WorkerFailure, r"STOP handshake failed.*exited with 0"
+        ):
+            with mock.patch.object(quickstart.time, "monotonic", clock.monotonic):
+                quickstart._stop(process, connection, "writer", 2.0)
+        self.assertEqual(connection.sent, [("STOP", ())])
+        self.assertFalse(process.is_alive())
+        self.assertEqual(process.terminate_calls, 0)
+        self.assertEqual(process.kill_calls, 0)
+        self.assertTrue(connection.closed)
+
+        clock = _FakeClock()
+        process = _FakeProcess(clock, natural_exit_at=0.2)
+        connection = _FakeConnection(clock, send_error=BrokenPipeError("closed"))
+        with self.assertRaisesRegex(
+            quickstart.WorkerFailure, r"STOP handshake failed.*closed"
+        ):
+            with mock.patch.object(quickstart.time, "monotonic", clock.monotonic):
+                quickstart._stop(process, connection, "writer", 2.0)
+        self.assertFalse(process.is_alive())
+        self.assertTrue(connection.closed)
+
+        clock = _FakeClock()
+        process = _FakeProcess(clock, natural_exit_at=0.2)
+        connection = _FakeConnection(
+            clock, packet_at=0.1, packet=("INVALID", "unexpected")
+        )
+        with self.assertRaisesRegex(
+            quickstart.WorkerFailure, r"invalid STOP response INVALID: unexpected"
+        ):
+            with mock.patch.object(quickstart.time, "monotonic", clock.monotonic):
+                quickstart._stop(process, connection, "writer", 2.0)
+        self.assertFalse(process.is_alive())
+        self.assertTrue(connection.closed)
+
+    def test_stop_exhaustion_reaps_and_reports_missing_ack(self) -> None:
+        quickstart = _load_quickstart()
+
+        clock = _FakeClock()
+        process = _FakeProcess(clock)
+        connection = _FakeConnection(clock)
+        with self.assertRaisesRegex(
+            quickstart.WorkerFailure, r"STOP handshake failed.*timed out waiting"
+        ):
+            with mock.patch.object(quickstart.time, "monotonic", clock.monotonic):
+                quickstart._stop(process, connection, "writer", 2.0)
+        self.assertFalse(process.is_alive())
+        self.assertEqual(process.terminate_calls, 1)
+        self.assertEqual(process.kill_calls, 0)
+        self.assertTrue(connection.closed)
+        self.assertLessEqual(clock.now, 2.0 + 1e-9)
+
+    def test_stop_allowed_fallback_reaps_after_terminate_or_kill(self) -> None:
+        quickstart = _load_quickstart()
+
+        for terminate_exits, expected_kills in ((True, 0), (False, 1)):
+            with self.subTest(terminate_exits=terminate_exits):
+                clock = _FakeClock()
+                process = _FakeProcess(clock, terminate_exits=terminate_exits)
+                connection = _FakeConnection(clock)
+                with mock.patch.object(
+                    quickstart.time, "monotonic", clock.monotonic
+                ):
+                    quickstart._stop(
+                        process,
+                        connection,
+                        "writer",
+                        2.0,
+                        allow_forced=True,
+                    )
+                self.assertFalse(process.is_alive())
+                self.assertEqual(process.terminate_calls, 1)
+                self.assertEqual(process.kill_calls, expected_kills)
+                self.assertTrue(connection.closed)
+                self.assertLessEqual(clock.now, 2.0 + 1e-9)
+
+    def test_stop_uses_kill_after_terminate_raises(self) -> None:
+        quickstart = _load_quickstart()
+        clock = _FakeClock()
+        process = _FakeProcess(
+            clock,
+            terminate_exits=False,
+            terminate_error=PermissionError("terminate denied"),
+        )
+        connection = _FakeConnection(clock)
+
+        with mock.patch.object(quickstart.time, "monotonic", clock.monotonic):
+            quickstart._stop(
+                process,
+                connection,
+                "writer",
+                2.0,
+                allow_forced=True,
+            )
+
+        self.assertFalse(process.is_alive())
+        self.assertEqual(process.terminate_calls, 1)
+        self.assertEqual(process.kill_calls, 1)
+        self.assertTrue(connection.closed)
+        self.assertLessEqual(clock.now, 2.0 + 1e-9)
+
+    def test_primary_failure_precedes_cleanup_diagnostics(self) -> None:
+        quickstart = _load_quickstart()
+        stderr = io.StringIO()
+        with (
+            mock.patch.dict(quickstart.os.environ, {}, clear=True),
+            mock.patch.object(
+                quickstart, "_spawn", side_effect=RuntimeError("primary failed")
+            ),
+            mock.patch.object(
+                quickstart,
+                "_cleanup",
+                return_value=["cleanup writer: forced cleanup failed"],
+            ),
+            contextlib.redirect_stderr(stderr),
+        ):
+            result = quickstart.run_example(
+                "test/prefix",
+                writer_target=lambda *_args: None,
+                writer_args_factory=lambda _sid, _key: (),
+                cache_target=lambda *_args: None,
+                cache_args_factory=lambda _sid, _key: (),
+                put_args_factory=lambda _sid, _key, _value: (),
+                check_command="GET",
+                observe=lambda _value: False,
+                marker="SHOULD_NOT_PRINT",
+            )
+
+        self.assertEqual(result, 1)
+        self.assertEqual(
+            stderr.getvalue().splitlines(),
+            [
+                "example failed: primary failed",
+                "cleanup: cleanup writer: forced cleanup failed",
+            ],
+        )
+
     def test_raw_example_has_no_sitos_or_numpy_import(self) -> None:
         path = REQUIRED["raw-zenoh"]
         self.assertEqual(
@@ -775,6 +1073,12 @@ def _contract_methods(case: str) -> tuple[str, ...]:
         "test_process_examples_declare_lifecycle_contract",
         "test_pipe_failures_keep_stage_and_exit_diagnostics",
         "test_near_expiry_does_not_spawn_a_coordinator",
+        "test_cleanup_accepts_delayed_ack_within_graceful_budget",
+        "test_stop_reports_exit_pipe_and_invalid_ack_failures",
+        "test_stop_exhaustion_reaps_and_reports_missing_ack",
+        "test_stop_allowed_fallback_reaps_after_terminate_or_kill",
+        "test_stop_uses_kill_after_terminate_raises",
+        "test_primary_failure_precedes_cleanup_diagnostics",
     )
     if case in {"quickstart", "failure-cleanup"}:
         return common + process_contracts


### PR DESCRIPTION
## Summary

Closes #163

Harden process-isolated Python example shutdown with one shared monotonic cleanup deadline. Send STOP to every child before waiting, collect acknowledgements fairly, reject late or malformed acknowledgements, and perform bounded phase-wide terminate/kill fallback with final reaping.

The initial PR head proved that replacing the old 0.6-second slice with a new 5-second per-child slice was insufficient: Windows run 32374617871 passed one live quickstart and then failed the second because the writer acknowledgement exceeded 5 seconds. The current head removes per-child slices, places the expected failure scenario under the same bounded cleanup deadline, and keeps abnormal natural exits visible even for workers exempt from STOP acknowledgement.

## Requirements

Reference requirement IDs from docs/01_requirements.md (F/N/C/P/X): N/A — CI/example lifecycle reliability only.

## Contract Registry

Affected contract-registry row(s) (docs/08_contract_registry.md) with their status transition (`Contract` / `Implementation` / `none`), or `N/A` if no contract is touched: N/A — no public contract is changed.

## Frozen Issue Checklist

Copy the frozen Issue checklist here and track progress only in this PR:

- [x] Add a deterministic regression that fails against the current STOP-handshake implementation without relying on live Zenoh timing.
- [x] Cover delayed successful acknowledgement, child exit before acknowledgement, pipe failure, deadline exhaustion, terminate fallback, and kill fallback.
- [x] Demonstrate that no injected case leaves a surviving child or orphaned process-tree member.
- [x] Keep `tests/examples/test_python_examples.py` green on Linux and Windows.
- [x] Keep the repaired Linux and Windows CPython 3.12 wheel validation paths intact; do not skip quickstart, NumPy LUT, raw-Zenoh, failure-cleanup, wheel-boundary, Python API, or typing checks.
- [x] Obtain a green Windows CPython 3.12 wheel job on the exact implementation head without treating an Actions rerun alone as correctness evidence.
- [x] Record the RED command, expected failure reason, one representative failure line, and GREEN validation commands in the PR.

## Acceptance Criteria Verification

Local validation at `f325a8b9d5313cf4dc6ad8f92db56bbd0964f439`:

```text
PYTHONDONTWRITEBYTECODE=1 python3 -B tests/examples/test_python_examples.py contract
Ran 25 tests
OK

(cd /tmp && PYTHONDONTWRITEBYTECODE=1 python3 -B /home/hayate/git/sitos/tests/examples/test_python_examples.py contract)
Ran 25 tests
OK

100 consecutive contract-suite runs
PASS

PYTHONDONTWRITEBYTECODE=1 python3 -B tests/docs/test_public_documentation.py -q
Ran 11 tests
OK

in-memory syntax compilation of both changed Python files
git diff --check
PASS
```

The local checkout does not contain an installed or source-built `sitos` Python module, so live quickstart/NumPy/failure-cleanup process execution is provided by the existing source and repaired-wheel CI lanes. Exact-head Linux and Windows wheel validation passed.

Final independent read-only review: PASS with no included findings. It confirmed all-STOP-first ordering, fair acknowledgement polling, strict pre/post-poll deadline enforcement, one shared failure-cleanup deadline, STOP-acknowledgement-only exemption, abnormal-exit visibility, phase-wide terminate/kill fallback, complete child reaping, deterministic diagnostics, two-file scope, and no public API or wire change.

### Initial-head Windows evidence

Run: https://github.com/tetsuh/sitos/actions/runs/32374617871  
Failed job: https://github.com/tetsuh/sitos/actions/runs/32374617871/job/96442905231  
Initial head: `4b33f14d9db31cf1e71f3aa23c69d14a0ccb1f42`

- Wheel build, repair, content validation, native dependency checks, and clean installation succeeded.
- Deterministic contract tests succeeded on Windows.
- The first live quickstart succeeded.
- The second live quickstart failed after 6.111 seconds with `writer: STOP handshake failed; exit None: timed out waiting for writer`.
- This failure produced the follow-up RED proving that a new 5-second per-child slice was still incorrect.

### Final exact-head CI evidence

Current head: `f325a8b9d5313cf4dc6ad8f92db56bbd0964f439`  
Fresh CI run: https://github.com/tetsuh/sitos/actions/runs/32392931892  
Fresh wheel run: https://github.com/tetsuh/sitos/actions/runs/32392931923

- Windows CPython 3.12 wheel: PASS in 3m16s — https://github.com/tetsuh/sitos/actions/runs/32392931923/job/96503053510
- Linux CPython 3.12 wheel: PASS in 14m12s — https://github.com/tetsuh/sitos/actions/runs/32392931923/job/96503053661
- Both wheel jobs executed the two new regressions plus live quickstart, NumPy LUT, raw-Zenoh, and failure-cleanup successfully.
- All 18 executed PR checks passed; TestPyPI, PyPI, latest-compatible, and benchmark jobs skipped under their existing conditions.
- PR is OPEN, non-draft, MERGEABLE, and CLEAN at the exact reviewed head.
- No failed-job rerun was used for this evidence; it came from fresh workflow runs triggered by commit `f325a8b9d5313cf4dc6ad8f92db56bbd0964f439`.

## RED-phase Evidence

### Original implementation RED

- Command: `PYTHONDONTWRITEBYTECODE=1 python3 -B tests/examples/test_python_examples.py contract`
- Failing test name: `test_stop_accepts_delayed_ack_within_cleanup_budget`
- Expected failure reason: the original implementation stopped waiting for a healthy STOP acknowledgement after a fixed 0.6-second slice.
- Representative failure-message line: `WorkerFailure: writer: STOP handshake failed; exit None: timed out waiting for writer`
- Complete CI-log link: N/A — deterministic local fake-clock reproduction was sufficient.

### Initial PR-head follow-up RED

- Command: same contract command after adding shared-deadline regressions.
- Failing test: `test_cleanup_requests_all_stops_before_shared_deadline_wait`
- Expected reason: the initial PR head still imposed a 5-second per-child graceful slice and did not send STOP to all children first.
- Representative line: `AssertionError: ['cleanup writer: writer: STOP handshake failed; ... timed out waiting for writer'] != []`
- Windows evidence: https://github.com/tetsuh/sitos/actions/runs/32374617871/job/96442905231

### Review-driven strict-deadline RED

```text
test_cleanup_polls_pending_acknowledgements_fairly ... FAIL
AssertionError: [1.0] != [0.2]
test_wait_packet_rejects_ack_observed_after_deadline ... FAIL
AssertionError: TimeoutError not raised
FAILED (failures=2)
```

A final scheduler-overshoot fixture starts polling at 0.99 seconds, uses a 1.00-second deadline, observes the ACK at 1.01 seconds, and verifies the ACK remains a timeout.

### Standalone-review shared-budget RED

- Command: `PYTHONDONTWRITEBYTECODE=1 python3 -B tests/examples/test_python_examples.py contract`
- Failing test: `test_failure_cleanup_uses_single_shared_deadline`
- Expected reason: `_run_failure` performed a fixed `join(1.0)` before starting a fresh cleanup deadline, so a scheduler-delayed cache changed the expected return code from 70 to 1.
- Representative line: `AssertionError: 1 != 70`

### Standalone-review abnormal-exit RED

- Command: same contract command after adding the exempt-worker regression.
- Failing test: `test_exempt_cleanup_still_reports_abnormal_exit`
- Expected reason: the cache exemption suppressed a natural nonzero exit in addition to suppressing the expected STOP acknowledgement.
- Representative line: `AssertionError: Lists differ: [] != ['cleanup cache: cache: graceful cleanup exit 7']`

## ADR Needed?

An ADR is required when docs/10_adr_process.md §6 applies. §6 includes introducing a second surface that overlaps an existing contract-registry row (registry Rule 2).

- [x] No
- [ ] Yes — ADR PR: #

This change is private example/test shutdown orchestration and does not alter a public lifecycle, API, wire protocol, or Contract Registry surface.

## Owner Merge Authorization

Complete this section only after the owner authorizes this exact PR head. Leave the status as `Pending` when opening or updating the PR.

- Status: Pending
- Authorized head SHA:
- Owner instruction link:

Authorization is one-time, expires after a new commit or new blocking finding, and never enables auto-merge.

