### PR TITLE
fix(ack): prevent deadline overflow (#169)

### DIFF
--- a/src/ack_client.cpp
+++ b/src/ack_client.cpp
@@ -33,13 +33,24 @@ std::string TimeoutMessage(const std::string& latest_message) {
   return message;
 }
 
-Clock::time_point SaturatingDeadline(std::chrono::milliseconds requested) {
-  const auto now = Clock::now();
+}  // namespace
+
+namespace ack_client_internal {
+
+Clock::time_point SaturatingDeadlineAt(Clock::time_point now, std::chrono::milliseconds requested) {
   const auto remaining = Clock::time_point::max() - now;
   const auto remaining_milliseconds =
       std::chrono::duration_cast<std::chrono::milliseconds>(remaining);
-  if (requested >= remaining_milliseconds) return Clock::time_point::max();
+  if (requested > remaining_milliseconds) return Clock::time_point::max();
   return now + std::chrono::duration_cast<Clock::duration>(requested);
+}
+
+}  // namespace ack_client_internal
+
+namespace {
+
+Clock::time_point SaturatingDeadline(std::chrono::milliseconds requested) {
+  return ack_client_internal::SaturatingDeadlineAt(Clock::now(), requested);
 }
 
 }  // namespace

--- a/src/ack_client.cpp
+++ b/src/ack_client.cpp
@@ -33,6 +33,15 @@ std::string TimeoutMessage(const std::string& latest_message) {
   return message;
 }
 
+Clock::time_point SaturatingDeadline(std::chrono::milliseconds requested) {
+  const auto now = Clock::now();
+  const auto remaining = Clock::time_point::max() - now;
+  const auto remaining_milliseconds =
+      std::chrono::duration_cast<std::chrono::milliseconds>(remaining);
+  if (requested >= remaining_milliseconds) return Clock::time_point::max();
+  return now + std::chrono::duration_cast<Clock::duration>(requested);
+}
+
 }  // namespace
 
 Result<AckResultV1> PollAcknowledgement(Transport& transport, std::string_view prefix,
@@ -116,7 +125,7 @@ Result<AckResultV1> SubmitAcknowledgedWrite(Transport& transport, std::string_vi
     return R::Err(Status::InvalidArgument, std::string(kInvalidPrefix));
   }
 
-  const Clock::time_point deadline_at = Clock::now() + total_deadline;
+  const Clock::time_point deadline_at = SaturatingDeadline(total_deadline);
   PutOptions options;
   options.ack_token = token;
   std::optional<ErrorInfo> latest_error;

--- a/tests/unit/ack_client_test.cpp
+++ b/tests/unit/ack_client_test.cpp
@@ -26,6 +26,11 @@
 #include "sitos/transport.hpp"
 #include "transport/declaration_handle_test_access.hpp"
 
+namespace sitos::ack_client_internal {
+std::chrono::steady_clock::time_point SaturatingDeadlineAt(
+    std::chrono::steady_clock::time_point now, std::chrono::milliseconds requested);
+}  // namespace sitos::ack_client_internal
+
 namespace {
 
 using namespace std::chrono_literals;
@@ -209,6 +214,18 @@ TEST(AckClientTest, SaturatesVeryLargeDeadlineWithoutFalseTimeout) {
   EXPECT_EQ(result.Value(), PutOk());
   EXPECT_EQ(transport.Puts().size(), 1U);
   EXPECT_EQ(transport.Gets().size(), 1U);
+}
+
+TEST(AckClientTest, SaturatesOnlyBeyondTheWholeMillisecondBoundary) {
+  const auto ten_milliseconds = std::chrono::duration_cast<Clock::duration>(10ms);
+  const auto half_millisecond = std::chrono::duration_cast<Clock::duration>(500us);
+  ASSERT_GT(half_millisecond, Clock::duration::zero());
+  const auto now = Clock::time_point::max() - ten_milliseconds - half_millisecond;
+
+  EXPECT_EQ(sitos::ack_client_internal::SaturatingDeadlineAt(now, 10ms), now + ten_milliseconds)
+      << "an exact whole-millisecond fit must preserve the requested deadline";
+  EXPECT_EQ(sitos::ack_client_internal::SaturatingDeadlineAt(now, 11ms), Clock::time_point::max())
+      << "the next millisecond must saturate past the representable range";
 }
 
 TEST(AckClientTest, ResultStatusIsReturnedUnchanged) {

--- a/tests/unit/ack_client_test.cpp
+++ b/tests/unit/ack_client_test.cpp
@@ -199,6 +199,18 @@ TEST(AckClientTest, SubmitsDataExactlyOnceWithFreshTokenAndReturnsDecodedResult)
   }
 }
 
+TEST(AckClientTest, SaturatesVeryLargeDeadlineWithoutFalseTimeout) {
+  ScriptedTransport transport;
+  transport.script = {Reply(PutOk())};
+
+  const auto result = Submit(transport, std::chrono::milliseconds::max());
+
+  ASSERT_TRUE(result.IsOk()) << result.Message();
+  EXPECT_EQ(result.Value(), PutOk());
+  EXPECT_EQ(transport.Puts().size(), 1U);
+  EXPECT_EQ(transport.Gets().size(), 1U);
+}
+
 TEST(AckClientTest, ResultStatusIsReturnedUnchanged) {
   ScriptedTransport transport;
   transport.script = {Reply(PutUnknown())};


### PR DESCRIPTION
## Summary

- saturate oversized ADR-0028 acknowledgement deadlines at the `steady_clock` limit
- prevent a maximum positive millisecond timeout from wrapping into an immediate false `Timeout`
- preserve one data submission and normal acknowledgement-query polling

Closes #169

## Frozen Issue checklist

- [x] RED regression demonstrates the current immediate false `Timeout` with a very large positive timeout and an immediate valid ACK.
- [x] The helper returns the valid ACK and performs exactly one data Put and one ACK query.
- [x] Zero and negative timeouts remain `InvalidArgument` before Transport operations.
- [x] Existing ACK client and ParamStore acknowledgement tests remain green.
- [x] No public API, wire protocol, key grammar, Status value, or Contract Registry row changes.

## Requirements

- N07 — Thread-safe: concurrent Get from multiple threads and concurrent execution of Get and Put are safe. The local deadline calculation adds no shared mutable state and preserves this requirement.

## Contract Registry

- N/A — no contract row or wire meaning changes

## ADR Needed

- No — this is a correctness fix to Accepted ADR-0028 deadline construction

## RED evidence

- Command: `ctest --test-dir build/red --output-on-failure -R '^AckClientTest.SaturatesVeryLargeDeadlineWithoutFalseTimeout$'`
- Failing test: `AckClientTest.SaturatesVeryLargeDeadlineWithoutFalseTimeout`
- Expected reason: `Clock::now() + milliseconds::max()` overflowed before ACK polling.
- Representative failure: `Actual: false ... no acknowledgement within the total deadline`

## Validation

- `AckClientTest.*`: 12/12 passed
- complete Zenoh-OFF CTest suite: 417/417 passed
- ASan/UBSan `AckClientTest.*`: 12/12 passed
- `git diff --check`: passed
- independent read-only review: PASS

## Owner Merge Authorization

- Status: Authorized for one-time normal merge
- Authorized head SHA: a94aba4dfc7bff754665f2d0df42a8fe67d9d609
- Authorization link: https://github.com/tetsuh/sitos/pull/170#issuecomment-5451171564

