### PR TITLE
fix(test): isolate Fence Zenoh tests per process and prove paths (#176)

### DIFF
--- a/tests/integration/fence_test.cpp
+++ b/tests/integration/fence_test.cpp
@@ -10,11 +10,20 @@
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <future>
 #include <memory>
 #include <mutex>
+#include <random>
 #include <string>
+#include <thread>
 #include <vector>
+
+#if defined(_WIN32)
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
 
 #include "ack_client.hpp"
 #include "fence_internal.hpp"
@@ -22,6 +31,7 @@
 #include "sitos/ack.hpp"
 #include "sitos/in_memory_engine.hpp"
 #include "sitos/param_cache.hpp"
+#include "sitos/param_value.hpp"
 #include "sitos/storage_node.hpp"
 #include "sitos/transport.hpp"
 #include "storage_node_test_access.hpp"
@@ -76,6 +86,47 @@ struct OwnedObservation {
   sitos::FenceLaneObservation lane;
 };
 
+// Separates this process's Zenoh routes from any other process running these tests on
+// the same host. The fence generation alone cannot do that: every freshly opened session
+// reports generation 1, so two concurrent runs build the same prefix, subscribe to each
+// other's writes, and collide on the shared lane. The process id distinguishes live
+// processes and the random draw distinguishes a reused id, both from the standard
+// library so the tests stay runnable from a plain developer shell.
+const std::string& RunUniquePrefixSuffix() {
+  static const std::string suffix = [] {
+#if defined(_WIN32)
+    const auto process_id = _getpid();
+#else
+    const auto process_id = getpid();
+#endif
+    std::random_device device;
+    const auto draw = (static_cast<std::uint64_t>(device()) << 32) | device();
+    return std::to_string(process_id) + "_" + std::to_string(draw);
+  }();
+  return suffix;
+}
+
+// A subscriber that lives on a session opened a moment ago is matched to a publishing
+// session asynchronously, and a publication issued before that completes is not delivered
+// at all. Zenoh offers no matching signal on the ad-hoc Put path this library uses, so a
+// test that is about to assert on a cross-session delivery must first prove the path is
+// live: keep publishing a probe until the far side observes one, within a bounded budget.
+// Returns false when a publish fails or the budget expires without an observation.
+bool PublishUntilObserved(const std::function<bool(std::int64_t)>& publish,
+                          const std::function<bool()>& observed) {
+  const auto budget = std::chrono::steady_clock::now() + 10s;
+  std::int64_t probe_value = 0;
+  while (std::chrono::steady_clock::now() < budget) {
+    if (!publish(++probe_value)) return false;
+    const auto poll_until = std::chrono::steady_clock::now() + 200ms;
+    while (std::chrono::steady_clock::now() < poll_until) {
+      if (observed()) return true;
+      std::this_thread::sleep_for(10ms);
+    }
+  }
+  return observed();
+}
+
 TEST(FenceZenohIntegrationTest, QualifiesTopologiesQosAndControlIsolation) {
   auto opened = sitos::OpenZenohTransport();
   ASSERT_TRUE(opened.IsOk());
@@ -84,8 +135,9 @@ TEST(FenceZenohIntegrationTest, QualifiesTopologiesQosAndControlIsolation) {
   ASSERT_NE(transport->FenceGeneration(), 0U);
   EXPECT_TRUE(sitos::transport_test_access::UsesFencePutProfile());
 
-  const std::string prefix =
-      "sitos/fence_integration_" + std::to_string(transport->FenceGeneration());
+  const std::string prefix = "sitos/fence_integration_" +
+                             std::to_string(transport->FenceGeneration()) + "_" +
+                             RunUniquePrefixSuffix();
   std::mutex mutex;
   std::condition_variable condition;
   std::vector<OwnedObservation> observations;
@@ -204,6 +256,20 @@ TEST(FenceZenohIntegrationTest, QualifiesTopologiesQosAndControlIsolation) {
   auto remote_opened = sitos::OpenZenohTransport();
   ASSERT_TRUE(remote_opened.IsOk());
   std::shared_ptr<sitos::Transport> remote(std::move(remote_opened).Value());
+  // Both cache subscribers were declared before `remote` opened, so one observed data
+  // probe shows `remote` has learned this session's declarations.
+  ASSERT_TRUE(PublishUntilObserved(
+      [&](std::int64_t value) {
+        return remote
+            ->Put(node_prefix + "/session/s1/probe", sitos::ParamValue(value).Encode(),
+                  sitos::Encoding{std::string(sitos::Encoding::kSitosV1)}, sitos::PutOptions{})
+            .IsOk();
+      },
+      [&] {
+        const auto contains = cache.Contains("probe");
+        return contains.IsOk() && contains.Value();
+      }))
+      << "the remote session never matched this session's cache subscribers";
   std::string uppercase_receiver = sitos::fence_internal::FormatFenceUuid(kPublisherB);
   std::transform(
       uppercase_receiver.begin(), uppercase_receiver.end(), uppercase_receiver.begin(),
@@ -324,7 +390,8 @@ TEST(FenceZenohIntegrationTest, QualifiesPublicParamCacheLocalDelivery) {
   ASSERT_NE(transport_generation, 0U);
 
   // A non-default, per-session prefix must govern the marker route and the wait (X03).
-  const std::string prefix = "sitos/fence_public_wait_" + std::to_string(transport_generation);
+  const std::string prefix = "sitos/fence_public_wait_" + std::to_string(transport_generation) +
+                             "_" + RunUniquePrefixSuffix();
   sitos::StorageNode node(*transport);
   ASSERT_TRUE(node.Start(std::make_shared<sitos::InMemoryEngine>(),
                          sitos::StorageNodeConfig{.prefix = prefix, .log_sink = nullptr})
@@ -366,6 +433,13 @@ TEST(FenceZenohIntegrationTest, QualifiesPublicParamCacheLocalDelivery) {
   ASSERT_TRUE(peer_opened.IsOk());
   auto peer = std::move(peer_opened).Value();
   ASSERT_TRUE(peer.Attach("s1").IsOk());
+  ASSERT_TRUE(PublishUntilObserved(
+      [&](std::int64_t value) { return cache.Put("peer-probe", value).IsOk(); },
+      [&] {
+        const auto contains = peer.Contains("peer-probe");
+        return contains.IsOk() && contains.Value();
+      }))
+      << "the initiating session never matched the peer's subscriber";
   ASSERT_TRUE(sitos::fence_test_access::FenceTestAccess::GateCacheCallback(peer));
   const auto peer_write = cache.Put("peer-independent", std::int64_t{9});
   if (!peer_write.IsOk()) {

--- a/tests/integration/fence_test.cpp
+++ b/tests/integration/fence_test.cpp
@@ -118,13 +118,15 @@ bool PublishUntilObserved(const std::function<bool(std::int64_t)>& publish,
   std::int64_t probe_value = 0;
   while (std::chrono::steady_clock::now() < budget) {
     if (!publish(++probe_value)) return false;
-    const auto poll_until = std::chrono::steady_clock::now() + 200ms;
+    // Each poll window is clamped to the budget so an observation is only ever reported
+    // from inside it; after expiry the answer is false even if a late callback lands.
+    const auto poll_until = std::min(std::chrono::steady_clock::now() + 200ms, budget);
     while (std::chrono::steady_clock::now() < poll_until) {
       if (observed()) return true;
       std::this_thread::sleep_for(10ms);
     }
   }
-  return observed();
+  return false;
 }
 
 TEST(FenceZenohIntegrationTest, QualifiesTopologiesQosAndControlIsolation) {


### PR DESCRIPTION
## Summary

Closes #176

Both Zenoh Fence integration tests derived their key prefix from the fence generation alone. A freshly opened session reports generation `1`, so two processes running these tests on one host built the same prefix, subscribed to each other's writes, and collided on the shared lane. Reported by CodeRabbit on #174; the convention predates #99, which is why it is fixed here for both sites rather than in that PR.

Two changes, both in `tests/integration/fence_test.cpp`, both test-only:

1. **Process-unique prefixes.** `RunUniquePrefixSuffix()` mixes the process id and a `std::random_device` draw into both prefixes. The process id distinguishes live processes and the random draw distinguishes a reused id; both come from the standard library, so the tests stay runnable from a plain developer shell. The `_getpid` / `getpid` split follows `tests/unit/rocksdb_engine_test.cpp`.
2. **Bounded cross-session readiness probe** (`DEC-176-CROSS-SESSION-READINESS-001`). Isolating the prefixes exposed a second defect the collision had been masking: each test opens a second Zenoh session and publishes across it before the far side's subscriber is matched, and a publication issued before matching completes is silently dropped. Another process's writes on the shared route used to satisfy those waits. With unique prefixes, `QualifiesPublicParamCacheLocalDelivery` blocked forever in the unbounded `WaitForCacheCallbackBlocked` and `QualifiesTopologiesQosAndControlIsolation` timed out at its 5 s marker wait. `PublishUntilObserved()` republishes a probe until the far side observes it within a 10 s budget and fails loudly when the budget expires; each test calls it once, ahead of its first cross-session publication.

`src/`, CTest names, and `RUN_SERIAL` properties are untouched. Two pre-existing clang-format violations in this file (long `EXPECT_EQ` lines) are deliberately left as on `main`.

## Requirements

N/A. Test-only. No requirement behavior, wire format, route grammar, or public API is touched.

## Contract Registry

**N/A.** No contract-registry row is affected.

## Frozen Issue Checklist

- [x] Each prefix contains a component that differs between two concurrent processes on one host.
- [x] The uniqueness component is derived from the standard library or an existing dependency; no new dependency, no reliance on a CI-only environment variable.
- [x] Both sites use the same construction, so the file keeps one convention.
- [x] The registered CTest names and their `RUN_SERIAL` properties are unchanged, and `tests/verify_fence_test_registration.py` passes for `zenoh-off`, `sanitizer`, and `zenoh-on`.
- [x] The two `FenceZenohIntegrationTest` cases pass, and two copies of the Zenoh-ON test binary started concurrently on one host both pass.
- [x] Before either test asserts on a delivery across two Zenoh sessions, it proves the path is live with a bounded probe and fails loudly when the budget expires; no wait on that path blocks without a bound (DEC-176-CROSS-SESSION-READINESS-001).
- [x] The concurrent-copies evidence is collected with a per-process timeout so a regression to a hang is reported as a failure rather than observed as a stall.

## Acceptance Criteria Verification

Exact-head evidence for `684051c`, Zenoh-ON `dev-linux` build, every process under `timeout 60`. The head adds a review correction on top of `94decc9`: the probe's poll window is clamped to its budget and the helper returns `false` after expiry (CodeRabbit finding), re-verified with singles 3/3 and five concurrent pairs at 0 hangs / 0 failures, and the full suite (493/493) and all three registration profiles were re-taken at this head. The larger concurrency matrix below (10 pairs, 3 triples) was taken at `94decc9`, whose only difference is that clamp.

```text
2 copies concurrently x10 rounds          0 hangs, 0 failures / 20 runs
3 copies concurrently x3 rounds           0 hangs, 0 failures / 9 runs
single                                    3/3 passed, timing unchanged (268 ms / 19 ms)
ctest --test-dir build/dev-linux          493/493 passed
verify_fence_test_registration zenoh-on   16 tests, OK
                               zenoh-off  13 tests, OK   (Zenoh-OFF build)
                               sanitizer  13 tests, OK   (Zenoh-OFF build)
git diff --check                          clean
```

## RED-phase Evidence

- Command: two copies of `build/dev-linux/tests/sitos_fence_zenoh_integration_test` started concurrently on one host, repeated.
- Failing test names: `FenceZenohIntegrationTest.QualifiesTopologiesQosAndControlIsolation`, `FenceZenohIntegrationTest.QualifiesPublicParamCacheLocalDelivery`.
- Expected failure reason: both processes built the same prefix and collided on the shared fence lane.
- Representative failure-message lines, `main` at `43b17b8`, **9 failures / 10 runs**:
  - `fence_test.cpp:243: fence_result.Value().status  Which is: 4-byte object <08-00 00-00>` against `sitos::Status::Ok`
  - `fence_test.cpp:296: gap_result.Value().status  Which is: <08-00 00-00>` against `sitos::Status::OutcomeUnknown`; `:297: failed_sequence Which is: 1` against `2U`

A second RED surfaced only after the prefix change, and is the reason for `DEC-176-CROSS-SESSION-READINESS-001`:

- Same command, prefix change only, 60 s per-process timeout: **one process per pair hangs**, 0 assertion failures. With progress markers the last line before the stall was always the call into `WaitForCacheCallbackBlocked` (`src/param_cache.cpp:1051`, unbounded). Without the timeout the stall was observed for 4.6 h at 0 % CPU, main thread and one Zenoh rx thread in `futex`.
- The sibling test also timed out at its 5 s marker wait in 5 / 16 runs (`fence_test.cpp:253`, `waiter->condition.wait_for(lock, 5s, ...)` returned false).
- Both are the same mechanism: a publication across a just-opened Zenoh session before matching completes. `OnSample` runs the test hook for any sample, so under the shared prefix the other process's traffic had been satisfying these waits.

## ADR Needed?

- [x] No — no contract-registry row, no overlapping surface, no wire or API change. docs/10_adr_process.md §6 does not apply to a test-only change.
- [ ] Yes — ADR PR: #

## Owner Merge Authorization

- Status: Pending
- Authorized head SHA:
- Owner instruction link:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qtdwtd7ehVxjGEhqDJqRqL


