### PR TITLE
fix(bench): guard Put session ids independent of formatting (#177)

### DIFF
--- a/tests/bench/test_benchmark_report.py
+++ b/tests/bench/test_benchmark_report.py
@@ -334,6 +334,20 @@ def test_raw_fixtures_reject_fractional_negative_and_truncated_evidence() -> Non
     with pytest.raises(ValueError): _raw_expectations(raw)
 
 
+def _put_session_arguments(source: str) -> list[str]:
+    """Session-id argument of every ``store.Put`` call in ``source``.
+
+    Whitespace between ``store``, ``.``, ``Put``, ``(`` and the first argument is
+    insignificant to the compiler, so it must be insignificant here: clang-format rewraps
+    these calls whenever an argument is added, and a substring guard that assumes one
+    spelling stops guarding silently.
+    """
+    return [
+        re.sub(r"\s+", " ", argument).strip()
+        for argument in re.findall(r"store\s*\.\s*Put\s*\(\s*([^,]+),", source)
+    ]
+
+
 def test_policy_and_workload_fences() -> None:
     policy = json.loads((ROOT / "tests/bench/benchmark_policy.json").read_text(encoding="utf-8"))
     assert policy["actual_thresholds"] == "none—not established"
@@ -407,13 +421,13 @@ def test_policy_and_workload_fences() -> None:
     assert process_target is not None
     source = (ROOT / "tests/bench/process_bench.cpp").read_text(encoding="utf-8")
     assert "n08/v1/scalar/" in source and "n09/v1/value/" in source
-    assert 'store.Put("session/" + sid' in source
     assert 'N09Key' in source and 'std::setw(6)' in source
     assert 'sitos/bench/n09/v1/' in source
     assert 'ThroughputSequence' in source and 'std::setw(10)' in source
     assert '(trial << 48) | (producer << 40) | sequence' in source
-    assert 'store.Put("base"' in source
-    assert 'store.Put("",' not in source
+    put_sessions = _put_session_arguments(source)
+    assert '"base"' in put_sessions and '"session/" + sid' in put_sessions
+    assert '""' not in put_sessions
     assert 'VERIFY_BASE' in source and 'BASE_READY' in source
     assert 'BASE_STATUS ' in source and 'base readiness resubmission failed' in source
     assert 'ParamValue::Decode(value)' in source and 'AsSpan<std::byte>()' in source
@@ -640,12 +654,40 @@ def test_report_cli_rejects_final_incomplete_reference(tmp_path: Path) -> None:
     assert escaped.returncode == 2 and 'escapes artifact root' in escaped.stderr
 
 
+def test_put_session_guard_survives_reformatting() -> None:
+    """The store.Put session-id guard must not depend on clang-format's wrapping (#177).
+
+    The guard exists to pin which session id the benchmark writes to, and in particular
+    to reject an empty one. An assertion that only matches a single-line spelling stops
+    guarding the moment the formatter wraps the call, and does so silently on the
+    negative half. Every spelling below is the same call.
+    """
+    single_line = 'store.Put("base", "n08/v1/lut", value);'
+    wrapped_arguments = 'store.Put(\n    "base",\n    "n08/v1/lut", value);'
+    wrapped_receiver = 'if (!store\n         .Put(\n             "base",\n             "n08/v1/lut", value)\n         .IsOk())'
+    for spelling in (single_line, wrapped_arguments, wrapped_receiver):
+        assert _put_session_arguments(spelling) == ['"base"']
+
+    # The negative half must reject an empty session id in every spelling too.
+    for spelling in (
+        'store.Put("", "n08/v1/lut", value);',
+        'if (!store\n         .Put(\n             "",\n             "n08/v1/lut", value)\n         .IsOk())',
+    ):
+        assert _put_session_arguments(spelling) == ['""']
+
+    # Expressions, not just literals, survive extraction.
+    assert _put_session_arguments('store.Put("session/" + sid, N09Key(index), value);') == [
+        '"session/" + sid'
+    ]
+
+
 def main() -> None:
     for test in (
         test_expected_artifacts_exist, test_decimal_statistics_are_exact,
         test_synthetic_regression_is_flagged, test_workflow_security_and_truth_table,
         test_trial_zero_cache_ready_requires_unambiguous_sentinel,
         test_policy_and_workload_fences,
+        test_put_session_guard_survives_reformatting,
     ):
         test()
     print("benchmark contract tests passed")


### PR DESCRIPTION
## Summary

Closes #177

The nightly Benchmark on `main` has failed every night since 2026-08-30. `40efe27` added a `WriteOptions` argument to the populate writes in `tests/bench/process_bench.cpp`, clang-format rewrapped both `"base"` writes so that `store` and `.Put(` no longer sit on one line, and the guard's exact substring `'store.Put("base"'` stopped matching. The benchmark itself is unchanged and correct; the guard is what broke.

The louder half is the assertion that failed. The quieter half is that `assert 'store.Put("",' not in source` went vacuous at the same moment: after the same rewrapping an empty session id would not match that pattern either, so the check that exists to reject one had silently stopped rejecting anything.

This PR extracts the session-id argument of every `store.Put` call with whitespace treated as insignificant — which is what it is to the compiler — and asserts over the extracted arguments rather than over source spelling.

`tests/bench/process_bench.cpp` is deliberately untouched. Reflowing production-shaped source to satisfy a substring match would leave the same class of breakage in place for the next argument that gets added.

## Requirements

N/A. This is a test-guard correction. No requirement behavior, wire format, or public API is touched.

## Contract Registry

**N/A.** No contract-registry row is affected.

## Frozen Issue Checklist

- [x] The three `store.Put(...)` session-id assertions tolerate any whitespace, including newlines, between `store`, `.`, `Put`, `(` and the first argument.
- [x] The negative assertion genuinely rejects an empty session id under the same tolerance, demonstrated by a test that feeds the checker a rewrapped empty-session write and observes a failure.
- [x] `test_policy_and_workload_fences` passes on current `main` with no change to `tests/bench/process_bench.cpp`.
- [x] The Benchmark workflow is green on `main` afterwards.

## Acceptance Criteria Verification

Exact-head evidence for `9e25d0d`.

```text
python -m pytest tests/bench/test_benchmark_report.py -q        19 passed
python tests/bench/test_benchmark_report.py                     benchmark contract tests passed
git diff --check                                                clean
git status --porcelain                                          clean (process_bench.cpp untouched)
```

Mutation check, proving the guard can fail and that the previous one could not. The wrapped `"base"` write in `process_bench.cpp` was temporarily changed to an empty session id, keeping the same clang-format wrapping, and the file was then restored:

```text
new guard   assert '""' not in ['""', '"base"', '"session/" + sid']   -> FAILED (correct)
old guard   'store.Put("",' in source                                 -> False, so the
                                                                         assertion passed
                                                                         and the write was
                                                                         not rejected
```

Criterion 4 is verified by the `bench` label on this PR, which runs the otherwise opt-in Benchmark workflow against this head.

## RED-phase Evidence

- Command: `python -m pytest tests/bench/test_benchmark_report.py -q`
- Failing test names: `test_policy_and_workload_fences`, `test_put_session_guard_survives_reformatting`
- Expected failure reason: the pre-existing guard matched a single-line spelling that clang-format no longer produces; the new guard test referenced a helper that did not exist yet.
- Representative failure-message lines:
  - `tests/bench/test_benchmark_report.py:415: AssertionError` — `assert 'store.Put("base"' in '// Copyright 2026 sitos contributors...'`, reproducing run 33941985212 locally on `main`.
  - `tests/bench/test_benchmark_report.py:655: NameError: name '_put_session_arguments' is not defined`
- Result before the fix: `2 failed, 17 passed`. After: `19 passed`.
- Complete CI-log link: https://github.com/tetsuh/sitos/actions/runs/33941985212

## ADR Needed?

- [x] No — no contract-registry row, no overlapping surface, no wire or API change. docs/10_adr_process.md §6 does not apply to a test-guard correction.
- [ ] Yes — ADR PR: #

## Owner Merge Authorization

- Status: Pending
- Authorized head SHA:
- Owner instruction link:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qtdwtd7ehVxjGEhqDJqRqL
